### PR TITLE
crossplane: code generator for lateInitialize function

### DIFF
--- a/pkg/generate/ack/hook_test.go
+++ b/pkg/generate/ack/hook_test.go
@@ -31,7 +31,7 @@ func TestResourceHookCodeInline(t *testing.T) {
 	basePaths := []string{}
 	hookID := "sdk_update_pre_build_request"
 
-	g := testutil.NewGeneratorForService(t, "mq")
+	g := testutil.NewGeneratorForService(t, "mq", ack.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Broker")
 	require.NotNil(crd)
@@ -52,7 +52,7 @@ func TestResourceHookCodeTemplatePath(t *testing.T) {
 	}
 	hookID := "sdk_delete_pre_build_request"
 
-	g := testutil.NewGeneratorForService(t, "mq")
+	g := testutil.NewGeneratorForService(t, "mq", ack.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Broker")
 	require.NotNil(crd)

--- a/pkg/generate/apigwv2_test.go
+++ b/pkg/generate/apigwv2_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestAPIGatewayV2_GetTypeDefs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	// There is an "Api" Shape that is a struct that is an element of the
 	// GetApis Operation. Its name conflicts with the CRD called API and thus
@@ -43,7 +44,7 @@ func TestAPIGatewayV2_Api(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)
@@ -71,7 +72,7 @@ func TestAPIGatewayV2_Route(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/code/check_test.go
+++ b/pkg/generate/code/check_test.go
@@ -14,12 +14,14 @@
 package code_test
 
 import (
+
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
@@ -29,7 +31,7 @@ func TestCheckRequiredFields_Attributes_ARNField(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Topic")
 	require.NotNil(crd)
@@ -57,7 +59,7 @@ func TestCheckRequiredFields_Attributes_StatusField(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
@@ -78,7 +80,7 @@ func TestCheckRequiredFields_Attributes_StatusAndSpecField(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Route")
 	require.NotNil(crd)

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
@@ -27,7 +28,8 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
@@ -108,7 +110,7 @@ func TestCompareResource_Lambda_CodeSigningConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "lambda")
+	g := testutil.NewGeneratorForService(t, "lambda", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "CodeSigningConfig")
 	require.NotNil(crd)

--- a/pkg/generate/code/late_initialization.go
+++ b/pkg/generate/code/late_initialization.go
@@ -1,0 +1,246 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/names"
+)
+
+func LateInitializeReadOne(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+// String representing the name of the variable that we will grab the
+// Output shape from. This will likely be "resp" since in the templates
+// that call this method, the "source variable" is the response struct
+// returned by the aws-sdk-go's SDK API call corresponding to the Operation
+	sourceVarName string,
+// String representing the name of the variable that we will be **setting**
+// with values we get from the Output shape. This will likely be
+// "ko.Status" since that is the name of the "target variable" that the
+// templates that call this method use.
+	targetPath string,
+) string {
+	out := ""
+	path := sourceVarName
+	shape := r.Ops.ReadOne.OutputRef.Shape
+	if len(shape.MemberRefs) == 1 {
+		for key, val := range shape.MemberRefs {
+			if val.Shape.Type == "structure" {
+				path = fmt.Sprintf("%s.%s", path, key)
+				shape = val.Shape
+				break
+			}
+			panic("there has to be a structure field in unwrapped readone output shape")
+		}
+	}
+	for _, memberName := range shape.MemberNames() {
+		f, found := r.SpecFields[memberName]
+		if !found {
+			continue
+		}
+		responsePath := fmt.Sprintf("%s.%s", path, f.Names.Original)
+		crPath := fmt.Sprintf("%s%s.%s", targetPath, cfg.PrefixConfig.SpecField, f.Names.Camel)
+		out += lateInit(responsePath, crPath, r, f.ShapeRef, 0)
+	}
+	return strings.TrimSuffix(out, "\n")
+}
+
+func LateInitializeReadMany(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+// String representing the name of the variable that we will grab the
+// Output shape from. This will likely be "resp" since in the templates
+// that call this method, the "source variable" is the response struct
+// returned by the aws-sdk-go's SDK API call corresponding to the Operation
+	sourceVarName string,
+// String representing the name of the variable that we will be **setting**
+// with values we get from the Output shape. This will likely be
+// "ko.Status" since that is the name of the "target variable" that the
+// templates that call this method use.
+	targetPath string,
+) string {
+	listFieldName := ""
+	var respShapeRef *awssdkmodel.ShapeRef
+	for name, ref := range r.Ops.ReadMany.OutputRef.Shape.MemberRefs {
+		if ref.Shape.Type == "list"{
+			listFieldName = name
+			respShapeRef = &ref.Shape.MemberRef
+			break
+		}
+	}
+	if respShapeRef == nil {
+		panic("could not find a list shaped member in readmany output shape")
+	}
+	out := fmt.Sprintf("for _, resource := range %s.%s {\n", sourceVarName, listFieldName)
+	path := "resource"
+	shape := respShapeRef.Shape
+	for _, memberName := range shape.MemberNames() {
+		f, found := r.SpecFields[memberName]
+		if !found {
+			continue
+		}
+		responsePath := fmt.Sprintf("%s.%s", path, f.Names.Original)
+		crPath := fmt.Sprintf("%s%s.%s", targetPath, cfg.PrefixConfig.SpecField, f.Names.Camel)
+		out += lateInit(responsePath, crPath, r, f.ShapeRef, 0)
+	}
+	out += fmt.Sprintf("}")
+	return out
+}
+
+func LateInitializeGetAttributes(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+// String representing the name of the variable that we will grab the
+// Output shape from. This will likely be "resp" since in the templates
+// that call this method, the "source variable" is the response struct
+// returned by the aws-sdk-go's SDK API call corresponding to the Operation
+	path string,
+// String representing the name of the variable that we will be **setting**
+// with values we get from the Output shape. This will likely be
+// "ko.Status" since that is the name of the "target variable" that the
+// templates that call this method use.
+	targetPath string,
+) string {
+	if !r.UnpacksAttributesMap() {
+		// This is a bug in the code generation if this occurs...
+		msg := fmt.Sprintf(
+			"called SetResourceGetAttributes for a resource '%s' that doesn't unpack attributes map",
+			r.Ops.GetAttributes.Name,
+		)
+		panic(msg)
+	}
+	out := ""
+	var fieldList []string
+	for name, config := range cfg.ResourceFields(r.Names.Original) {
+		if config.IsAttribute && !config.IsReadOnly {
+			fieldList = append(fieldList, name)
+		}
+	}
+	sort.Strings(fieldList)
+	for _, name := range fieldList {
+		n := names.New(name)
+		respFieldPath := fmt.Sprintf("%s.Attributes[\"%s\"]", path, n.Original)
+		crFieldPath := fmt.Sprintf("%s%s.%s", targetPath, cfg.PrefixConfig.SpecField, n.Camel)
+		out += fmt.Sprintf("%s = awsclients.LateInitializeStringPtr(%s, %s)\n", crFieldPath, crFieldPath, respFieldPath)
+	}
+	return strings.TrimSuffix(out, "\n")
+}
+
+func lateInitStruct(responsePath, crPath string, r *model.CRD, str *awssdkmodel.ShapeRef, level int) string {
+	out := fmt.Sprintf("if %s != nil {\n", responsePath)
+	out += fmt.Sprintf("if %s == nil {\n", crPath)
+	out += fmt.Sprintf("%s = &%s{}\n", crPath, GetCorrespondingCRDType(str.Shape, r, false))
+	out += fmt.Sprintf("}\n")
+	// Keys need to be sorted so that we get deterministic output.
+	var keys []string
+	for key := range str.Shape.MemberRefs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, name := range keys {
+		n := names.New(name)
+		respFieldPath := fmt.Sprintf("%s.%s", responsePath, n.Original)
+		crFieldPath := fmt.Sprintf("%s.%s", crPath, n.Camel)
+		out += lateInit(respFieldPath, crFieldPath, r, str.Shape.MemberRefs[name], level+1)
+	}
+	out += fmt.Sprintf("}\n")
+	return out
+}
+
+func lateInitMap(responsePath, crPath string, r *model.CRD, str *awssdkmodel.ShapeRef, level int) string {
+	out := fmt.Sprintf("if %s != nil {\n", responsePath)
+	out += fmt.Sprintf("if %s == nil {\n", crPath)
+	out += fmt.Sprintf("%s = %s{}\n", crPath, GetCorrespondingCRDType(str.Shape, r, false))
+	out += fmt.Sprintf("}\n")
+
+	out += fmt.Sprintf("for key%d := range %s {\n", level, responsePath)
+	respFieldPath := fmt.Sprintf("%s[key%d]", responsePath, level)
+	crFieldPath := fmt.Sprintf("%s[key%d]", crPath, level)
+	out += lateInit(respFieldPath, crFieldPath, r, str, level+1)
+	out += fmt.Sprintf("}\n")
+	out += fmt.Sprintf("}\n")
+	return out
+}
+
+func lateInitSlice(responsePath, crPath string, r *model.CRD, respShapeRef *awssdkmodel.ShapeRef, level int) string {
+	// NOTE(muvaf): Late initialization for slices is not a full-featured late-init.
+	// It works only if the slice in CRD is empty. If there is even one element,
+	// we don't late-init since slices do not have unique identifier like map/struct.
+	// We're playing conservative and not rely on index so that we don't risk
+	// overriding desired state with what's observed.
+	// TODO(muvaf): Kubernetes Apply uses comment markers on fields to specify an
+	// identifier (`name` most of the time). If we can do such thing, we can implement
+	// full late-init for slice elements as well, just like maps.
+	out := fmt.Sprintf(
+		"if len(%s) != 0 && len(%s) == 0 {\n", responsePath, crPath,
+	)
+	out += fmt.Sprintf("%s = make([]%s, len(%s))\n", crPath, GetCorrespondingCRDType(respShapeRef.Shape.MemberRef.Shape, r, true), responsePath)
+	out += fmt.Sprintf("for i%d := range %s {\n", level, responsePath)
+	respFieldPath := fmt.Sprintf("%s[i%d]", responsePath, level)
+	crFieldPath := fmt.Sprintf("%s[i%d]", crPath, level)
+	out += lateInit(respFieldPath, crFieldPath, r, &respShapeRef.Shape.MemberRef, level+1)
+	out += fmt.Sprintf("}\n")
+	out += fmt.Sprintf("}\n")
+	return out
+}
+
+func lateInit(responsePath, crPath string, r *model.CRD, str *awssdkmodel.ShapeRef, level int) string {
+	switch str.Shape.Type {
+	case "string":
+		return fmt.Sprintf("%s = awsclients.LateInitializeStringPtr(%s, %s)\n", crPath, crPath, responsePath)
+	case "long", "integer":
+		return fmt.Sprintf("%s = awsclients.LateInitializeInt64Ptr(%s, %s)\n", crPath, crPath, responsePath)
+	case "boolean":
+		return fmt.Sprintf("%s = awsclients.LateInitializeBoolPtr(%s, %s)\n", crPath, crPath, responsePath)
+	case "list":
+		return lateInitSlice(responsePath, crPath, r, str, level)
+	case "structure":
+		return lateInitStruct(responsePath, crPath, r, str, level)
+	case "map":
+		return lateInitMap(responsePath, crPath, r, str, level)
+	default:
+		panic(fmt.Sprintf("unknown shape type %s", str.Shape.Type))
+	}
+}
+
+func GetCorrespondingCRDType(s *awssdkmodel.Shape, r *model.CRD, keepPointer bool) string {
+	switch s.Type {
+	case "string":
+		return "*string"
+	case "long", "integer":
+		return "*int64"
+	case "boolean":
+		return "*bool"
+	case "list":
+		return fmt.Sprintf("[]%s", GetCorrespondingCRDType(s.ValueRef.Shape, r, true))
+	case "map":
+		return fmt.Sprintf("map[string]%s", GetCorrespondingCRDType(s.ValueRef.Shape, r, true))
+	}
+	goType := s.GoTypeWithPkgName()
+	goType = model.ReplacePkgName(goType, r.SDKAPIPackageName(), "svcapitypes", keepPointer)
+	goTypeNoPkg := strings.Split(goType, ".")[1]
+	goPkg := strings.Split(goType, ".")[0]
+	if r.TypeRenames()[goTypeNoPkg] != "" {
+		goTypeNoPkg = r.TypeRenames()[goTypeNoPkg]
+	}
+	return fmt.Sprintf("%s.%s", goPkg, goTypeNoPkg)
+}

--- a/pkg/generate/code/late_initialization.go
+++ b/pkg/generate/code/late_initialization.go
@@ -152,7 +152,7 @@ func LateInitializeGetAttributes(
 		n := names.New(name)
 		respFieldPath := fmt.Sprintf("%s.Attributes[\"%s\"]", path, n.Original)
 		crFieldPath := fmt.Sprintf("%s%s.%s", targetPath, cfg.PrefixConfig.SpecField, n.Camel)
-		out += fmt.Sprintf("%s = awsclients.LateInitializeStringPtr(%s, %s)\n", crFieldPath, crFieldPath, respFieldPath)
+		out += fmt.Sprintf("%s = li.LateInitializeStringPtr(%s, %s)\n", crFieldPath, crFieldPath, respFieldPath)
 	}
 	return strings.TrimSuffix(out, "\n")
 }
@@ -218,11 +218,16 @@ func lateInitSlice(responsePath, crPath string, r *model.CRD, respShapeRef *awss
 func lateInit(responsePath, crPath string, r *model.CRD, str *awssdkmodel.ShapeRef, level int) string {
 	switch str.Shape.Type {
 	case "string":
-		return fmt.Sprintf("%s = awsclients.LateInitializeStringPtr(%s, %s)\n", crPath, crPath, responsePath)
+		return fmt.Sprintf("%s = li.LateInitializeStringPtr(%s, %s)\n", crPath, crPath, responsePath)
 	case "long", "integer":
-		return fmt.Sprintf("%s = awsclients.LateInitializeInt64Ptr(%s, %s)\n", crPath, crPath, responsePath)
+		return fmt.Sprintf("%s = li.LateInitializeInt64Ptr(%s, %s)\n", crPath, crPath, responsePath)
 	case "boolean":
-		return fmt.Sprintf("%s = awsclients.LateInitializeBoolPtr(%s, %s)\n", crPath, crPath, responsePath)
+		return fmt.Sprintf("%s = li.LateInitializeBoolPtr(%s, %s)\n", crPath, crPath, responsePath)
+	case "timestamp":
+		return fmt.Sprintf("%s = li.LateInitializeTimePtr(%s, %s)\n", crPath, crPath, responsePath)
+	// NOTE(muvaf): double type is not yet supported.
+	case "double":
+		return "\n"
 	case "list":
 		return lateInitSlice(responsePath, crPath, r, str, level)
 	case "structure":

--- a/pkg/generate/code/late_initialization_test.go
+++ b/pkg/generate/code/late_initialization_test.go
@@ -41,8 +41,8 @@ if resp.Table.AttributeDefinitions[i0] != nil {
 if cr.Spec.ForProvider.AttributeDefinitions[i0] == nil {
 cr.Spec.ForProvider.AttributeDefinitions[i0] = &svcapitypes.AttributeDefinition{}
 }
-cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName, resp.Table.AttributeDefinitions[i0].AttributeName)
-cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType, resp.Table.AttributeDefinitions[i0].AttributeType)
+cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName, resp.Table.AttributeDefinitions[i0].AttributeName)
+cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType = li.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType, resp.Table.AttributeDefinitions[i0].AttributeType)
 }
 }
 }
@@ -53,7 +53,7 @@ if resp.Table.GlobalSecondaryIndexes[i0] != nil {
 if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] == nil {
 cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] = &svcapitypes.GlobalSecondaryIndex{}
 }
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName, resp.Table.GlobalSecondaryIndexes[i0].IndexName)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName, resp.Table.GlobalSecondaryIndexes[i0].IndexName)
 if len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema) == 0 {
 cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema))
 for i2 := range resp.Table.GlobalSecondaryIndexes[i0].KeySchema {
@@ -61,8 +61,8 @@ if resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2] != nil {
 if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] == nil {
 cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
 }
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType)
 }
 }
 }
@@ -73,17 +73,17 @@ cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection = &svcapitypes.Project
 if len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
 cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes))
 for i3 := range resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
 }
 }
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.GlobalSecondaryIndexes[i0].Projection.ProjectionType)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.GlobalSecondaryIndexes[i0].Projection.ProjectionType)
 }
 if resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput != nil {
 if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput == nil {
 cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
 }
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits)
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits)
 }
 }
 }
@@ -95,8 +95,8 @@ if resp.Table.KeySchema[i0] != nil {
 if cr.Spec.ForProvider.KeySchema[i0] == nil {
 cr.Spec.ForProvider.KeySchema[i0] = &svcapitypes.KeySchemaElement{}
 }
-cr.Spec.ForProvider.KeySchema[i0].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].AttributeName, resp.Table.KeySchema[i0].AttributeName)
-cr.Spec.ForProvider.KeySchema[i0].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].KeyType, resp.Table.KeySchema[i0].KeyType)
+cr.Spec.ForProvider.KeySchema[i0].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].AttributeName, resp.Table.KeySchema[i0].AttributeName)
+cr.Spec.ForProvider.KeySchema[i0].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].KeyType, resp.Table.KeySchema[i0].KeyType)
 }
 }
 }
@@ -107,7 +107,7 @@ if resp.Table.LocalSecondaryIndexes[i0] != nil {
 if cr.Spec.ForProvider.LocalSecondaryIndexes[i0] == nil {
 cr.Spec.ForProvider.LocalSecondaryIndexes[i0] = &svcapitypes.LocalSecondaryIndex{}
 }
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName, resp.Table.LocalSecondaryIndexes[i0].IndexName)
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName, resp.Table.LocalSecondaryIndexes[i0].IndexName)
 if len(resp.Table.LocalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema) == 0 {
 cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.LocalSecondaryIndexes[i0].KeySchema))
 for i2 := range resp.Table.LocalSecondaryIndexes[i0].KeySchema {
@@ -115,8 +115,8 @@ if resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2] != nil {
 if cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] == nil {
 cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
 }
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType)
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType)
 }
 }
 }
@@ -127,10 +127,10 @@ cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection = &svcapitypes.Projecti
 if len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
 cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes))
 for i3 := range resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
 }
 }
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.LocalSecondaryIndexes[i0].Projection.ProjectionType)
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.LocalSecondaryIndexes[i0].Projection.ProjectionType)
 }
 }
 }
@@ -139,17 +139,17 @@ if resp.Table.ProvisionedThroughput != nil {
 if cr.Spec.ForProvider.ProvisionedThroughput == nil {
 cr.Spec.ForProvider.ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
 }
-cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits, resp.Table.ProvisionedThroughput.ReadCapacityUnits)
-cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits, resp.Table.ProvisionedThroughput.WriteCapacityUnits)
+cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits, resp.Table.ProvisionedThroughput.ReadCapacityUnits)
+cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits, resp.Table.ProvisionedThroughput.WriteCapacityUnits)
 }
 if resp.Table.StreamSpecification != nil {
 if cr.Spec.ForProvider.StreamSpecification == nil {
 cr.Spec.ForProvider.StreamSpecification = &svcapitypes.StreamSpecification{}
 }
-cr.Spec.ForProvider.StreamSpecification.StreamEnabled = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.StreamSpecification.StreamEnabled, resp.Table.StreamSpecification.StreamEnabled)
-cr.Spec.ForProvider.StreamSpecification.StreamViewType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.StreamSpecification.StreamViewType, resp.Table.StreamSpecification.StreamViewType)
+cr.Spec.ForProvider.StreamSpecification.StreamEnabled = li.LateInitializeBoolPtr(cr.Spec.ForProvider.StreamSpecification.StreamEnabled, resp.Table.StreamSpecification.StreamEnabled)
+cr.Spec.ForProvider.StreamSpecification.StreamViewType = li.LateInitializeStringPtr(cr.Spec.ForProvider.StreamSpecification.StreamViewType, resp.Table.StreamSpecification.StreamViewType)
 }
-cr.Spec.ForProvider.TableName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.TableName, resp.Table.TableName)`
+cr.Spec.ForProvider.TableName = li.LateInitializeStringPtr(cr.Spec.ForProvider.TableName, resp.Table.TableName)`
 	assert.Equal(
 		expected,
 		code.LateInitializeReadOne(crd.Config(), crd, "resp", "cr"),
@@ -169,26 +169,26 @@ func Test_LateInitializeReadMany(t *testing.T) {
 if len(resource.AvailabilityZones) != 0 && len(cr.Spec.ForProvider.AvailabilityZones) == 0 {
 cr.Spec.ForProvider.AvailabilityZones = make([]*string, len(resource.AvailabilityZones))
 for i0 := range resource.AvailabilityZones {
-cr.Spec.ForProvider.AvailabilityZones[i0] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AvailabilityZones[i0], resource.AvailabilityZones[i0])
+cr.Spec.ForProvider.AvailabilityZones[i0] = li.LateInitializeStringPtr(cr.Spec.ForProvider.AvailabilityZones[i0], resource.AvailabilityZones[i0])
 }
 }
-cr.Spec.ForProvider.BacktrackWindow = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.BacktrackWindow, resource.BacktrackWindow)
-cr.Spec.ForProvider.BackupRetentionPeriod = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.BackupRetentionPeriod, resource.BackupRetentionPeriod)
-cr.Spec.ForProvider.CharacterSetName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.CharacterSetName, resource.CharacterSetName)
-cr.Spec.ForProvider.CopyTagsToSnapshot = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.CopyTagsToSnapshot, resource.CopyTagsToSnapshot)
-cr.Spec.ForProvider.DBClusterIdentifier = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DBClusterIdentifier, resource.DBClusterIdentifier)
-cr.Spec.ForProvider.DatabaseName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DatabaseName, resource.DatabaseName)
-cr.Spec.ForProvider.DeletionProtection = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.DeletionProtection, resource.DeletionProtection)
-cr.Spec.ForProvider.Engine = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.Engine, resource.Engine)
-cr.Spec.ForProvider.EngineMode = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.EngineMode, resource.EngineMode)
-cr.Spec.ForProvider.EngineVersion = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.EngineVersion, resource.EngineVersion)
-cr.Spec.ForProvider.KMSKeyID = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSKeyID, resource.KmsKeyId)
-cr.Spec.ForProvider.MasterUsername = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MasterUsername, resource.MasterUsername)
-cr.Spec.ForProvider.Port = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.Port, resource.Port)
-cr.Spec.ForProvider.PreferredBackupWindow = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredBackupWindow, resource.PreferredBackupWindow)
-cr.Spec.ForProvider.PreferredMaintenanceWindow = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredMaintenanceWindow, resource.PreferredMaintenanceWindow)
-cr.Spec.ForProvider.ReplicationSourceIdentifier = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ReplicationSourceIdentifier, resource.ReplicationSourceIdentifier)
-cr.Spec.ForProvider.StorageEncrypted = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.StorageEncrypted, resource.StorageEncrypted)
+cr.Spec.ForProvider.BacktrackWindow = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.BacktrackWindow, resource.BacktrackWindow)
+cr.Spec.ForProvider.BackupRetentionPeriod = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.BackupRetentionPeriod, resource.BackupRetentionPeriod)
+cr.Spec.ForProvider.CharacterSetName = li.LateInitializeStringPtr(cr.Spec.ForProvider.CharacterSetName, resource.CharacterSetName)
+cr.Spec.ForProvider.CopyTagsToSnapshot = li.LateInitializeBoolPtr(cr.Spec.ForProvider.CopyTagsToSnapshot, resource.CopyTagsToSnapshot)
+cr.Spec.ForProvider.DBClusterIdentifier = li.LateInitializeStringPtr(cr.Spec.ForProvider.DBClusterIdentifier, resource.DBClusterIdentifier)
+cr.Spec.ForProvider.DatabaseName = li.LateInitializeStringPtr(cr.Spec.ForProvider.DatabaseName, resource.DatabaseName)
+cr.Spec.ForProvider.DeletionProtection = li.LateInitializeBoolPtr(cr.Spec.ForProvider.DeletionProtection, resource.DeletionProtection)
+cr.Spec.ForProvider.Engine = li.LateInitializeStringPtr(cr.Spec.ForProvider.Engine, resource.Engine)
+cr.Spec.ForProvider.EngineMode = li.LateInitializeStringPtr(cr.Spec.ForProvider.EngineMode, resource.EngineMode)
+cr.Spec.ForProvider.EngineVersion = li.LateInitializeStringPtr(cr.Spec.ForProvider.EngineVersion, resource.EngineVersion)
+cr.Spec.ForProvider.KMSKeyID = li.LateInitializeStringPtr(cr.Spec.ForProvider.KMSKeyID, resource.KmsKeyId)
+cr.Spec.ForProvider.MasterUsername = li.LateInitializeStringPtr(cr.Spec.ForProvider.MasterUsername, resource.MasterUsername)
+cr.Spec.ForProvider.Port = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.Port, resource.Port)
+cr.Spec.ForProvider.PreferredBackupWindow = li.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredBackupWindow, resource.PreferredBackupWindow)
+cr.Spec.ForProvider.PreferredMaintenanceWindow = li.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredMaintenanceWindow, resource.PreferredMaintenanceWindow)
+cr.Spec.ForProvider.ReplicationSourceIdentifier = li.LateInitializeStringPtr(cr.Spec.ForProvider.ReplicationSourceIdentifier, resource.ReplicationSourceIdentifier)
+cr.Spec.ForProvider.StorageEncrypted = li.LateInitializeBoolPtr(cr.Spec.ForProvider.StorageEncrypted, resource.StorageEncrypted)
 }`
 	assert.Equal(
 		expected,
@@ -205,17 +205,17 @@ func Test_LateInitializeGetAttributes(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
 
-	expected := `cr.Spec.ForProvider.ContentBasedDeduplication = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ContentBasedDeduplication, resp.Attributes["ContentBasedDeduplication"])
-cr.Spec.ForProvider.DelaySeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DelaySeconds, resp.Attributes["DelaySeconds"])
-cr.Spec.ForProvider.FifoQueue = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.FifoQueue, resp.Attributes["FifoQueue"])
-cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds, resp.Attributes["KmsDataKeyReusePeriodSeconds"])
-cr.Spec.ForProvider.KMSMasterKeyID = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSMasterKeyID, resp.Attributes["KmsMasterKeyId"])
-cr.Spec.ForProvider.MaximumMessageSize = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MaximumMessageSize, resp.Attributes["MaximumMessageSize"])
-cr.Spec.ForProvider.MessageRetentionPeriod = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MessageRetentionPeriod, resp.Attributes["MessageRetentionPeriod"])
-cr.Spec.ForProvider.Policy = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.Policy, resp.Attributes["Policy"])
-cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds, resp.Attributes["ReceiveMessageWaitTimeSeconds"])
-cr.Spec.ForProvider.RedrivePolicy = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.RedrivePolicy, resp.Attributes["RedrivePolicy"])
-cr.Spec.ForProvider.VisibilityTimeout = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.VisibilityTimeout, resp.Attributes["VisibilityTimeout"])`
+	expected := `cr.Spec.ForProvider.ContentBasedDeduplication = li.LateInitializeStringPtr(cr.Spec.ForProvider.ContentBasedDeduplication, resp.Attributes["ContentBasedDeduplication"])
+cr.Spec.ForProvider.DelaySeconds = li.LateInitializeStringPtr(cr.Spec.ForProvider.DelaySeconds, resp.Attributes["DelaySeconds"])
+cr.Spec.ForProvider.FifoQueue = li.LateInitializeStringPtr(cr.Spec.ForProvider.FifoQueue, resp.Attributes["FifoQueue"])
+cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds = li.LateInitializeStringPtr(cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds, resp.Attributes["KmsDataKeyReusePeriodSeconds"])
+cr.Spec.ForProvider.KMSMasterKeyID = li.LateInitializeStringPtr(cr.Spec.ForProvider.KMSMasterKeyID, resp.Attributes["KmsMasterKeyId"])
+cr.Spec.ForProvider.MaximumMessageSize = li.LateInitializeStringPtr(cr.Spec.ForProvider.MaximumMessageSize, resp.Attributes["MaximumMessageSize"])
+cr.Spec.ForProvider.MessageRetentionPeriod = li.LateInitializeStringPtr(cr.Spec.ForProvider.MessageRetentionPeriod, resp.Attributes["MessageRetentionPeriod"])
+cr.Spec.ForProvider.Policy = li.LateInitializeStringPtr(cr.Spec.ForProvider.Policy, resp.Attributes["Policy"])
+cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds = li.LateInitializeStringPtr(cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds, resp.Attributes["ReceiveMessageWaitTimeSeconds"])
+cr.Spec.ForProvider.RedrivePolicy = li.LateInitializeStringPtr(cr.Spec.ForProvider.RedrivePolicy, resp.Attributes["RedrivePolicy"])
+cr.Spec.ForProvider.VisibilityTimeout = li.LateInitializeStringPtr(cr.Spec.ForProvider.VisibilityTimeout, resp.Attributes["VisibilityTimeout"])`
 	assert.Equal(
 		expected,
 		code.LateInitializeGetAttributes(crd.Config(), crd, "resp", "cr"),

--- a/pkg/generate/code/late_initialization_test.go
+++ b/pkg/generate/code/late_initialization_test.go
@@ -1,0 +1,223 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/crossplane"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func Test_LateInitializeReadOne(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "dynamodb", crossplane.DefaultConfig)
+
+	crd := testutil.GetCRDByName(t, g, "Table")
+	require.NotNil(crd)
+
+	expected := `if len(resp.Table.AttributeDefinitions) != 0 && len(cr.Spec.ForProvider.AttributeDefinitions) == 0 {
+cr.Spec.ForProvider.AttributeDefinitions = make([]*svcapitypes.AttributeDefinition, len(resp.Table.AttributeDefinitions))
+for i0 := range resp.Table.AttributeDefinitions {
+if resp.Table.AttributeDefinitions[i0] != nil {
+if cr.Spec.ForProvider.AttributeDefinitions[i0] == nil {
+cr.Spec.ForProvider.AttributeDefinitions[i0] = &svcapitypes.AttributeDefinition{}
+}
+cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName, resp.Table.AttributeDefinitions[i0].AttributeName)
+cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType, resp.Table.AttributeDefinitions[i0].AttributeType)
+}
+}
+}
+if len(resp.Table.GlobalSecondaryIndexes) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes) == 0 {
+cr.Spec.ForProvider.GlobalSecondaryIndexes = make([]*svcapitypes.GlobalSecondaryIndex, len(resp.Table.GlobalSecondaryIndexes))
+for i0 := range resp.Table.GlobalSecondaryIndexes {
+if resp.Table.GlobalSecondaryIndexes[i0] != nil {
+if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] == nil {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] = &svcapitypes.GlobalSecondaryIndex{}
+}
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName, resp.Table.GlobalSecondaryIndexes[i0].IndexName)
+if len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema) == 0 {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema))
+for i2 := range resp.Table.GlobalSecondaryIndexes[i0].KeySchema {
+if resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2] != nil {
+if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] == nil {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
+}
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType)
+}
+}
+}
+if resp.Table.GlobalSecondaryIndexes[i0].Projection != nil {
+if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection == nil {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection = &svcapitypes.Projection{}
+}
+if len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes))
+for i3 := range resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
+}
+}
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.GlobalSecondaryIndexes[i0].Projection.ProjectionType)
+}
+if resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput != nil {
+if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput == nil {
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
+}
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits)
+cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits)
+}
+}
+}
+}
+if len(resp.Table.KeySchema) != 0 && len(cr.Spec.ForProvider.KeySchema) == 0 {
+cr.Spec.ForProvider.KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.KeySchema))
+for i0 := range resp.Table.KeySchema {
+if resp.Table.KeySchema[i0] != nil {
+if cr.Spec.ForProvider.KeySchema[i0] == nil {
+cr.Spec.ForProvider.KeySchema[i0] = &svcapitypes.KeySchemaElement{}
+}
+cr.Spec.ForProvider.KeySchema[i0].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].AttributeName, resp.Table.KeySchema[i0].AttributeName)
+cr.Spec.ForProvider.KeySchema[i0].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].KeyType, resp.Table.KeySchema[i0].KeyType)
+}
+}
+}
+if len(resp.Table.LocalSecondaryIndexes) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes) == 0 {
+cr.Spec.ForProvider.LocalSecondaryIndexes = make([]*svcapitypes.LocalSecondaryIndex, len(resp.Table.LocalSecondaryIndexes))
+for i0 := range resp.Table.LocalSecondaryIndexes {
+if resp.Table.LocalSecondaryIndexes[i0] != nil {
+if cr.Spec.ForProvider.LocalSecondaryIndexes[i0] == nil {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0] = &svcapitypes.LocalSecondaryIndex{}
+}
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName, resp.Table.LocalSecondaryIndexes[i0].IndexName)
+if len(resp.Table.LocalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema) == 0 {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.LocalSecondaryIndexes[i0].KeySchema))
+for i2 := range resp.Table.LocalSecondaryIndexes[i0].KeySchema {
+if resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2] != nil {
+if cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] == nil {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
+}
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType)
+}
+}
+}
+if resp.Table.LocalSecondaryIndexes[i0].Projection != nil {
+if cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection == nil {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection = &svcapitypes.Projection{}
+}
+if len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes))
+for i3 := range resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes {
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
+}
+}
+cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.LocalSecondaryIndexes[i0].Projection.ProjectionType)
+}
+}
+}
+}
+if resp.Table.ProvisionedThroughput != nil {
+if cr.Spec.ForProvider.ProvisionedThroughput == nil {
+cr.Spec.ForProvider.ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
+}
+cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits, resp.Table.ProvisionedThroughput.ReadCapacityUnits)
+cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits, resp.Table.ProvisionedThroughput.WriteCapacityUnits)
+}
+if resp.Table.StreamSpecification != nil {
+if cr.Spec.ForProvider.StreamSpecification == nil {
+cr.Spec.ForProvider.StreamSpecification = &svcapitypes.StreamSpecification{}
+}
+cr.Spec.ForProvider.StreamSpecification.StreamEnabled = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.StreamSpecification.StreamEnabled, resp.Table.StreamSpecification.StreamEnabled)
+cr.Spec.ForProvider.StreamSpecification.StreamViewType = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.StreamSpecification.StreamViewType, resp.Table.StreamSpecification.StreamViewType)
+}
+cr.Spec.ForProvider.TableName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.TableName, resp.Table.TableName)`
+	assert.Equal(
+		expected,
+		code.LateInitializeReadOne(crd.Config(), crd, "resp", "cr"),
+	)
+}
+
+func Test_LateInitializeReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "rds", crossplane.DefaultConfig)
+
+	crd := testutil.GetCRDByName(t, g, "DBCluster")
+	require.NotNil(crd)
+
+	expected := `for _, resource := range resp.DBClusters {
+if len(resource.AvailabilityZones) != 0 && len(cr.Spec.ForProvider.AvailabilityZones) == 0 {
+cr.Spec.ForProvider.AvailabilityZones = make([]*string, len(resource.AvailabilityZones))
+for i0 := range resource.AvailabilityZones {
+cr.Spec.ForProvider.AvailabilityZones[i0] = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.AvailabilityZones[i0], resource.AvailabilityZones[i0])
+}
+}
+cr.Spec.ForProvider.BacktrackWindow = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.BacktrackWindow, resource.BacktrackWindow)
+cr.Spec.ForProvider.BackupRetentionPeriod = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.BackupRetentionPeriod, resource.BackupRetentionPeriod)
+cr.Spec.ForProvider.CharacterSetName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.CharacterSetName, resource.CharacterSetName)
+cr.Spec.ForProvider.CopyTagsToSnapshot = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.CopyTagsToSnapshot, resource.CopyTagsToSnapshot)
+cr.Spec.ForProvider.DBClusterIdentifier = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DBClusterIdentifier, resource.DBClusterIdentifier)
+cr.Spec.ForProvider.DatabaseName = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DatabaseName, resource.DatabaseName)
+cr.Spec.ForProvider.DeletionProtection = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.DeletionProtection, resource.DeletionProtection)
+cr.Spec.ForProvider.Engine = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.Engine, resource.Engine)
+cr.Spec.ForProvider.EngineMode = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.EngineMode, resource.EngineMode)
+cr.Spec.ForProvider.EngineVersion = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.EngineVersion, resource.EngineVersion)
+cr.Spec.ForProvider.KMSKeyID = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSKeyID, resource.KmsKeyId)
+cr.Spec.ForProvider.MasterUsername = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MasterUsername, resource.MasterUsername)
+cr.Spec.ForProvider.Port = awsclients.LateInitializeInt64Ptr(cr.Spec.ForProvider.Port, resource.Port)
+cr.Spec.ForProvider.PreferredBackupWindow = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredBackupWindow, resource.PreferredBackupWindow)
+cr.Spec.ForProvider.PreferredMaintenanceWindow = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.PreferredMaintenanceWindow, resource.PreferredMaintenanceWindow)
+cr.Spec.ForProvider.ReplicationSourceIdentifier = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ReplicationSourceIdentifier, resource.ReplicationSourceIdentifier)
+cr.Spec.ForProvider.StorageEncrypted = awsclients.LateInitializeBoolPtr(cr.Spec.ForProvider.StorageEncrypted, resource.StorageEncrypted)
+}`
+	assert.Equal(
+		expected,
+		code.LateInitializeReadMany(crd.Config(), crd, "resp", "cr"),
+	)
+}
+
+func Test_LateInitializeGetAttributes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "sqs", crossplane.DefaultConfig)
+
+	crd := testutil.GetCRDByName(t, g, "Queue")
+	require.NotNil(crd)
+
+	expected := `cr.Spec.ForProvider.ContentBasedDeduplication = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ContentBasedDeduplication, resp.Attributes["ContentBasedDeduplication"])
+cr.Spec.ForProvider.DelaySeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.DelaySeconds, resp.Attributes["DelaySeconds"])
+cr.Spec.ForProvider.FifoQueue = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.FifoQueue, resp.Attributes["FifoQueue"])
+cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSDataKeyReusePeriodSeconds, resp.Attributes["KmsDataKeyReusePeriodSeconds"])
+cr.Spec.ForProvider.KMSMasterKeyID = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.KMSMasterKeyID, resp.Attributes["KmsMasterKeyId"])
+cr.Spec.ForProvider.MaximumMessageSize = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MaximumMessageSize, resp.Attributes["MaximumMessageSize"])
+cr.Spec.ForProvider.MessageRetentionPeriod = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.MessageRetentionPeriod, resp.Attributes["MessageRetentionPeriod"])
+cr.Spec.ForProvider.Policy = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.Policy, resp.Attributes["Policy"])
+cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.ReceiveMessageWaitTimeSeconds, resp.Attributes["ReceiveMessageWaitTimeSeconds"])
+cr.Spec.ForProvider.RedrivePolicy = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.RedrivePolicy, resp.Attributes["RedrivePolicy"])
+cr.Spec.ForProvider.VisibilityTimeout = awsclients.LateInitializeStringPtr(cr.Spec.ForProvider.VisibilityTimeout, resp.Attributes["VisibilityTimeout"])`
+	assert.Equal(
+		expected,
+		code.LateInitializeGetAttributes(crd.Config(), crd, "resp", "cr"),
+	)
+}

--- a/pkg/generate/code/late_initialization_test.go
+++ b/pkg/generate/code/late_initialization_test.go
@@ -29,127 +29,46 @@ func Test_LateInitializeReadOne(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "dynamodb", crossplane.DefaultConfig)
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", crossplane.DefaultConfig)
 
-	crd := testutil.GetCRDByName(t, g, "Table")
+	crd := testutil.GetCRDByName(t, g, "Route")
 	require.NotNil(crd)
 
-	expected := `if len(resp.Table.AttributeDefinitions) != 0 && len(cr.Spec.ForProvider.AttributeDefinitions) == 0 {
-cr.Spec.ForProvider.AttributeDefinitions = make([]*svcapitypes.AttributeDefinition, len(resp.Table.AttributeDefinitions))
-for i0 := range resp.Table.AttributeDefinitions {
-if resp.Table.AttributeDefinitions[i0] != nil {
-if cr.Spec.ForProvider.AttributeDefinitions[i0] == nil {
-cr.Spec.ForProvider.AttributeDefinitions[i0] = &svcapitypes.AttributeDefinition{}
-}
-cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeName, resp.Table.AttributeDefinitions[i0].AttributeName)
-cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType = li.LateInitializeStringPtr(cr.Spec.ForProvider.AttributeDefinitions[i0].AttributeType, resp.Table.AttributeDefinitions[i0].AttributeType)
+	expected := `cr.Spec.ForProvider.APIKeyRequired = li.LateInitializeBoolPtr(cr.Spec.ForProvider.APIKeyRequired, resp.ApiKeyRequired)
+if len(resp.AuthorizationScopes) != 0 && len(cr.Spec.ForProvider.AuthorizationScopes) == 0 {
+cr.Spec.ForProvider.AuthorizationScopes = make([]*string, len(resp.AuthorizationScopes))
+for i0 := range resp.AuthorizationScopes {
+cr.Spec.ForProvider.AuthorizationScopes[i0] = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizationScopes[i0], resp.AuthorizationScopes[i0])
 }
 }
+cr.Spec.ForProvider.AuthorizationType = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizationType, resp.AuthorizationType)
+cr.Spec.ForProvider.AuthorizerID = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizerID, resp.AuthorizerId)
+cr.Spec.ForProvider.ModelSelectionExpression = li.LateInitializeStringPtr(cr.Spec.ForProvider.ModelSelectionExpression, resp.ModelSelectionExpression)
+cr.Spec.ForProvider.OperationName = li.LateInitializeStringPtr(cr.Spec.ForProvider.OperationName, resp.OperationName)
+if resp.RequestModels != nil {
+if cr.Spec.ForProvider.RequestModels == nil {
+cr.Spec.ForProvider.RequestModels = map[string]*string{}
 }
-if len(resp.Table.GlobalSecondaryIndexes) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes) == 0 {
-cr.Spec.ForProvider.GlobalSecondaryIndexes = make([]*svcapitypes.GlobalSecondaryIndex, len(resp.Table.GlobalSecondaryIndexes))
-for i0 := range resp.Table.GlobalSecondaryIndexes {
-if resp.Table.GlobalSecondaryIndexes[i0] != nil {
-if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] == nil {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0] = &svcapitypes.GlobalSecondaryIndex{}
-}
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].IndexName, resp.Table.GlobalSecondaryIndexes[i0].IndexName)
-if len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema) == 0 {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.GlobalSecondaryIndexes[i0].KeySchema))
-for i2 := range resp.Table.GlobalSecondaryIndexes[i0].KeySchema {
-if resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2] != nil {
-if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] == nil {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
-}
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.GlobalSecondaryIndexes[i0].KeySchema[i2].KeyType)
+for key0 := range resp.RequestModels {
+cr.Spec.ForProvider.RequestModels[key0] = li.LateInitializeStringPtr(cr.Spec.ForProvider.RequestModels[key0], resp.RequestModels[key0])
 }
 }
+if resp.RequestParameters != nil {
+if cr.Spec.ForProvider.RequestParameters == nil {
+cr.Spec.ForProvider.RequestParameters = map[string]*svcapitypes.ParameterConstraints{}
 }
-if resp.Table.GlobalSecondaryIndexes[i0].Projection != nil {
-if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection == nil {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection = &svcapitypes.Projection{}
+for key0 := range resp.RequestParameters {
+if resp.RequestParameters[key0] != nil {
+if cr.Spec.ForProvider.RequestParameters[key0] == nil {
+cr.Spec.ForProvider.RequestParameters[key0] = &svcapitypes.ParameterConstraints{}
 }
-if len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes))
-for i3 := range resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.GlobalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
-}
-}
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType = li.LateInitializeStringPtr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.GlobalSecondaryIndexes[i0].Projection.ProjectionType)
-}
-if resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput != nil {
-if cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput == nil {
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
-}
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.ReadCapacityUnits)
-cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits, resp.Table.GlobalSecondaryIndexes[i0].ProvisionedThroughput.WriteCapacityUnits)
+cr.Spec.ForProvider.RequestParameters[key0].Required = li.LateInitializeBoolPtr(cr.Spec.ForProvider.RequestParameters[key0].Required, resp.RequestParameters[key0].Required)
 }
 }
 }
-}
-if len(resp.Table.KeySchema) != 0 && len(cr.Spec.ForProvider.KeySchema) == 0 {
-cr.Spec.ForProvider.KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.KeySchema))
-for i0 := range resp.Table.KeySchema {
-if resp.Table.KeySchema[i0] != nil {
-if cr.Spec.ForProvider.KeySchema[i0] == nil {
-cr.Spec.ForProvider.KeySchema[i0] = &svcapitypes.KeySchemaElement{}
-}
-cr.Spec.ForProvider.KeySchema[i0].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].AttributeName, resp.Table.KeySchema[i0].AttributeName)
-cr.Spec.ForProvider.KeySchema[i0].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.KeySchema[i0].KeyType, resp.Table.KeySchema[i0].KeyType)
-}
-}
-}
-if len(resp.Table.LocalSecondaryIndexes) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes) == 0 {
-cr.Spec.ForProvider.LocalSecondaryIndexes = make([]*svcapitypes.LocalSecondaryIndex, len(resp.Table.LocalSecondaryIndexes))
-for i0 := range resp.Table.LocalSecondaryIndexes {
-if resp.Table.LocalSecondaryIndexes[i0] != nil {
-if cr.Spec.ForProvider.LocalSecondaryIndexes[i0] == nil {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0] = &svcapitypes.LocalSecondaryIndex{}
-}
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].IndexName, resp.Table.LocalSecondaryIndexes[i0].IndexName)
-if len(resp.Table.LocalSecondaryIndexes[i0].KeySchema) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema) == 0 {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema = make([]*svcapitypes.KeySchemaElement, len(resp.Table.LocalSecondaryIndexes[i0].KeySchema))
-for i2 := range resp.Table.LocalSecondaryIndexes[i0].KeySchema {
-if resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2] != nil {
-if cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] == nil {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2] = &svcapitypes.KeySchemaElement{}
-}
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].AttributeName)
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType, resp.Table.LocalSecondaryIndexes[i0].KeySchema[i2].KeyType)
-}
-}
-}
-if resp.Table.LocalSecondaryIndexes[i0].Projection != nil {
-if cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection == nil {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection = &svcapitypes.Projection{}
-}
-if len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) != 0 && len(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes) == 0 {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes = make([]*string, len(resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes))
-for i3 := range resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes {
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3] = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3], resp.Table.LocalSecondaryIndexes[i0].Projection.NonKeyAttributes[i3])
-}
-}
-cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType = li.LateInitializeStringPtr(cr.Spec.ForProvider.LocalSecondaryIndexes[i0].Projection.ProjectionType, resp.Table.LocalSecondaryIndexes[i0].Projection.ProjectionType)
-}
-}
-}
-}
-if resp.Table.ProvisionedThroughput != nil {
-if cr.Spec.ForProvider.ProvisionedThroughput == nil {
-cr.Spec.ForProvider.ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{}
-}
-cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.ReadCapacityUnits, resp.Table.ProvisionedThroughput.ReadCapacityUnits)
-cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits = li.LateInitializeInt64Ptr(cr.Spec.ForProvider.ProvisionedThroughput.WriteCapacityUnits, resp.Table.ProvisionedThroughput.WriteCapacityUnits)
-}
-if resp.Table.StreamSpecification != nil {
-if cr.Spec.ForProvider.StreamSpecification == nil {
-cr.Spec.ForProvider.StreamSpecification = &svcapitypes.StreamSpecification{}
-}
-cr.Spec.ForProvider.StreamSpecification.StreamEnabled = li.LateInitializeBoolPtr(cr.Spec.ForProvider.StreamSpecification.StreamEnabled, resp.Table.StreamSpecification.StreamEnabled)
-cr.Spec.ForProvider.StreamSpecification.StreamViewType = li.LateInitializeStringPtr(cr.Spec.ForProvider.StreamSpecification.StreamViewType, resp.Table.StreamSpecification.StreamViewType)
-}
-cr.Spec.ForProvider.TableName = li.LateInitializeStringPtr(cr.Spec.ForProvider.TableName, resp.Table.TableName)`
+cr.Spec.ForProvider.RouteKey = li.LateInitializeStringPtr(cr.Spec.ForProvider.RouteKey, resp.RouteKey)
+cr.Spec.ForProvider.RouteResponseSelectionExpression = li.LateInitializeStringPtr(cr.Spec.ForProvider.RouteResponseSelectionExpression, resp.RouteResponseSelectionExpression)
+cr.Spec.ForProvider.Target = li.LateInitializeStringPtr(cr.Spec.ForProvider.Target, resp.Target)`
 	assert.Equal(
 		expected,
 		code.LateInitializeReadOne(crd.Config(), crd, "resp", "cr"),

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
@@ -28,7 +29,7 @@ func TestSetResource_APIGWv2_Route_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Route")
 	require.NotNil(crd)
@@ -55,7 +56,7 @@ func TestSetResource_APIGWv2_Route_ReadOne(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Route")
 	require.NotNil(crd)
@@ -157,7 +158,7 @@ func TestSetResource_CodeDeploy_Deployment_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "codedeploy")
+	g := testutil.NewGeneratorForService(t, "codedeploy", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Deployment")
 	require.NotNil(crd)
@@ -183,7 +184,7 @@ func TestSetResource_DynamoDB_Table_ReadOne(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "dynamodb")
+	g := testutil.NewGeneratorForService(t, "dynamodb", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Table")
 	require.NotNil(crd)
@@ -531,7 +532,7 @@ func TestSetResource_EC2_LaunchTemplate_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ec2")
+	g := testutil.NewGeneratorForService(t, "ec2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "LaunchTemplate")
 	require.NotNil(crd)
@@ -592,7 +593,7 @@ func TestSetResource_ECR_Repository_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ecr")
+	g := testutil.NewGeneratorForService(t, "ecr", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
@@ -634,7 +635,7 @@ func TestSetResource_ECR_Repository_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ecr")
+	g := testutil.NewGeneratorForService(t, "ecr", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
@@ -710,7 +711,7 @@ func TestSetResource_Elasticache_ReplicationGroup_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
@@ -975,7 +976,7 @@ func TestSetResource_Elasticache_ReplicationGroup_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
@@ -1331,7 +1332,7 @@ func TestSetResource_RDS_DBInstance_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "rds")
+	g := testutil.NewGeneratorForService(t, "rds", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "DBInstance")
 	require.NotNil(crd)
@@ -1714,7 +1715,7 @@ func TestSetResource_RDS_DBInstance_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "rds")
+	g := testutil.NewGeneratorForService(t, "rds", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "DBInstance")
 	require.NotNil(crd)
@@ -2279,7 +2280,7 @@ func TestSetResource_S3_Bucket_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
@@ -2301,7 +2302,7 @@ func TestSetResource_S3_Bucket_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
@@ -2336,7 +2337,7 @@ func TestSetResource_SNS_Topic_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Topic")
 	require.NotNil(crd)
@@ -2366,7 +2367,7 @@ func TestSetResource_SNS_Topic_GetAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Topic")
 	require.NotNil(crd)
@@ -2396,7 +2397,7 @@ func TestSetResource_SQS_Queue_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
@@ -2420,7 +2421,7 @@ func TestSetResource_SQS_Queue_GetAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
@@ -2449,7 +2450,7 @@ func TestSetResource_RDS_DBSubnetGroup_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "rds")
+	g := testutil.NewGeneratorForService(t, "rds", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "DBSubnetGroup")
 	require.NotNil(crd)

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1102,41 +1102,16 @@ func varEmptyConstructorK8sType(
 ) string {
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
-	goType := shape.GoTypeWithPkgName()
-	keepPointer := (shape.Type == "list" || shape.Type == "map")
-	goType = model.ReplacePkgName(goType, r.SDKAPIPackageName(), "svcapitypes", keepPointer)
-	goTypeNoPkg := goType
-	goPkg := ""
-	hadPkg := false
-	if strings.Contains(goType, ".") {
-		parts := strings.Split(goType, ".")
-		goTypeNoPkg = parts[1]
-		goPkg = parts[0]
-		hadPkg = true
-	}
-	renames := r.TypeRenames()
-	altTypeName, renamed := renames[goTypeNoPkg]
-	if renamed {
-		goTypeNoPkg = altTypeName
-	} else if hadPkg {
-		cleanNames := names.New(goTypeNoPkg)
-		goTypeNoPkg = cleanNames.Camel
-	}
-	goType = goTypeNoPkg
-	if hadPkg {
-		goType = goPkg + "." + goType
-	}
-
 	switch shape.Type {
 	case "structure":
 		// f0 := &svcapitypes.BookData{}
-		out += fmt.Sprintf("%s%s := &%s{}\n", indent, varName, goType)
+		out += fmt.Sprintf("%s%s := &%s{}\n", indent, varName, GetCRDStructType(shape, r, false))
 	case "list", "map":
 		// f0 := []*string{}
-		out += fmt.Sprintf("%s%s := %s{}\n", indent, varName, goType)
+		out += fmt.Sprintf("%s%s := %s{}\n", indent, varName, GetCRDStructType(shape, r, true))
 	default:
 		// var f0 string
-		out += fmt.Sprintf("%svar %s %s\n", indent, varName, goType)
+		out += fmt.Sprintf("%svar %s %s\n", indent, varName, GetCRDStructType(shape, r, false))
 	}
 	return out
 }

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
@@ -28,7 +29,7 @@ func TestSetSDK_APIGWv2_Route_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+	g := testutil.NewGeneratorForService(t, "apigatewayv2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Route")
 	require.NotNil(crd)
@@ -101,7 +102,7 @@ func TestSetSDK_DynamoDB_Table_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "dynamodb")
+	g := testutil.NewGeneratorForService(t, "dynamodb", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Table")
 	require.NotNil(crd)
@@ -291,7 +292,7 @@ func TestSetSDK_EC2_LaunchTemplate_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ec2")
+	g := testutil.NewGeneratorForService(t, "ec2", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "LaunchTemplate")
 	require.NotNil(crd)
@@ -695,7 +696,7 @@ func TestSetSDK_ECR_Repository_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ecr")
+	g := testutil.NewGeneratorForService(t, "ecr", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
@@ -743,7 +744,7 @@ func TestSetSDK_Elasticache_ReplicationGroup_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
@@ -976,7 +977,7 @@ func TestSetSDK_Elasticache_ReplicationGroup_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
@@ -1000,7 +1001,7 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
@@ -1113,7 +1114,7 @@ func TestSetSDK_RDS_DBInstance_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "rds")
+	g := testutil.NewGeneratorForService(t, "rds", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "DBInstance")
 	require.NotNil(crd)
@@ -1308,7 +1309,7 @@ func TestSetSDK_S3_Bucket_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
@@ -1356,7 +1357,7 @@ func TestSetSDK_S3_Bucket_Delete(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
@@ -1376,7 +1377,7 @@ func TestSetSDK_SNS_Topic_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Topic")
 	require.NotNil(crd)
@@ -1428,7 +1429,7 @@ func TestSetSDK_SNS_Topic_GetAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Topic")
 	require.NotNil(crd)
@@ -1454,7 +1455,7 @@ func TestSetSDK_SQS_Queue_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
@@ -1518,7 +1519,7 @@ func TestSetSDK_SQS_Queue_GetAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Queue")
 	require.NotNil(crd)
@@ -1548,7 +1549,7 @@ func TestSetSDK_MQ_Broker_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "mq")
+	g := testutil.NewGeneratorForService(t, "mq", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Broker")
 	require.NotNil(crd)

--- a/pkg/generate/codedeploy_test.go
+++ b/pkg/generate/codedeploy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestCodeDeploy_Deployment(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "codedeploy")
+	g := testutil.NewGeneratorForService(t, "codedeploy", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -88,6 +88,15 @@ var (
 		"GoCodeSetDeleteInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeLateInitializeReadOne": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int, performSpecUpdate bool) string {
+			return code.LateInitializeReadOne(r.Config(), r, sourceVarName, targetVarName)
+		},
+		"GoCodeLateInitializeReadMany": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int, performSpecUpdate bool) string {
+			return code.LateInitializeReadMany(r.Config(), r, sourceVarName, targetVarName)
+		},
+		"GoCodeLateInitializeGetAttributes": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int, performSpecUpdate bool) string {
+			return code.LateInitializeGetAttributes(r.Config(), r, sourceVarName, targetVarName)
+		},
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},

--- a/pkg/generate/dynamodb_test.go
+++ b/pkg/generate/dynamodb_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestDynamoDB_Table(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "dynamodb")
+	g := testutil.NewGeneratorForService(t, "dynamodb", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/ec2_test.go
+++ b/pkg/generate/ec2_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestEC2_LaunchTemplate(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ec2")
+	g := testutil.NewGeneratorForService(t, "ec2", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/ecr_test.go
+++ b/pkg/generate/ecr_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestECRRepository(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "ecr")
+	g := testutil.NewGeneratorForService(t, "ecr", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestElasticache_ReplicationGroup(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)
@@ -160,7 +161,7 @@ func TestElasticache_ReplicationGroup(t *testing.T) {
 func TestElasticache_Ignored_Resources(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)
@@ -172,7 +173,7 @@ func TestElasticache_Ignored_Resources(t *testing.T) {
 func TestElasticache_Additional_Snapshot_Spec(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -187,7 +188,7 @@ func TestElasticache_Additional_Snapshot_Spec(t *testing.T) {
 func TestElasticache_Additional_CacheParameterGroup_Spec(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -202,7 +203,7 @@ func TestElasticache_Additional_CacheParameterGroup_Spec(t *testing.T) {
 func TestElasticache_Additional_CacheParameterGroup_Status(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -218,7 +219,7 @@ func TestElasticache_Additional_CacheParameterGroup_Status(t *testing.T) {
 func TestElasticache_Additional_ReplicationGroup_Status(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -233,7 +234,7 @@ func TestElasticache_Additional_ReplicationGroup_Status(t *testing.T) {
 func TestElasticache_Additional_CacheSubnetGroup_Status(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -248,7 +249,7 @@ func TestElasticache_Additional_CacheSubnetGroup_Status(t *testing.T) {
 func TestElasticache_Additional_ReplicationGroup_Status_RenameField(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)
@@ -264,7 +265,7 @@ func TestElasticache_Additional_ReplicationGroup_Status_RenameField(t *testing.T
 func TestElasticache_ValidateAuthTokenIsSecret(t *testing.T) {
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "elasticache")
+	g := testutil.NewGeneratorForService(t, "elasticache", ackgenconfig.DefaultConfig)
 	crds, err := g.GetCRDs()
 
 	require.Nil(err)

--- a/pkg/generate/enum_def_test.go
+++ b/pkg/generate/enum_def_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
@@ -95,7 +96,7 @@ func TestEnumDefs(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		g := testutil.NewGeneratorForService(t, test.service)
+		g := testutil.NewGeneratorForService(t, test.service, ackgenconfig.DefaultConfig)
 
 		edefs, err := g.GetEnumDefs()
 		require.Nil(err)

--- a/pkg/generate/lambda_test.go
+++ b/pkg/generate/lambda_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestLambda_Function(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "lambda")
+	g := testutil.NewGeneratorForService(t, "lambda", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/mq_test.go
+++ b/pkg/generate/mq_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestMQ_Broker(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "mq")
+	g := testutil.NewGeneratorForService(t, "mq", ackgenconfig.DefaultConfig)
 
 	crd := testutil.GetCRDByName(t, g, "Broker")
 	require.NotNil(crd)

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestRDS_DBInstance(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "rds")
+	g := testutil.NewGeneratorForService(t, "rds", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/s3_test.go
+++ b/pkg/generate/s3_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestS3_Bucket(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "s3")
+	g := testutil.NewGeneratorForService(t, "s3", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/sagemaker_test.go
+++ b/pkg/generate/sagemaker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestSageMaker_ARN_Field_Override(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sagemaker")
+	g := testutil.NewGeneratorForService(t, "sagemaker", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/sns_test.go
+++ b/pkg/generate/sns_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestSNS_Topic(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sns")
+	g := testutil.NewGeneratorForService(t, "sns", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/generate/sqs_test.go
+++ b/pkg/generate/sqs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
@@ -26,7 +27,7 @@ func TestSQS_Queue(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	g := testutil.NewGeneratorForService(t, "sqs")
+	g := testutil.NewGeneratorForService(t, "sqs", ackgenconfig.DefaultConfig)
 
 	crds, err := g.GetCRDs()
 	require.Nil(err)

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -14,17 +14,17 @@
 package testutil
 
 import (
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate"
-	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
-func NewGeneratorForService(t *testing.T, serviceAlias string) *generate.Generator {
+func NewGeneratorForService(t *testing.T, serviceAlias string, config ackgenconfig.Config) *generate.Generator {
 	path, _ := filepath.Abs("testdata")
 	// We have subdirectories in pkg/generate that rely on the testdata in
 	// pkg/generate. This code simply detects if we're running from one of
@@ -47,7 +47,7 @@ func NewGeneratorForService(t *testing.T, serviceAlias string) *generate.Generat
 	if _, err := os.Stat(generatorConfigPath); os.IsNotExist(err) {
 		generatorConfigPath = ""
 	}
-	g, err := generate.New(sdkAPI, "v1alpha1", generatorConfigPath, ackgenerate.DefaultConfig)
+	g, err := generate.New(sdkAPI, "v1alpha1", generatorConfigPath, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -95,7 +95,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 {{- end }}
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
-	if err := e.lateInitialize(&cr.Spec.ForProvider, resp); err != nil {
+	if err := e.lateInitialize(cr, resp); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	Generate{{ .CRD.Names.Camel }}(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
@@ -183,7 +183,7 @@ func newExternal(kube client.Client, client svcsdkapi.{{ .SDKAPIInterfaceTypeNam
 		{{- if .CRD.Ops.ReadOne }}
 		preObserve:     nopPreObserve,
 		postObserve:    nopPostObserve,
-		lateInitialize: nopLateInitialize,
+		lateInitialize: lateInitialize,
 		isUpToDate:     alwaysUpToDate,
 		{{- else if .CRD.Ops.GetAttributes }}
 		preObserve:     nopPreObserve,
@@ -226,18 +226,18 @@ type external struct {
 	{{- if .CRD.Ops.ReadOne }}
 	preObserve  func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}) error
 	postObserve func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}, managed.ExternalObservation, error) (managed.ExternalObservation, error)
-	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) error
+	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) error
 	isUpToDate     func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) (bool, error)
 	{{- else if .CRD.Ops.GetAttributes }}
 	preObserve  func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.GetAttributes.InputRef.Shape.ShapeName }}) error
 	postObserve func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}, managed.ExternalObservation, error) (managed.ExternalObservation, error)
-	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) error
+	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) error
 	isUpToDate     func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) (bool, error)
 	{{- else if .CRD.Ops.ReadMany }}
 	preObserve  func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.InputRef.Shape.ShapeName }}) error
 	postObserve func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}
-	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) error
+	lateInitialize func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) error
 	isUpToDate     func(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) (bool, error)
 	{{- else }}
 	observe     func(context.Context, cpresource.Managed) (managed.ExternalObservation, error)
@@ -266,9 +266,7 @@ func nopPreObserve(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk
 func nopPostObserve(_ context.Context, _ *svcapitypes.{{ .CRD.Names.Camel }}, _ *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	return obs, err
 }
-func nopLateInitialize(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) error {
-	return nil
-}
+
 func alwaysUpToDate(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }})  (bool, error) {
 	return true, nil
 }
@@ -280,9 +278,7 @@ func nopPreObserve(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk
 func nopPostObserve(_ context.Context, _ *svcapitypes.{{ .CRD.Names.Camel }}, _ *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	return obs, err
 }
-func nopLateInitialize(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) error {
-	return nil
-}
+
 func alwaysUpToDate(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) (bool, error) {
 	return true, nil
 }
@@ -297,9 +293,6 @@ func nopFilterList(_ *svcapitypes.{{ .CRD.Names.Camel }}, list *svcsdk.{{ .CRD.O
 	return list
 }
 
-func nopLateInitialize(*svcapitypes.{{ .CRD.Names.Camel }}Parameters, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) error {
-	return nil
-}
 func alwaysUpToDate(*svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) (bool, error) {
 	return true, nil
 }

--- a/templates/crossplane/pkg/conversions.go.tpl
+++ b/templates/crossplane/pkg/conversions.go.tpl
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
 
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
 	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceIDClean }}/{{ .APIVersion}}"
 	awsclients "github.com/crossplane/provider-aws/pkg/clients"
 )

--- a/templates/crossplane/pkg/conversions.go.tpl
+++ b/templates/crossplane/pkg/conversions.go.tpl
@@ -14,6 +14,7 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
 
 	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceIDClean }}/{{ .APIVersion}}"
+	awsclients "github.com/crossplane/provider-aws/pkg/clients"
 )
 
 // NOTE(muvaf): We return pointers in case the function needs to start with an

--- a/templates/crossplane/pkg/sdk_find_get_attributes.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_get_attributes.go.tpl
@@ -14,9 +14,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.GetAttributes.Outpu
 return cr
 }
 
-func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) error {
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) (bool, error) {
+	li := resource.NewLateInitializer()
 {{ GoCodeLateInitializeGetAttributes .CRD  "resp" "cr" 1 false }}
-	return nil
+	return li.IsChanged(), nil
 }
 
 {{- end -}}

--- a/templates/crossplane/pkg/sdk_find_get_attributes.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_get_attributes.go.tpl
@@ -13,4 +13,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.GetAttributes.Outpu
 {{ GoCodeGetAttributesSetOutput .CRD "resp" "cr" 1 }}
 return cr
 }
+
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.GetAttributes.OutputRef.Shape.ShapeName }}) error {
+{{ GoCodeLateInitializeGetAttributes .CRD  "resp" "cr" 1 false }}
+	return nil
+}
+
 {{- end -}}

--- a/templates/crossplane/pkg/sdk_find_read_many.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_read_many.go.tpl
@@ -13,4 +13,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.
 {{ GoCodeSetReadManyOutput .CRD "resp" "cr" 1 false }}
 return cr
 }
+
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) error {
+{{ GoCodeLateInitializeReadMany .CRD  "resp" "cr" 1 false }}
+	return nil
+}
+
 {{- end -}}

--- a/templates/crossplane/pkg/sdk_find_read_many.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_read_many.go.tpl
@@ -14,9 +14,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.
 return cr
 }
 
-func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) error {
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadMany.OutputRef.Shape.ShapeName }}) (bool, error) {
+	li := resource.NewLateInitializer()
 {{ GoCodeLateInitializeReadMany .CRD  "resp" "cr" 1 false }}
-	return nil
+	return li.IsChanged(), nil
 }
 
 {{- end -}}

--- a/templates/crossplane/pkg/sdk_find_read_one.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_read_one.go.tpl
@@ -13,4 +13,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.S
 {{ GoCodeSetReadOneOutput .CRD "resp" "cr" 1 false }}
 return cr
 }
+
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) error {
+{{ GoCodeLateInitializeReadOne .CRD "resp" "cr" 1 false }}
+	return nil
+}
+
 {{- end -}}

--- a/templates/crossplane/pkg/sdk_find_read_one.go.tpl
+++ b/templates/crossplane/pkg/sdk_find_read_one.go.tpl
@@ -14,9 +14,10 @@ func Generate{{ .CRD.Names.Camel }}(resp *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.S
 return cr
 }
 
-func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) error {
+func lateInitialize(cr *svcapitypes.{{ .CRD.Names.Camel }}, resp *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}) (bool, error) {
+	li := resource.NewLateInitializer()
 {{ GoCodeLateInitializeReadOne .CRD "resp" "cr" 1 false }}
-	return nil
+	return li.IsChanged(), nil
 }
 
 {{- end -}}


### PR DESCRIPTION
Description of changes: Crossplane uses late initialization functions to fill up the empty fields in spec with the current state in the AWS API, defaults most of the time. This PR introduces code generator to generate that late initialization function.

Fixes https://github.com/crossplane/provider-aws/issues/491

An example output looks like the following:
```go
func lateInitialize(cr *svcapitypes.Route, resp *svcsdk.GetRouteOutput) (bool, error) {
	li := resource.NewLateInitializer()
	cr.Spec.ForProvider.APIKeyRequired = li.LateInitializeBoolPtr(cr.Spec.ForProvider.APIKeyRequired, resp.ApiKeyRequired)
	if len(resp.AuthorizationScopes) != 0 && len(cr.Spec.ForProvider.AuthorizationScopes) == 0 {
		cr.Spec.ForProvider.AuthorizationScopes = make([]*string, len(resp.AuthorizationScopes))
		for i0 := range resp.AuthorizationScopes {
			cr.Spec.ForProvider.AuthorizationScopes[i0] = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizationScopes[i0], resp.AuthorizationScopes[i0])
		}
	}
	cr.Spec.ForProvider.AuthorizationType = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizationType, resp.AuthorizationType)
	cr.Spec.ForProvider.AuthorizerID = li.LateInitializeStringPtr(cr.Spec.ForProvider.AuthorizerID, resp.AuthorizerId)
	cr.Spec.ForProvider.ModelSelectionExpression = li.LateInitializeStringPtr(cr.Spec.ForProvider.ModelSelectionExpression, resp.ModelSelectionExpression)
	cr.Spec.ForProvider.OperationName = li.LateInitializeStringPtr(cr.Spec.ForProvider.OperationName, resp.OperationName)
	if resp.RequestModels != nil {
		if cr.Spec.ForProvider.RequestModels == nil {
			cr.Spec.ForProvider.RequestModels = map[string]*string{}
		}
		for key0 := range resp.RequestModels {
			cr.Spec.ForProvider.RequestModels[key0] = li.LateInitializeStringPtr(cr.Spec.ForProvider.RequestModels[key0], resp.RequestModels[key0])
		}
	}
	if resp.RequestParameters != nil {
		if cr.Spec.ForProvider.RequestParameters == nil {
			cr.Spec.ForProvider.RequestParameters = map[string]*svcapitypes.ParameterConstraints{}
		}
		for key0 := range resp.RequestParameters {
			if resp.RequestParameters[key0] != nil {
				if cr.Spec.ForProvider.RequestParameters[key0] == nil {
					cr.Spec.ForProvider.RequestParameters[key0] = &svcapitypes.ParameterConstraints{}
				}
				cr.Spec.ForProvider.RequestParameters[key0].Required = li.LateInitializeBoolPtr(cr.Spec.ForProvider.RequestParameters[key0].Required, resp.RequestParameters[key0].Required)
			}
		}
	}
	cr.Spec.ForProvider.RouteKey = li.LateInitializeStringPtr(cr.Spec.ForProvider.RouteKey, resp.RouteKey)
	cr.Spec.ForProvider.RouteResponseSelectionExpression = li.LateInitializeStringPtr(cr.Spec.ForProvider.RouteResponseSelectionExpression, resp.RouteResponseSelectionExpression)
	cr.Spec.ForProvider.Target = li.LateInitializeStringPtr(cr.Spec.ForProvider.Target, resp.Target)
	return li.IsChanged(), nil
}
```

It's been tested with `ReadOne`, `ReadMany` and `GetAttributes` outputs.

@jaypipes I wanted to get your take on this approach ~~before writing unit tests~~ (unit tests are written now). I started by copying `SetResource` functions but couldn't really make it work for this scenario so I wrote it from scratch. Though the end result is similar anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
