### PR TITLE
crossplane: referencer and selector fields generation

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -136,6 +136,10 @@ type FieldConfig struct {
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
 	IsOwnerAccountID bool `json:"is_owner_account_id"`
+	// ReferencedType is the Group Version Kind of another CRD that can be referenced
+	// to get the value of this field. The format is <group>/<version>.<kind>.
+	// For example: "sns/v1alpha1.Topic"
+	ReferencedType *string `json:"referenced_type,omitempty"`
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -88,6 +88,7 @@ var (
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},
+		"Contains": strings.Contains,
 	}
 )
 

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -46,6 +46,15 @@ func (f *Field) IsRequired() bool {
 	return util.InStrings(f.Names.ModelOrginal, f.CRD.Ops.Create.InputRef.Shape.Required)
 }
 
+// ReferencedType returns the given type information for the referencer of this
+// field.
+func (f *Field) ReferencedType() *string {
+	if f.FieldConfig == nil {
+		return nil
+	}
+	return f.FieldConfig.ReferencedType
+}
+
 // newField returns a pointer to a new Field object
 func newField(
 	crd *CRD,


### PR DESCRIPTION
This PR is migrated from https://github.com/aws/aws-controllers-k8s/pull/643

Description of changes: Crossplane uses two additional fields for the ones that can be referenced by another CRD - `Reference` and `Selector`. This PR allows users to enter the type of the referenced object so that we automatically generate these fields. The type information is necessary for the resolver but since we're not yet generating it, only the existence of a value in `referenced_type` is used. When we generate the resolver code, we'll need type information as well.

One caveat is that any field on the CR (including the ones in `types.go`) could be a candidate as a reference field but from what I can tell, we are only able to address the top level fields in `Config` object. For now, that will be a limitation we'll live with.

Fixes https://github.com/crossplane/provider-aws/issues/484

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
