### PR TITLE
Add a CLI flag to set the version of aws-sdk-go used by `ack-generate`

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -35,10 +35,9 @@ const (
 )
 
 var (
-	optGenVersion     string
-	optAPIsInputPath  string
-	optAPIsOutputPath string
-	apisVersionPath   string
+	optGenVersion    string
+	optAPIsInputPath string
+	apisVersionPath  string
 )
 
 // apiCmd is the command that generates service API types
@@ -52,9 +51,6 @@ func init() {
 	apisCmd.PersistentFlags().StringVar(
 		&optGenVersion, "version", "v1alpha1", "the resource API Version to use when generating API infrastructure and type definitions",
 	)
-	apisCmd.PersistentFlags().StringVarP(
-		&optAPIsOutputPath, "output", "o", "", "path to directory for service controller to create generated files. Defaults to "+optServicesDir+"/$service",
-	)
 	rootCmd.AddCommand(apisCmd)
 }
 
@@ -65,8 +61,8 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please specify the service alias for the AWS service API to generate")
 	}
 	svcAlias := strings.ToLower(args[0])
-	if optAPIsOutputPath == "" {
-		optAPIsOutputPath = filepath.Join(optServicesDir, svcAlias)
+	if optOutputPath == "" {
+		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 	if err := ensureSDKRepo(optCacheDir); err != nil {
 		return err
@@ -98,7 +94,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	apisVersionPath = filepath.Join(optAPIsOutputPath, "apis", optGenVersion)
+	apisVersionPath = filepath.Join(optOutputPath, "apis", optGenVersion)
 	for path, contents := range ts.Executed() {
 		if optDryRun {
 			fmt.Printf("============================= %s ======================================\n", path)

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -32,10 +32,9 @@ import (
 )
 
 var (
-	optControllerOutputPath string
-	cmdControllerPath       string
-	pkgResourcePath         string
-	latestAPIVersion        string
+	cmdControllerPath string
+	pkgResourcePath   string
+	latestAPIVersion  string
 )
 
 var controllerCmd = &cobra.Command{
@@ -45,9 +44,6 @@ var controllerCmd = &cobra.Command{
 }
 
 func init() {
-	controllerCmd.PersistentFlags().StringVarP(
-		&optControllerOutputPath, "output", "o", "", "path to root directory to create generated files. Defaults to "+optServicesDir+"/$service",
-	)
 	rootCmd.AddCommand(controllerCmd)
 }
 
@@ -57,8 +53,8 @@ func generateController(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please specify the service alias for the AWS service API to generate")
 	}
 	svcAlias := strings.ToLower(args[0])
-	if optControllerOutputPath == "" {
-		optControllerOutputPath = filepath.Join(optServicesDir, svcAlias)
+	if optOutputPath == "" {
+		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 
 	if err := ensureSDKRepo(optCacheDir); err != nil {
@@ -101,7 +97,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 			fmt.Println(strings.TrimSpace(contents.String()))
 			continue
 		}
-		outPath := filepath.Join(optControllerOutputPath, path)
+		outPath := filepath.Join(optOutputPath, path)
 		outDir := filepath.Dir(outPath)
 		if _, err := ensureDir(outDir); err != nil {
 			return err
@@ -117,7 +113,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 // latest Kubernetes API version for CRDs exposed by the generated service
 // controller.
 func getLatestAPIVersion() (string, error) {
-	apisPath := filepath.Join(optControllerOutputPath, "apis")
+	apisPath := filepath.Join(optOutputPath, "apis")
 	versions := []string{}
 	subdirs, err := ioutil.ReadDir(apisPath)
 	if err != nil {

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -37,6 +37,7 @@ var (
 	defaultCacheDir        string
 	optCacheDir            string
 	optRefreshCache        bool
+	optAWSSDKGoVersion     string
 	defaultTemplatesDir    string
 	optTemplatesDir        string
 	defaultServicesDir     string
@@ -116,6 +117,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVarP(
 		&optOutputPath, "output", "o", "", "Path to directory to output generated files.",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&optAWSSDKGoVersion, "aws-sdk-go-version", "", "Version of github.com/aws/aws-sdk-go used to generate apis and controllers files",
 	)
 }
 

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -44,6 +44,7 @@ var (
 	optDryRun              bool
 	sdkDir                 string
 	optGeneratorConfigPath string
+	optOutputPath          string
 )
 
 var rootCmd = &cobra.Command{
@@ -112,6 +113,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optGeneratorConfigPath, "generator-config-path", "", "Path to file containing instructions for code generation to use",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optOutputPath, "output", "o", "", "Path to directory to output generated files.",
 	)
 }
 

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -26,6 +26,7 @@ DEFAULT_ACK_GENERATE_BIN_PATH="$ROOT_DIR/bin/ack-generate"
 ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
+AWS_SDK_GO_VERSION=${AWS_SDK_GO_VERSION:-""}
 DEFAULT_TEMPLATES_DIR="$ROOT_DIR/templates"
 TEMPLATES_DIR=${TEMPLATES_DIR:-$DEFAULT_TEMPLATES_DIR}
 
@@ -37,7 +38,7 @@ Usage:
 's3' 'sns' or 'sqs'
 
 Environment variables:
-  ACK_GENERATE_CACHE_DIR    Overrides the directory used for caching AWS API
+  ACK_GENERATE_CACHE_DIR:   Overrides the directory used for caching AWS API
                             models used by the ack-generate tool.
                             Default: $ACK_GENERATE_CACHE_DIR
   ACK_GENERATE_BIN_PATH:    Overrides the path to the the ack-generate binary.
@@ -51,6 +52,8 @@ Environment variables:
   ACK_GENERATE_CONFIG_PATH: Specify a path to the generator config YAML file to
                             instruct the code generator for the service.
                             Default: services/{SERVICE}/generator.yaml
+  AWS_SDK_GO_VERSION:       Overrides the version of github.com/aws/aws-sdk-go used
+                            by `ack-generate` to fetch the service API Specifications.
   TEMPLATES_DIR:            Overrides the directory containg ack-generate templates
                             Default: $TEMPLATES_DIR
   K8S_RBAC_ROLE_NAME:       Name of the Kubernetes Role to use when generating
@@ -118,6 +121,10 @@ fi
 if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
     ag_args="$ag_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
     apis_args="$apis_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
+fi
+
+if [ -n "$AWS_SDK_GO_VERSION" ]; then
+    ag_args="$ag_args --aws-sdk-go-version $AWS_SDK_GO_VERSION"
 fi
 
 echo "Building Kubernetes API objects for $SERVICE"


### PR DESCRIPTION
Issue N/A

Description of changes:
- Use one shared optOutputPath for both API and Controller sub commands 
- Add a CLI flag to set the version of aws-sdk-go used by `ack-generate`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
