### PR TITLE
Add support for go.mod file generation

### DIFF
--- a/pkg/generate/ack/config.go
+++ b/pkg/generate/ack/config.go
@@ -23,4 +23,15 @@ var DefaultConfig = config.Config{
 	},
 	IncludeACKMetadata:             true,
 	SetManyOutputNotFoundErrReturn: "return nil, ackerr.NotFound",
+	GoModule: config.GoModule{
+		CompilerVersion: "1.15",
+		RequiredModulesVersions: config.RequiredModulesVersions{
+			AWSSDKGo:             "v1.35.5",
+			ACKCore:              "v0.0.2",
+			K8sAPI:               "v0.18.2",
+			K8sAPIMachinery:      "v0.18.6",
+			K8sClientGo:          "v0.18.2",
+			K8sControllerRuntime: "v0.6.0",
+		},
+	},
 }

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
@@ -171,6 +172,15 @@ func Controller(
 		return nil, err
 	}
 
+	// Next add the template for the go.mod file
+	goModulesVars := &templateGoModuleVars{
+		metaVars,
+		g.GetGoModuleConfig(),
+	}
+	if err = ts.Add("go.mod", "go.mod.tpl", goModulesVars); err != nil {
+		return nil, err
+	}
+
 	// Finally, add the configuration YAML file templates
 	for _, path := range controllerConfigTemplatePaths {
 		outPath := strings.TrimSuffix(path, ".tpl")
@@ -186,4 +196,11 @@ func Controller(
 type templateCmdVars struct {
 	templateset.MetaVars
 	SnakeCasedCRDNames []string
+}
+
+// templateGoModuleVars contains template variables for the template that generates
+// go.mod file
+type templateGoModuleVars struct {
+	templateset.MetaVars
+	GoModule config.GoModule
 }

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	// SetManyOutput function fails with NotFound error.
 	// Default is "return nil, ackerr.NotFound"
 	SetManyOutputNotFoundErrReturn string `json:"set_many_output_notfound_err_return,omitempty"`
+	// GoModule let you describe the controller module information and it dependencies
+	GoModule GoModule `json:"go_module"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to

--- a/pkg/generate/config/module.go
+++ b/pkg/generate/config/module.go
@@ -1,0 +1,25 @@
+package config
+
+// GoModule contains controller Go module informations
+type GoModule struct {
+	// Go compiler version. Defaults to 1.15
+	CompilerVersion string `json:"compiler_version"`
+	// Required modules versions
+	RequiredModulesVersions RequiredModulesVersions `json:"required_modules_versions"`
+}
+
+// RequiredModulesVersions contains required modules versions
+type RequiredModulesVersions struct {
+	// Version of github.com/aws/aws-sdk-go. Defaults to v1.35.5
+	AWSSDKGo string `json:"aws_sdk_go"`
+	// Version of github.com/aws/aws-controllers-k8s. Defaults to v0.0.2
+	ACKCore string `json:"ack_core"`
+	// Version of k8s.io/api. Defaults to v0.18.2
+	K8sAPI string `json:"k8s_api"`
+	// Version of k8s.io/apimachinery. Defaults to v0.18.6
+	K8sAPIMachinery string `json:"k8s_api_machinery"`
+	// Version of k8s.io/client-go. Defaults to v0.18.2
+	K8sClientGo string `json:"k8s_client_go"`
+	// Version of sigs.k8s.io/controller-runtime version. Defaults to v0.6.0
+	K8sControllerRuntime string `json:"k8s_controller_runtime"`
+}

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -66,6 +66,11 @@ func (g *Generator) crdNames() []string {
 	return crdConfigs
 }
 
+// GetGoModuleConfig returns go.mod configuration
+func (g *Generator) GetGoModuleConfig() ackgenconfig.GoModule {
+	return g.cfg.GoModule
+}
+
 // GetCRDs returns a slice of `ackmodel.CRD` structs that describe the
 // top-level resources discovered by the code generator for an AWS service API
 func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {

--- a/templates/go.mod.tpl
+++ b/templates/go.mod.tpl
@@ -1,0 +1,15 @@
+module github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
+
+go {{ .GoModule.CompilerVersion }}
+
+require (
+	github.com/aws/aws-controllers-k8s {{ .GoModule.RequiredModulesVersions.ACKCore }}
+	github.com/aws/aws-sdk-go {{ .GoModule.RequiredModulesVersions.AWSSDKGo }}
+	github.com/go-logr/logr v0.1.0
+	github.com/google/go-cmp v0.3.1
+	github.com/spf13/pflag v1.0.5
+	k8s.io/api {{ .GoModule.RequiredModulesVersions.K8sAPI }}
+	k8s.io/apimachinery {{ .GoModule.RequiredModulesVersions.K8sAPIMachinery }}
+	k8s.io/client-go {{ .GoModule.RequiredModulesVersions.K8sClientGo }}
+	sigs.k8s.io/controller-runtime {{ .GoModule.RequiredModulesVersions.K8sControllerRuntime }}
+)


### PR DESCRIPTION
Issue: N/A
Changes:
- Add support for go.mod file generation
- Expand `ack-generate` configuration to allow specifying required modules versions

`generator.yaml` configuration example:
```yaml
go_module:
  compiler_version: v1.13.13
  required_modules_versions:
    aws_sdk_go: v1.35.34
    ack_core: v0.0.2 #for now sets 'github.com/aws/aws-controllers-k8s' version
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.