### PR TITLE
Enhance `scripts/build-controller.sh` USAGE and error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-ack-generate:	## Build ack-generate binary
 	@go build ${GO_TAGS} ${GO_LDFLAGS} -o bin/ack-generate cmd/ack-generate/main.go
 	@echo "ok."
 
-build-controller: build-ack-generate ## Generate controller code for SERVICE
+build-controller:   ## Generate controller code for SERVICE
 	@./scripts/install-controller-gen.sh 
 	@./scripts/build-controller.sh $(AWS_SERVICE)
 

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -51,6 +51,8 @@ Environment variables:
   ACK_GENERATE_CONFIG_PATH: Specify a path to the generator config YAML file to
                             instruct the code generator for the service.
                             Default: services/{SERVICE}/generator.yaml
+  TEMPLATES_DIR:            Overrides the directory containg ack-generate templates
+                            Default: $TEMPLATES_DIR
   K8S_RBAC_ROLE_NAME:       Name of the Kubernetes Role to use when generating
                             the RBAC manifests for the custom resource
                             definitions.
@@ -75,7 +77,7 @@ run:
  
 from the root directory or install ack-generate using:
 
-   go get -u github.com/aws-controllers-k8s/code-generator/cmd/ack-generate" 1>&2
+   go get -u -tags codegen github.com/aws-controllers-k8s/code-generator/cmd/ack-generate" 1>&2
         exit 1;
     fi
 fi


### PR DESCRIPTION
Follow up to #6 

Description of changes:
- Add `-tags codegen` to `go get` ack-generate binary help message
- Add `TEMPLATES_DIR` to the USAGE help message
- Remove `build-ack-generate` from the prerequired rules of `build-controller`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
