### PR TITLE
Update go templates to use runtime/pkg and runtime/apis as per split repo

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -9,7 +9,7 @@ import (
 {{ end }}
 
 {{- end }}
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
-	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
+	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -69,6 +69,7 @@ func main() {
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup,
+		ackrt.VersionInfo{},	// TODO: populate version info
 	).WithLogger(
 		ctrlrt.Log,
 	).WithResourceManagerFactories(

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -3,8 +3,8 @@
 package {{ .CRD.Names.Snake }}
 
 import (
-	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
-	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/templates/pkg/resource/identifiers.go.tpl
+++ b/templates/pkg/resource/identifiers.go.tpl
@@ -3,7 +3,7 @@
 package {{ .CRD.Names.Snake }}
 
 import (
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 )
 
 // resourceIdentifiers implements the

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -5,14 +5,14 @@ package {{ .CRD.Names.Snake }}
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
-	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
-	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
-	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
-	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"sync"
 
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
-	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
-	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
-	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 

--- a/templates/pkg/resource/registry.go.tpl
+++ b/templates/pkg/resource/registry.go.tpl
@@ -3,8 +3,8 @@
 package resource
 
 import (
-	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
-	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 var (

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -3,8 +3,8 @@
 package {{ .CRD.Names.Snake }}
 
 import (
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
-	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -6,9 +6,9 @@ import (
 	"context"
 	"strings"
 
-	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
-	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
-	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Issue #, if available:

1. Need to update go files import paths to new repo path:
`make build-controller SERVICE=$SERVICE` generates service controller go code files that refer to old repo paths:
* `github.com/aws/aws-controllers-k8s/pkg`
* `github.com/aws/aws-controllers-k8s/apis`

This lead to failure in compilation when `make test` is executed from service controller repo.

2. `main.go.tpl` needs to supply additional VersionInfo to `ackrt.NewServiceController()` method.

Description of changes:

Updated templates files for service controller go code to import paths for new split repos:
* `github.com/aws-controllers-k8s/runtime/pkg`
* `github.com/aws-controllers-k8s/runtime/apis`

After making these changes, tested the changes using:
```
cd $GOPATH/src/github.com/aws-controllers-k8s/code-generator
make build-ack-generate

export SERVICE="elasticache"
make build-controller SERVICE=$SERVICE

cd $GOPATH/src/github.com/aws-controllers-k8s/$SERVICE-controller
make test
```
and tests passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
