### PR TITLE
add custom methods for sdkFind readOne and sdkDelete

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -105,6 +105,13 @@ func (rm *resourceManager) sdkDelete(
 	r *resource,
 ) error {
 {{- if .CRD.Ops.Delete }}
+{{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Delete }}
+{{ if $customMethod }}
+	customRespErr := rm.{{ $customMethod }}(ctx, r)
+	if customRespErr != nil {
+		return customRespErr
+	}
+{{ end }}
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return err

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -29,6 +29,13 @@ func (rm *resourceManager) sdkFind(
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
 	rm.setStatusDefaults(ko)
+{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.ReadOne }}
+	// custom set output from response
+	ko, err = rm.{{ $setOutputCustomMethodName }}(ctx, r, resp, ko)
+	if err != nil {
+		return nil, err
+	}
+{{ end }}
 	return &resource{ko}, nil
 }
 


### PR DESCRIPTION
### Description of changes:
- sdkFind readOne: Allows adding/setting custom output. Similar to [sdkFind readMany](https://github.com/aws-controllers-k8s/code-generator/blob/main/templates/pkg/resource/sdk_find_read_many.go.tpl#L25-L31)
- sdkDelete: Introduce adding custom implementation for delete operation

### Testing
Using SageMaker Controller
TBD - link related PRs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
