### PR TITLE
Adopted resource template changes

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -223,7 +223,7 @@ func SetSDK(
 			out += fmt.Sprintf(
 				"%s} else {\n", indent,
 			)
-			nameField := r.NameField()
+			nameField := *r.SpecIdentifierField()
 			out += fmt.Sprintf(
 				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
 				indent, targetVarName, memberName, sourceVarName, nameField,
@@ -444,7 +444,7 @@ func SetSDKGetAttributes(
 			out += fmt.Sprintf(
 				"%s} else {\n", indent,
 			)
-			nameField := r.NameField()
+			nameField := *r.SpecIdentifierField()
 			out += fmt.Sprintf(
 				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
 				indent, targetVarName, memberName, sourceVarName, nameField,
@@ -617,7 +617,7 @@ func SetSDKSetAttributes(
 			out += fmt.Sprintf(
 				"%s} else {\n", indent,
 			)
-			nameField := r.NameField()
+			nameField := *r.SpecIdentifierField()
 			out += fmt.Sprintf(
 				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
 				indent, targetVarName, memberName, sourceVarName, nameField,

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -69,6 +69,10 @@ type ResourceConfig struct {
 	// All ShortNames must be distinct from any other ShortNames installed into the cluster,
 	// otherwise the CRD will fail to install.
 	ShortNames []string `json:"shortNames,omitempty"`
+	// IsAdoptable determines whether the CRD should be accepted by the adoption reconciler.
+	// If set to false, the user will be given an error if they attempt to adopt a resource
+	// with this type.
+	IsAdoptable *bool `json:"is_adoptable,omitempty"`
 }
 
 // CompareConfig informs instruct the code generator on how to compare two different
@@ -348,4 +352,20 @@ func (c *Config) ResourceShortNames(resourceName string) []string {
 		return nil
 	}
 	return rConfig.ShortNames
+}
+
+// ResourceIsAdoptable returns whether the given CRD is adoptable
+func (c *Config) ResourceIsAdoptable(resourceName string) bool {
+	if c == nil {
+		return true
+	}
+	rConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return true
+	}
+	// Default to True
+	if rConfig.IsAdoptable == nil {
+		return true
+	}
+	return *rConfig.IsAdoptable
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -327,14 +327,14 @@ func (r *CRD) UpdateConditionsCustomMethodName() string {
 	return resGenConfig.UpdateConditionsCustomMethodName
 }
 
-// NameField returns the name of the "Name" or string identifier field in the Spec
-func (r *CRD) NameField() string {
+// SpecIdentifierField returns the name of the "Name" or string identifier field in the Spec
+func (r *CRD) SpecIdentifierField() *string {
 	if r.cfg != nil {
 		rConfig, found := r.cfg.Resources[r.Names.Original]
 		if found {
 			for fName, fConfig := range rConfig.Fields {
 				if fConfig.IsName {
-					return fName
+					return &fName
 				}
 			}
 		}
@@ -346,10 +346,19 @@ func (r *CRD) NameField() string {
 	}
 	for memberName := range r.SpecFields {
 		if util.InStrings(memberName, lookup) {
-			return memberName
+			return &memberName
 		}
 	}
-	return "???"
+	return nil
+}
+
+// IsAdoptable returns true if the resource can be adopted
+func (r *CRD) IsAdoptable() bool {
+	if r.cfg == nil {
+		// Should never reach this condition
+		return false
+	}
+	return r.cfg.ResourceIsAdoptable(r.Names.Original)
 }
 
 // CustomUpdateMethodName returns the name of the custom resourceManager method

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -27,6 +27,8 @@ ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
 AWS_SDK_GO_VERSION=${AWS_SDK_GO_VERSION:-""}
+DEFAULT_RUNTIME_CRD_DIR="$ROOT_DIR/../../aws-controllers-k8s/runtime/config"
+RUNTIME_CRD_DIR=${RUNTIME_CRD_DIR:-$DEFAULT_RUNTIME_CRD_DIR}
 
 USAGE="
 Usage:
@@ -117,6 +119,12 @@ TEMPLATE_DIRS=${TEMPLATE_DIRS:-$DEFAULT_TEMPLATE_DIRS}
 
 K8S_RBAC_ROLE_NAME=${K8S_RBAC_ROLE_NAME:-"ack-$SERVICE-controller"}
 
+config_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/config/"
+
+echo "Copying common custom resource definitions into $SERVICE"
+mkdir -p $config_output_dir/crd/common
+cp -r $RUNTIME_CRD_DIR/crd/* $config_output_dir/crd/common/
+
 # If there's a generator.yaml in the service's directory and the caller hasn't
 # specified an override, use that.
 if [ -z "$ACK_GENERATE_CONFIG_PATH" ]; then
@@ -150,8 +158,6 @@ $ACK_GENERATE_BIN_PATH $apis_args
 if [ $? -ne 0 ]; then
     exit 2
 fi
-
-config_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/config/"
 
 pushd $SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION 1>/dev/null
 

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -13,6 +13,7 @@ import (
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	ctrlrtmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcresource "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/resource"
 	svctypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
 
@@ -30,6 +31,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = svctypes.AddToScheme(scheme)
+	_ = ackv1alpha1.AddToScheme(scheme)
 }
 
 func main() {

--- a/templates/config/crd/kustomization.yaml.tpl
+++ b/templates/config/crd/kustomization.yaml.tpl
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+  - common
 resources:
 {{- range .CRDNames }}
   - bases/{{ $.APIGroup }}_{{ . }}.yaml 

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -3,6 +3,7 @@
 package {{ .CRD.Names.Snake }}
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,3 +130,21 @@ func (d *resourceDescriptor) MarkUnmanaged(
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
 }
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
+} 

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -22,8 +22,6 @@ import (
 
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }}/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -37,9 +35,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -160,7 +158,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -36,7 +36,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -59,6 +59,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return {{ .CRD.IsAdoptable }}
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/templates/pkg/resource/registry.go.tpl
+++ b/templates/pkg/resource/registry.go.tpl
@@ -7,6 +7,11 @@ import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+
 var (
 	reg = ackrt.NewRegistry()
 )

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -5,6 +5,7 @@ package {{ .CRD.Names.Snake }}
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
@@ -53,4 +54,23 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 // Conditions returns the ACK Conditions collection for the AWSResource
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
+}
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta;
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+{{- if $idField := .CRD.SpecIdentifierField }}
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.{{ $idField }} = identifier.NameOrID
+{{- else }}
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
+{{- end }}
+	return nil
 }


### PR DESCRIPTION
Issue #, if available: 

Description of changes:
- Store `NameField` as part of each CRD - for use in templates
- Add the API scheme to each controller
- Provide each controller with permissions to access the `AdoptedResource` CRD
- Provide method to override resource object meta

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
