### PR TITLE
fix for ack-generate: command not found

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -53,7 +53,7 @@ Environment variables:
                             instruct the code generator for the service.
                             Default: services/{SERVICE}/generator.yaml
   AWS_SDK_GO_VERSION:       Overrides the version of github.com/aws/aws-sdk-go used
-                            by `ack-generate` to fetch the service API Specifications.
+                            by 'ack-generate' to fetch the service API Specifications.
   TEMPLATES_DIR:            Overrides the directory containg ack-generate templates
                             Default: $TEMPLATES_DIR
   K8S_RBAC_ROLE_NAME:       Name of the Kubernetes Role to use when generating


### PR DESCRIPTION
Issue #, if available:

Running `make build-controller SERVICE=$SERVICE` fails with error:

```
./scripts/build-controller.sh: line 63: ack-generate: command not found
make: *** [build-controller] Error 127
```

Description of changes:
The issue was because of `ack-generate` inside usage text. This pull request updates it to 'ack-generate' to fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
