### PR TITLE
crossplane: fix controller template for resources that might have both ReadOne and ReadMany

### DIFF
--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -188,7 +188,7 @@ func newExternal(kube client.Client, client svcsdkapi.{{ .SDKAPIInterfaceTypeNam
 		{{- else }}
 		observe:        nopObserve,
 		{{- end }}
-		{{- if .CRD.Ops.ReadMany }}
+		{{- if and .CRD.Ops.ReadMany (not .CRD.Ops.ReadOne) }}
 		filterList:     nopFilterList,
 		{{- end}}
 		preCreate:      nopPreCreate,


### PR DESCRIPTION
Description of changes: There are cases like `Lambda Function` where there are both ReadMany and ReadOne operations available. The first choice is always ReadOne, so we need to take that into account here as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
