### PR TITLE
crossplane: use nopFilterList as default filterList implementation

### DIFF
--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -188,6 +188,9 @@ func newExternal(kube client.Client, client svcsdkapi.{{ .SDKAPIInterfaceTypeNam
 		{{- else }}
 		observe:        nopObserve,
 		{{- end }}
+		{{- if .CRD.Ops.ReadMany }}
+		filterList:     nopFilterList,
+		{{- end}}
 		preCreate:      nopPreCreate,
 		postCreate:     nopPostCreate,
 		{{- if .CRD.Ops.Delete }}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/697

Description of changes: Apparently, I forgot to use the `nopFilterList` function as default, which in turn causes https://github.com/aws-controllers-k8s/community/issues/697 to happen.

Fixes https://github.com/aws-controllers-k8s/community/issues/697

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
