### PR TITLE
fix ack-generate release

### DIFF
--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -80,12 +80,8 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
-	latestAPIVersion, err = getLatestAPIVersion()
-	if err != nil {
-		return err
-	}
 	g, err := generate.New(
-		sdkAPI, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
+		sdkAPI, "", optGeneratorConfigPath, ackgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
When running `./test/release/test-helm.sh` from the community
repository, I was getting errors like this:

```
[jaypipes@thelio community]$ ./test/release/test-helm.sh s3 v0.0.2-37-g6c6957d-dirty
testing Helm release for s3 for release version v0.0.2-37-g6c6957d-dirty.
Building release artifacts for s3-v0.0.2-37-g6c6957d-dirty
Error: open apis: no such file or directory
```

The above was due to the `ack-generate release` command calling the
`getLatestAPIVersion()` function which in turn attempted to read the
(old, pre-split-repo) `services/$SERVICE/apis/` directory. We don't
actually need the latest API version when generating release artifacts
for a controller, but the `pkg/generate.New()` function requires an
APIVersion argument, so I'm just passing an empty string here, which
solves the above problem and allows the helm test to complete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
