### PR TITLE
update template service controller pkg paths

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -66,7 +66,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	}
 	svcAlias := strings.ToLower(args[0])
 	if optAPIsOutputPath == "" {
-		optAPIsOutputPath = filepath.Join(optServicesDir)
+		optAPIsOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 	if err := ensureSDKRepo(optCacheDir); err != nil {
 		return err
@@ -98,7 +98,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	apisVersionPath = filepath.Join(optAPIsOutputPath, svcAlias, "apis", optGenVersion)
+	apisVersionPath = filepath.Join(optAPIsOutputPath, "apis", optGenVersion)
 	for path, contents := range ts.Executed() {
 		if optDryRun {
 			fmt.Printf("============================= %s ======================================\n", path)

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -13,10 +13,10 @@ import (
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	ctrlrtmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	svcresource "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/pkg/resource"
-	svctypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/apis/{{ .APIVersion }}"
+	svcresource "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/resource"
+	svctypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
 
-	{{ $serviceIDClean := .ServiceIDClean }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws/aws-controllers-k8s/services/{{ $serviceIDClean }}/pkg/resource/{{ $crdName }}"
+	{{ $serviceIDClean := .ServiceIDClean }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $serviceIDClean }}-controller/pkg/resource/{{ $crdName }}"
 	{{end}}
 )
 

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -11,7 +11,7 @@ import (
 	k8sapirt "k8s.io/apimachinery/pkg/runtime"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	svcapitypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
 )
 
 const (

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 
-	svcresource "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/pkg/resource"
+	svcresource "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/resource"
 )
 
 // resourceManagerFactory produces resourceManager objects. It implements the

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
-	svcapitypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/apis/{{ .APIVersion}}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion}}"
 )
 
 // resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	svcapitypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceIDClean }}/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{.ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
 )
 
 // Hack to avoid import errors during build...


### PR DESCRIPTION
Updates the import paths in templates that refer to the service
controller's separate repository package paths.

Also updates the `ack-generate apis` command to respect a supplied
`--output` path argument and not automatically append the service alias
to the supplied output path.

Issue aws/aws-controllers-k8s#666

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
