### PR TITLE
SecretKeyRef - CodeGen changes

### DIFF
--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -896,7 +896,13 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 	expected := `
 	res.SetApplyImmediately(true)
 	if r.ko.Spec.AuthToken != nil {
-		res.SetAuthToken(*r.ko.Spec.AuthToken)
+		tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.AuthToken)
+		if err != nil {
+			return nil, err
+		}
+		if tmpSecret != "" {
+			res.SetAuthToken(tmpSecret)
+		}
 	}
 	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -136,6 +136,9 @@ type FieldConfig struct {
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
 	IsOwnerAccountID bool `json:"is_owner_account_id"`
+	// IsSecret instructs the code generator that this field should be a
+	// SecretKeyReference.
+	IsSecret bool `json:"is_secret"`
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -262,3 +262,20 @@ func TestElasticache_Additional_ReplicationGroup_Status_RenameField(t *testing.T
 	assert.Contains(crd.StatusFields, "AllowedScaleUpModifications")
 	assert.Contains(crd.StatusFields, "AllowedScaleDownModifications")
 }
+
+func TestElasticache_ValidateAuthTokenIsSecret(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+	crds, err := g.GetCRDs()
+
+	require.Nil(err)
+
+	crd := getCRDByName("ReplicationGroup", crds)
+	require.NotNil(crd)
+
+	assert := assert.New(t)
+	assert.Equal("*ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoType)
+	assert.Equal("ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoTypeElem)
+	assert.Equal("*ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoTypeWithPkgName)
+}

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -58,6 +58,8 @@ resources:
         from:
           operation: DescribeEvents
           path: Events
+      AuthToken:
+        is_secret: true
 operations:
   ModifyReplicationGroup:
     override_values:

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -14,11 +14,10 @@
 package model
 
 import (
-	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
-
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/names"
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
 // Field represents a single field in the CRD's Spec or Status objects
@@ -58,7 +57,12 @@ func newField(
 	if shapeRef != nil {
 		shape = shapeRef.Shape
 	}
-	if shape != nil {
+
+	if cfg != nil && cfg.IsSecret {
+		gt = "*ackv1alpha1.SecretKeyReference"
+		gte = "ackv1alpha1.SecretKeyReference"
+		gtwp = "*ackv1alpha1.SecretKeyReference"
+	} else if shape != nil {
 		gte, gt, gtwp = cleanGoType(crd.sdkAPI, crd.cfg, shape)
 	} else {
 		gte = "string"

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -52,7 +52,7 @@ func (rm *resourceManager) sdkCreate(
 		return customResp, customRespErr
 	}
 {{- end }}
-	input, err := rm.newCreateRequestPayload(r)
+	input, err := rm.newCreateRequestPayload(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,8 @@ func (rm *resourceManager) sdkCreate(
 // newCreateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Create API call for the resource
 func (rm *resourceManager) newCreateRequestPayload(
-	r *resource,
+    ctx context.Context,
+    r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}{}
 {{ GoCodeSetCreateInput .CRD "r.ko" "res" 1 }}

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -13,7 +13,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 {{ end }}
 
-	input, err := rm.newUpdateRequestPayload(desired)
+	input, err := rm.newUpdateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,8 @@ func (rm *resourceManager) sdkUpdate(
 // newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Update API call for the resource
 func (rm *resourceManager) newUpdateRequestPayload(
-	r *resource,
+    ctx context.Context,
+    r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}{}
 {{ GoCodeSetUpdateInput .CRD "r.ko" "res" 1 }}


### PR DESCRIPTION
- Introduced a new field config for secrets.
- This will turn a given field into SecretKeyRef.
- Initial approach to solve ElastiCache
    AuthToken usecase.

Other PR -
Runtime changes -
ElastiCache generated code - 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
