### PR TITLE
add support for generic callback hooks

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -122,6 +122,17 @@ func Controller(
 		return nil, err
 	}
 
+	// Hook code can reference a template path, and we can look up the template
+	// in any of our base paths...
+	controllerFuncMap["Hook"] = func(r *ackmodel.CRD, hookID string) string {
+		code, err := ResourceHookCode(templateBasePaths, r, hookID)
+		if err != nil {
+			// It's a compile-time error, so just panic...
+			panic(err)
+		}
+		return code
+	}
+
 	ts := templateset.New(
 		templateBasePaths,
 		controllerIncludePaths,

--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -1,0 +1,145 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ack
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	ttpl "text/template"
+
+	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
+	ackutil "github.com/aws-controllers-k8s/code-generator/pkg/util"
+)
+
+/*
+The following hook points are supported in the ACK controller resource manager
+code paths:
+
+* sdk_read_one_pre_build_request
+* sdk_read_many_pre_build_request
+* sdk_get_attributes_pre_build_request
+* sdk_create_pre_build_request
+* sdk_update_pre_build_request
+* sdk_delete_pre_build_request
+* sdk_read_one_post_request
+* sdk_read_many_post_request
+* sdk_get_attributes_post_request
+* sdk_create_post_request
+* sdk_update_post_request
+* sdk_delete_post_request
+* sdk_read_one_pre_set_output
+* sdk_read_many_pre_set_output
+* sdk_get_attributes_pre_set_output
+* sdk_create_pre_set_output
+* sdk_update_pre_set_output
+
+The "pre_build_request" hooks are called BEFORE the call to construct
+the Input shape that is used in the API operation and therefore BEFORE
+any call to validate that Input shape.
+
+The "post_request" hooks are called IMMEDIATELY AFTER the API operation
+aws-sdk-go client call.  These hooks will have access to a Go variable
+named `resp` that refers to the aws-sdk-go client response and a Go
+variable named `respErr` that refers to any error returned from the
+aws-sdk-go client call.
+
+The "pre_set_output" hooks are called BEFORE the code that processes the
+Outputshape (the pkg/generate/code.SetOutput function). These hooks will
+have access to a Go variable named `ko` that represents the concrete
+Kubernetes CR object that will be returned from the main method
+(sdkFind, sdkCreate, etc). This `ko` variable will have been defined
+immediately before the "pre_set_output" hooks as a copy of the resource
+that is supplied to the main method, like so:
+
+```go
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := r.ko.DeepCopy()
+```
+*/
+
+// ResourceHookCode returns a string with custom callback code for a resource
+// and hook identifier
+func ResourceHookCode(
+	templateBasePaths []string,
+	r *ackmodel.CRD,
+	hookID string,
+) (string, error) {
+	resourceName := r.Names.Original
+	if resourceName == "" || hookID == "" {
+		return "", nil
+	}
+	c := r.Config()
+	if c == nil {
+		return "", nil
+	}
+	rConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return "", nil
+	}
+	hook, ok := rConfig.Hooks[hookID]
+	if !ok {
+		return "", nil
+	}
+	if hook.Code != nil {
+		return *hook.Code, nil
+	}
+	if hook.TemplatePath == nil {
+		err := fmt.Errorf(
+			"resource %s hook config for %s is invalid. Need either code or template_path",
+			resourceName, hookID,
+		)
+		return "", err
+	}
+	for _, basePath := range templateBasePaths {
+		tplPath := filepath.Join(basePath, *hook.TemplatePath)
+		if !ackutil.FileExists(tplPath) {
+			continue
+		}
+		tplContents, err := ioutil.ReadFile(tplPath)
+		if err != nil {
+			err := fmt.Errorf(
+				"resource %s hook config for %s is invalid: error reading %s: %s",
+				resourceName, hookID, tplPath, err,
+			)
+			return "", err
+		}
+		t := ttpl.New(tplPath)
+		if t, err = t.Parse(string(tplContents)); err != nil {
+			err := fmt.Errorf(
+				"resource %s hook config for %s is invalid: error parsing %s: %s",
+				resourceName, hookID, tplPath, err,
+			)
+			return "", err
+		}
+		var b bytes.Buffer
+		// TODO(jaypipes): Instead of nil for template vars here, maybe pass in
+		// a struct of variables?
+		if err := t.Execute(&b, nil); err != nil {
+			err := fmt.Errorf(
+				"resource %s hook config for %s is invalid: error executing %s: %s",
+				resourceName, hookID, tplPath, err,
+			)
+			return "", err
+		}
+		return b.String(), nil
+	}
+	err := fmt.Errorf(
+		"resource %s hook config for %s is invalid: template_path %s not found",
+		resourceName, hookID, *hook.TemplatePath,
+	)
+	return "", err
+}

--- a/pkg/generate/ack/hook_test.go
+++ b/pkg/generate/ack/hook_test.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ack_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestResourceHookCodeInline(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	basePaths := []string{}
+	hookID := "sdk_update_pre_build_request"
+
+	g := testutil.NewGeneratorForService(t, "mq")
+
+	crd := testutil.GetCRDByName(t, g, "Broker")
+	require.NotNil(crd)
+
+	// The Broker's update operation has a special hook callback configured
+	expected := `if err := rm.requeueIfNotRunning(latest); err != nil { return nil, err }`
+	got, err := ack.ResourceHookCode(basePaths, crd, hookID)
+	assert.Nil(err)
+	assert.Equal(expected, got)
+}
+
+func TestResourceHookCodeTemplatePath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	wd, _ := os.Getwd()
+	basePaths := []string{
+		filepath.Join(wd, "testdata", "templates"),
+	}
+	hookID := "sdk_delete_pre_build_request"
+
+	g := testutil.NewGeneratorForService(t, "mq")
+
+	crd := testutil.GetCRDByName(t, g, "Broker")
+	require.NotNil(crd)
+
+	// The Broker's delete operation has a special hook configured to point to a template.
+	expected := "// this is my template.\n"
+	got, err := ack.ResourceHookCode(basePaths, crd, hookID)
+	assert.Nil(err)
+	assert.Equal(expected, got)
+}

--- a/pkg/generate/ack/testdata/templates/sdk_delete_pre_build_request.go.tpl
+++ b/pkg/generate/ack/testdata/templates/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,1 @@
+// this is my template.

--- a/pkg/generate/templateset/templateset.go
+++ b/pkg/generate/templateset/templateset.go
@@ -22,6 +22,8 @@ import (
 	ttpl "text/template"
 
 	"github.com/pkg/errors"
+
+	ackutil "github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
 var (
@@ -83,7 +85,7 @@ func (ts *TemplateSet) Add(
 	var foundPath string
 	for _, basePath := range ts.baseSearchPaths {
 		path := filepath.Join(basePath, templatePath)
-		if fileExists(path) {
+		if ackutil.FileExists(path) {
 			foundPath = path
 			break
 		}
@@ -116,7 +118,7 @@ func (ts *TemplateSet) joinIncludes(t *ttpl.Template) error {
 	for _, basePath := range ts.baseSearchPaths {
 		for _, includePath := range ts.includePaths {
 			tplPath := filepath.Join(basePath, includePath)
-			if !fileExists(tplPath) {
+			if !ackutil.FileExists(tplPath) {
 				continue
 			}
 			if t, err = includeTemplate(t, tplPath); err != nil {
@@ -142,7 +144,7 @@ func (ts *TemplateSet) Execute() error {
 	for _, basePath := range ts.baseSearchPaths {
 		for _, path := range ts.copyPaths {
 			copyPath := filepath.Join(basePath, path)
-			if !fileExists(copyPath) {
+			if !ackutil.FileExists(copyPath) {
 				continue
 			}
 			b, err := byteBufferFromFile(copyPath)
@@ -193,10 +195,4 @@ func includeTemplate(t *ttpl.Template, tplPath string) (*ttpl.Template, error) {
 		return nil, err
 	}
 	return t, nil
-}
-
-// fileExists returns tTrue if the supplied file path exists, false otherwise
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return !os.IsNotExist(err)
 }

--- a/pkg/generate/testdata/models/apis/mq/0000-00-00/api-2.json
+++ b/pkg/generate/testdata/models/apis/mq/0000-00-00/api-2.json
@@ -1,0 +1,2779 @@
+{
+  "metadata" : {
+    "apiVersion" : "2017-11-27",
+    "endpointPrefix" : "mq",
+    "signingName" : "mq",
+    "serviceFullName" : "AmazonMQ",
+    "serviceId" : "mq",
+    "protocol" : "rest-json",
+    "jsonVersion" : "1.1",
+    "uid" : "mq-2017-11-27",
+    "signatureVersion" : "v4"
+  },
+  "operations" : {
+    "CreateBroker" : {
+      "name" : "CreateBroker",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/brokers",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "CreateBrokerRequest"
+      },
+      "output" : {
+        "shape" : "CreateBrokerResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "UnauthorizedException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "CreateConfiguration" : {
+      "name" : "CreateConfiguration",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/configurations",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "CreateConfigurationRequest"
+      },
+      "output" : {
+        "shape" : "CreateConfigurationResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "CreateTags" : {
+      "name" : "CreateTags",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/tags/{resource-arn}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "CreateTagsRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "CreateUser" : {
+      "name" : "CreateUser",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/brokers/{broker-id}/users/{username}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "CreateUserRequest"
+      },
+      "output" : {
+        "shape" : "CreateUserResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DeleteBroker" : {
+      "name" : "DeleteBroker",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v1/brokers/{broker-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DeleteBrokerRequest"
+      },
+      "output" : {
+        "shape" : "DeleteBrokerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DeleteTags" : {
+      "name" : "DeleteTags",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v1/tags/{resource-arn}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteTagsRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DeleteUser" : {
+      "name" : "DeleteUser",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v1/brokers/{broker-id}/users/{username}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DeleteUserRequest"
+      },
+      "output" : {
+        "shape" : "DeleteUserResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeBroker" : {
+      "name" : "DescribeBroker",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/brokers/{broker-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeBrokerRequest"
+      },
+      "output" : {
+        "shape" : "DescribeBrokerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeBrokerEngineTypes" : {
+      "name" : "DescribeBrokerEngineTypes",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/broker-engine-types",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeBrokerEngineTypesRequest"
+      },
+      "output" : {
+        "shape" : "DescribeBrokerEngineTypesResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeBrokerInstanceOptions" : {
+      "name" : "DescribeBrokerInstanceOptions",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/broker-instance-options",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeBrokerInstanceOptionsRequest"
+      },
+      "output" : {
+        "shape" : "DescribeBrokerInstanceOptionsResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeConfiguration" : {
+      "name" : "DescribeConfiguration",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/configurations/{configuration-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeConfigurationRequest"
+      },
+      "output" : {
+        "shape" : "DescribeConfigurationResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeConfigurationRevision" : {
+      "name" : "DescribeConfigurationRevision",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/configurations/{configuration-id}/revisions/{configuration-revision}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeConfigurationRevisionRequest"
+      },
+      "output" : {
+        "shape" : "DescribeConfigurationRevisionResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "DescribeUser" : {
+      "name" : "DescribeUser",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/brokers/{broker-id}/users/{username}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "DescribeUserRequest"
+      },
+      "output" : {
+        "shape" : "DescribeUserResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "ListBrokers" : {
+      "name" : "ListBrokers",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/brokers",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ListBrokersRequest"
+      },
+      "output" : {
+        "shape" : "ListBrokersResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "ListConfigurationRevisions" : {
+      "name" : "ListConfigurationRevisions",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/configurations/{configuration-id}/revisions",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ListConfigurationRevisionsRequest"
+      },
+      "output" : {
+        "shape" : "ListConfigurationRevisionsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "ListConfigurations" : {
+      "name" : "ListConfigurations",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/configurations",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ListConfigurationsRequest"
+      },
+      "output" : {
+        "shape" : "ListConfigurationsResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "ListTags" : {
+      "name" : "ListTags",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/tags/{resource-arn}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ListTagsRequest"
+      },
+      "output" : {
+        "shape" : "ListTagsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "ListUsers" : {
+      "name" : "ListUsers",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/brokers/{broker-id}/users",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ListUsersRequest"
+      },
+      "output" : {
+        "shape" : "ListUsersResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "RebootBroker" : {
+      "name" : "RebootBroker",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/brokers/{broker-id}/reboot",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "RebootBrokerRequest"
+      },
+      "output" : {
+        "shape" : "RebootBrokerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "UpdateBroker" : {
+      "name" : "UpdateBroker",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v1/brokers/{broker-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateBrokerRequest"
+      },
+      "output" : {
+        "shape" : "UpdateBrokerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "UpdateConfiguration" : {
+      "name" : "UpdateConfiguration",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v1/configurations/{configuration-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateConfigurationRequest"
+      },
+      "output" : {
+        "shape" : "UpdateConfigurationResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    },
+    "UpdateUser" : {
+      "name" : "UpdateUser",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v1/brokers/{broker-id}/users/{username}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateUserRequest"
+      },
+      "output" : {
+        "shape" : "UpdateUserResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "ForbiddenException"
+      } ]
+    }
+  },
+  "shapes" : {
+    "AuthenticationStrategy" : {
+      "type" : "string",
+      "enum" : [ "SIMPLE", "LDAP" ]
+    },
+    "AvailabilityZone" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        }
+      }
+    },
+    "BadRequestException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 400
+      }
+    },
+    "BrokerEngineType" : {
+      "type" : "structure",
+      "members" : {
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersions" : {
+          "shape" : "__listOfEngineVersion",
+          "locationName" : "engineVersions"
+        }
+      }
+    },
+    "BrokerEngineTypeOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerEngineTypes" : {
+          "shape" : "__listOfBrokerEngineType",
+          "locationName" : "brokerEngineTypes"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "BrokerInstance" : {
+      "type" : "structure",
+      "members" : {
+        "ConsoleURL" : {
+          "shape" : "__string",
+          "locationName" : "consoleURL"
+        },
+        "Endpoints" : {
+          "shape" : "__listOf__string",
+          "locationName" : "endpoints"
+        },
+        "IpAddress" : {
+          "shape" : "__string",
+          "locationName" : "ipAddress"
+        }
+      }
+    },
+    "BrokerInstanceOption" : {
+      "type" : "structure",
+      "members" : {
+        "AvailabilityZones" : {
+          "shape" : "__listOfAvailabilityZone",
+          "locationName" : "availabilityZones"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "StorageType" : {
+          "shape" : "BrokerStorageType",
+          "locationName" : "storageType"
+        },
+        "SupportedDeploymentModes" : {
+          "shape" : "__listOfDeploymentMode",
+          "locationName" : "supportedDeploymentModes"
+        },
+        "SupportedEngineVersions" : {
+          "shape" : "__listOf__string",
+          "locationName" : "supportedEngineVersions"
+        }
+      }
+    },
+    "BrokerInstanceOptionsOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerInstanceOptions" : {
+          "shape" : "__listOfBrokerInstanceOption",
+          "locationName" : "brokerInstanceOptions"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "BrokerState" : {
+      "type" : "string",
+      "enum" : [ "CREATION_IN_PROGRESS", "CREATION_FAILED", "DELETION_IN_PROGRESS", "RUNNING", "REBOOT_IN_PROGRESS" ]
+    },
+    "BrokerStorageType" : {
+      "type" : "string",
+      "enum" : [ "EBS", "EFS" ]
+    },
+    "BrokerSummary" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerArn" : {
+          "shape" : "__string",
+          "locationName" : "brokerArn"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "BrokerName" : {
+          "shape" : "__string",
+          "locationName" : "brokerName"
+        },
+        "BrokerState" : {
+          "shape" : "BrokerState",
+          "locationName" : "brokerState"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "DeploymentMode" : {
+          "shape" : "DeploymentMode",
+          "locationName" : "deploymentMode"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        }
+      }
+    },
+    "ChangeType" : {
+      "type" : "string",
+      "enum" : [ "CREATE", "UPDATE", "DELETE" ]
+    },
+    "Configuration" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "ConfigurationId" : {
+      "type" : "structure",
+      "members" : {
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "Revision" : {
+          "shape" : "__integer",
+          "locationName" : "revision"
+        }
+      }
+    },
+    "ConfigurationRevision" : {
+      "type" : "structure",
+      "members" : {
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        },
+        "Revision" : {
+          "shape" : "__integer",
+          "locationName" : "revision"
+        }
+      }
+    },
+    "Configurations" : {
+      "type" : "structure",
+      "members" : {
+        "Current" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "current"
+        },
+        "History" : {
+          "shape" : "__listOfConfigurationId",
+          "locationName" : "history"
+        },
+        "Pending" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "pending"
+        }
+      }
+    },
+    "ConflictException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 409
+      }
+    },
+    "CreateBrokerInput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerName" : {
+          "shape" : "__string",
+          "locationName" : "brokerName"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "CreatorRequestId" : {
+          "shape" : "__string",
+          "locationName" : "creatorRequestId",
+          "idempotencyToken" : true
+        },
+        "DeploymentMode" : {
+          "shape" : "DeploymentMode",
+          "locationName" : "deploymentMode"
+        },
+        "EncryptionOptions" : {
+          "shape" : "EncryptionOptions",
+          "locationName" : "encryptionOptions"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataInput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "MaintenanceWindowStartTime" : {
+          "shape" : "WeeklyStartTime",
+          "locationName" : "maintenanceWindowStartTime"
+        },
+        "PubliclyAccessible" : {
+          "shape" : "__boolean",
+          "locationName" : "publiclyAccessible"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        },
+        "StorageType" : {
+          "shape" : "BrokerStorageType",
+          "locationName" : "storageType"
+        },
+        "SubnetIds" : {
+          "shape" : "__listOf__string",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        },
+        "Users" : {
+          "shape" : "__listOfUser",
+          "locationName" : "users"
+        }
+      }
+    },
+    "CreateBrokerOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerArn" : {
+          "shape" : "__string",
+          "locationName" : "brokerArn"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        }
+      }
+    },
+    "CreateBrokerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerName" : {
+          "shape" : "__string",
+          "locationName" : "brokerName"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "CreatorRequestId" : {
+          "shape" : "__string",
+          "locationName" : "creatorRequestId",
+          "idempotencyToken" : true
+        },
+        "DeploymentMode" : {
+          "shape" : "DeploymentMode",
+          "locationName" : "deploymentMode"
+        },
+        "EncryptionOptions" : {
+          "shape" : "EncryptionOptions",
+          "locationName" : "encryptionOptions"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataInput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "MaintenanceWindowStartTime" : {
+          "shape" : "WeeklyStartTime",
+          "locationName" : "maintenanceWindowStartTime"
+        },
+        "PubliclyAccessible" : {
+          "shape" : "__boolean",
+          "locationName" : "publiclyAccessible"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        },
+        "StorageType" : {
+          "shape" : "BrokerStorageType",
+          "locationName" : "storageType"
+        },
+        "SubnetIds" : {
+          "shape" : "__listOf__string",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        },
+        "Users" : {
+          "shape" : "__listOfUser",
+          "locationName" : "users"
+        }
+      }
+    },
+    "CreateBrokerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerArn" : {
+          "shape" : "__string",
+          "locationName" : "brokerArn"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        }
+      }
+    },
+    "CreateConfigurationInput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "CreateConfigurationOutput" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        }
+      }
+    },
+    "CreateConfigurationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "CreateConfigurationResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        }
+      }
+    },
+    "CreateTagsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "ResourceArn" ]
+    },
+    "CreateUserInput" : {
+      "type" : "structure",
+      "members" : {
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Password" : {
+          "shape" : "__string",
+          "locationName" : "password"
+        }
+      }
+    },
+    "CreateUserRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Password" : {
+          "shape" : "__string",
+          "locationName" : "password"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "username"
+        }
+      },
+      "required" : [ "Username", "BrokerId" ]
+    },
+    "CreateUserResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "DayOfWeek" : {
+      "type" : "string",
+      "enum" : [ "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY" ]
+    },
+    "DeleteBrokerOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        }
+      }
+    },
+    "DeleteBrokerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        }
+      },
+      "required" : [ "BrokerId" ]
+    },
+    "DeleteBrokerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        }
+      }
+    },
+    "DeleteTagsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        },
+        "TagKeys" : {
+          "shape" : "__listOf__string",
+          "location" : "querystring",
+          "locationName" : "tagKeys"
+        }
+      },
+      "required" : [ "TagKeys", "ResourceArn" ]
+    },
+    "DeleteUserRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "username"
+        }
+      },
+      "required" : [ "Username", "BrokerId" ]
+    },
+    "DeleteUserResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "DeploymentMode" : {
+      "type" : "string",
+      "enum" : [ "SINGLE_INSTANCE", "ACTIVE_STANDBY_MULTI_AZ" ]
+    },
+    "DescribeBrokerEngineTypesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "EngineType" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "engineType"
+        },
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "DescribeBrokerEngineTypesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerEngineTypes" : {
+          "shape" : "__listOfBrokerEngineType",
+          "locationName" : "brokerEngineTypes"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "DescribeBrokerInstanceOptionsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "EngineType" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "engineType"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "hostInstanceType"
+        },
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        },
+        "StorageType" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "storageType"
+        }
+      }
+    },
+    "DescribeBrokerInstanceOptionsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerInstanceOptions" : {
+          "shape" : "__listOfBrokerInstanceOption",
+          "locationName" : "brokerInstanceOptions"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "DescribeBrokerOutput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerArn" : {
+          "shape" : "__string",
+          "locationName" : "brokerArn"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "BrokerInstances" : {
+          "shape" : "__listOfBrokerInstance",
+          "locationName" : "brokerInstances"
+        },
+        "BrokerName" : {
+          "shape" : "__string",
+          "locationName" : "brokerName"
+        },
+        "BrokerState" : {
+          "shape" : "BrokerState",
+          "locationName" : "brokerState"
+        },
+        "Configurations" : {
+          "shape" : "Configurations",
+          "locationName" : "configurations"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "DeploymentMode" : {
+          "shape" : "DeploymentMode",
+          "locationName" : "deploymentMode"
+        },
+        "EncryptionOptions" : {
+          "shape" : "EncryptionOptions",
+          "locationName" : "encryptionOptions"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "LogsSummary",
+          "locationName" : "logs"
+        },
+        "MaintenanceWindowStartTime" : {
+          "shape" : "WeeklyStartTime",
+          "locationName" : "maintenanceWindowStartTime"
+        },
+        "PendingAuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "pendingAuthenticationStrategy"
+        },
+        "PendingEngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "pendingEngineVersion"
+        },
+        "PendingHostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "pendingHostInstanceType"
+        },
+        "PendingLdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "pendingLdapServerMetadata"
+        },
+        "PendingSecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "pendingSecurityGroups"
+        },
+        "PubliclyAccessible" : {
+          "shape" : "__boolean",
+          "locationName" : "publiclyAccessible"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        },
+        "StorageType" : {
+          "shape" : "BrokerStorageType",
+          "locationName" : "storageType"
+        },
+        "SubnetIds" : {
+          "shape" : "__listOf__string",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        },
+        "Users" : {
+          "shape" : "__listOfUserSummary",
+          "locationName" : "users"
+        }
+      }
+    },
+    "DescribeBrokerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        }
+      },
+      "required" : [ "BrokerId" ]
+    },
+    "DescribeBrokerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerArn" : {
+          "shape" : "__string",
+          "locationName" : "brokerArn"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "BrokerInstances" : {
+          "shape" : "__listOfBrokerInstance",
+          "locationName" : "brokerInstances"
+        },
+        "BrokerName" : {
+          "shape" : "__string",
+          "locationName" : "brokerName"
+        },
+        "BrokerState" : {
+          "shape" : "BrokerState",
+          "locationName" : "brokerState"
+        },
+        "Configurations" : {
+          "shape" : "Configurations",
+          "locationName" : "configurations"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "DeploymentMode" : {
+          "shape" : "DeploymentMode",
+          "locationName" : "deploymentMode"
+        },
+        "EncryptionOptions" : {
+          "shape" : "EncryptionOptions",
+          "locationName" : "encryptionOptions"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "LogsSummary",
+          "locationName" : "logs"
+        },
+        "MaintenanceWindowStartTime" : {
+          "shape" : "WeeklyStartTime",
+          "locationName" : "maintenanceWindowStartTime"
+        },
+        "PendingAuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "pendingAuthenticationStrategy"
+        },
+        "PendingEngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "pendingEngineVersion"
+        },
+        "PendingHostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "pendingHostInstanceType"
+        },
+        "PendingLdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "pendingLdapServerMetadata"
+        },
+        "PendingSecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "pendingSecurityGroups"
+        },
+        "PubliclyAccessible" : {
+          "shape" : "__boolean",
+          "locationName" : "publiclyAccessible"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        },
+        "StorageType" : {
+          "shape" : "BrokerStorageType",
+          "locationName" : "storageType"
+        },
+        "SubnetIds" : {
+          "shape" : "__listOf__string",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        },
+        "Users" : {
+          "shape" : "__listOfUserSummary",
+          "locationName" : "users"
+        }
+      }
+    },
+    "DescribeConfigurationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "configuration-id"
+        }
+      },
+      "required" : [ "ConfigurationId" ]
+    },
+    "DescribeConfigurationResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        },
+        "EngineType" : {
+          "shape" : "EngineType",
+          "locationName" : "engineType"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "DescribeConfigurationRevisionOutput" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "locationName" : "configurationId"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Data" : {
+          "shape" : "__string",
+          "locationName" : "data"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        }
+      }
+    },
+    "DescribeConfigurationRevisionRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "configuration-id"
+        },
+        "ConfigurationRevision" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "configuration-revision"
+        }
+      },
+      "required" : [ "ConfigurationRevision", "ConfigurationId" ]
+    },
+    "DescribeConfigurationRevisionResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "locationName" : "configurationId"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Data" : {
+          "shape" : "__string",
+          "locationName" : "data"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        }
+      }
+    },
+    "DescribeUserOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Pending" : {
+          "shape" : "UserPendingChanges",
+          "locationName" : "pending"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "locationName" : "username"
+        }
+      }
+    },
+    "DescribeUserRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "username"
+        }
+      },
+      "required" : [ "Username", "BrokerId" ]
+    },
+    "DescribeUserResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Pending" : {
+          "shape" : "UserPendingChanges",
+          "locationName" : "pending"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "locationName" : "username"
+        }
+      }
+    },
+    "EncryptionOptions" : {
+      "type" : "structure",
+      "members" : {
+        "KmsKeyId" : {
+          "shape" : "__string",
+          "locationName" : "kmsKeyId"
+        },
+        "UseAwsOwnedKey" : {
+          "shape" : "__boolean",
+          "locationName" : "useAwsOwnedKey"
+        }
+      },
+      "required" : [ "UseAwsOwnedKey" ]
+    },
+    "EngineType" : {
+      "type" : "string",
+      "enum" : [ "ACTIVEMQ" ]
+    },
+    "EngineVersion" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        }
+      }
+    },
+    "Error" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      }
+    },
+    "ForbiddenException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 403
+      }
+    },
+    "InternalServerErrorException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 500
+      }
+    },
+    "LdapServerMetadataInput" : {
+      "type" : "structure",
+      "members" : {
+        "Hosts" : {
+          "shape" : "__listOf__string",
+          "locationName" : "hosts"
+        },
+        "RoleBase" : {
+          "shape" : "__string",
+          "locationName" : "roleBase"
+        },
+        "RoleName" : {
+          "shape" : "__string",
+          "locationName" : "roleName"
+        },
+        "RoleSearchMatching" : {
+          "shape" : "__string",
+          "locationName" : "roleSearchMatching"
+        },
+        "RoleSearchSubtree" : {
+          "shape" : "__boolean",
+          "locationName" : "roleSearchSubtree"
+        },
+        "ServiceAccountPassword" : {
+          "shape" : "__string",
+          "locationName" : "serviceAccountPassword"
+        },
+        "ServiceAccountUsername" : {
+          "shape" : "__string",
+          "locationName" : "serviceAccountUsername"
+        },
+        "UserBase" : {
+          "shape" : "__string",
+          "locationName" : "userBase"
+        },
+        "UserRoleName" : {
+          "shape" : "__string",
+          "locationName" : "userRoleName"
+        },
+        "UserSearchMatching" : {
+          "shape" : "__string",
+          "locationName" : "userSearchMatching"
+        },
+        "UserSearchSubtree" : {
+          "shape" : "__boolean",
+          "locationName" : "userSearchSubtree"
+        }
+      }
+    },
+    "LdapServerMetadataOutput" : {
+      "type" : "structure",
+      "members" : {
+        "Hosts" : {
+          "shape" : "__listOf__string",
+          "locationName" : "hosts"
+        },
+        "RoleBase" : {
+          "shape" : "__string",
+          "locationName" : "roleBase"
+        },
+        "RoleName" : {
+          "shape" : "__string",
+          "locationName" : "roleName"
+        },
+        "RoleSearchMatching" : {
+          "shape" : "__string",
+          "locationName" : "roleSearchMatching"
+        },
+        "RoleSearchSubtree" : {
+          "shape" : "__boolean",
+          "locationName" : "roleSearchSubtree"
+        },
+        "ServiceAccountUsername" : {
+          "shape" : "__string",
+          "locationName" : "serviceAccountUsername"
+        },
+        "UserBase" : {
+          "shape" : "__string",
+          "locationName" : "userBase"
+        },
+        "UserRoleName" : {
+          "shape" : "__string",
+          "locationName" : "userRoleName"
+        },
+        "UserSearchMatching" : {
+          "shape" : "__string",
+          "locationName" : "userSearchMatching"
+        },
+        "UserSearchSubtree" : {
+          "shape" : "__boolean",
+          "locationName" : "userSearchSubtree"
+        }
+      }
+    },
+    "ListBrokersOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerSummaries" : {
+          "shape" : "__listOfBrokerSummary",
+          "locationName" : "brokerSummaries"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListBrokersRequest" : {
+      "type" : "structure",
+      "members" : {
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListBrokersResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerSummaries" : {
+          "shape" : "__listOfBrokerSummary",
+          "locationName" : "brokerSummaries"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListConfigurationRevisionsOutput" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "locationName" : "configurationId"
+        },
+        "MaxResults" : {
+          "shape" : "__integer",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        },
+        "Revisions" : {
+          "shape" : "__listOfConfigurationRevision",
+          "locationName" : "revisions"
+        }
+      }
+    },
+    "ListConfigurationRevisionsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "configuration-id"
+        },
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ConfigurationId" ]
+    },
+    "ListConfigurationRevisionsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "locationName" : "configurationId"
+        },
+        "MaxResults" : {
+          "shape" : "__integer",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        },
+        "Revisions" : {
+          "shape" : "__listOfConfigurationRevision",
+          "locationName" : "revisions"
+        }
+      }
+    },
+    "ListConfigurationsOutput" : {
+      "type" : "structure",
+      "members" : {
+        "Configurations" : {
+          "shape" : "__listOfConfiguration",
+          "locationName" : "configurations"
+        },
+        "MaxResults" : {
+          "shape" : "__integer",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListConfigurationsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListConfigurationsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Configurations" : {
+          "shape" : "__listOfConfiguration",
+          "locationName" : "configurations"
+        },
+        "MaxResults" : {
+          "shape" : "__integer",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "ListTagsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        }
+      },
+      "required" : [ "ResourceArn" ]
+    },
+    "ListTagsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "ListUsersOutput" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        },
+        "Users" : {
+          "shape" : "__listOfUserSummary",
+          "locationName" : "users"
+        }
+      }
+    },
+    "ListUsersRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "MaxResults" : {
+          "shape" : "MaxResults",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "BrokerId" ]
+    },
+    "ListUsersResponse" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "MaxResults" : {
+          "shape" : "__integerMin5Max100",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "locationName" : "nextToken"
+        },
+        "Users" : {
+          "shape" : "__listOfUserSummary",
+          "locationName" : "users"
+        }
+      }
+    },
+    "Logs" : {
+      "type" : "structure",
+      "members" : {
+        "Audit" : {
+          "shape" : "__boolean",
+          "locationName" : "audit"
+        },
+        "General" : {
+          "shape" : "__boolean",
+          "locationName" : "general"
+        }
+      }
+    },
+    "LogsSummary" : {
+      "type" : "structure",
+      "members" : {
+        "Audit" : {
+          "shape" : "__boolean",
+          "locationName" : "audit"
+        },
+        "AuditLogGroup" : {
+          "shape" : "__string",
+          "locationName" : "auditLogGroup"
+        },
+        "General" : {
+          "shape" : "__boolean",
+          "locationName" : "general"
+        },
+        "GeneralLogGroup" : {
+          "shape" : "__string",
+          "locationName" : "generalLogGroup"
+        },
+        "Pending" : {
+          "shape" : "PendingLogs",
+          "locationName" : "pending"
+        }
+      }
+    },
+    "MaxResults" : {
+      "type" : "integer",
+      "min" : 1,
+      "max" : 100
+    },
+    "NotFoundException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 404
+      }
+    },
+    "PendingLogs" : {
+      "type" : "structure",
+      "members" : {
+        "Audit" : {
+          "shape" : "__boolean",
+          "locationName" : "audit"
+        },
+        "General" : {
+          "shape" : "__boolean",
+          "locationName" : "general"
+        }
+      }
+    },
+    "RebootBrokerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        }
+      },
+      "required" : [ "BrokerId" ]
+    },
+    "RebootBrokerResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "SanitizationWarning" : {
+      "type" : "structure",
+      "members" : {
+        "AttributeName" : {
+          "shape" : "__string",
+          "locationName" : "attributeName"
+        },
+        "ElementName" : {
+          "shape" : "__string",
+          "locationName" : "elementName"
+        },
+        "Reason" : {
+          "shape" : "SanitizationWarningReason",
+          "locationName" : "reason"
+        }
+      }
+    },
+    "SanitizationWarningReason" : {
+      "type" : "string",
+      "enum" : [ "DISALLOWED_ELEMENT_REMOVED", "DISALLOWED_ATTRIBUTE_REMOVED", "INVALID_ATTRIBUTE_VALUE_REMOVED" ]
+    },
+    "Tags" : {
+      "type" : "structure",
+      "members" : {
+        "Tags" : {
+          "shape" : "__mapOf__string",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "UnauthorizedException" : {
+      "type" : "structure",
+      "members" : {
+        "ErrorAttribute" : {
+          "shape" : "__string",
+          "locationName" : "errorAttribute"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 401
+      }
+    },
+    "UpdateBrokerInput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataInput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        }
+      }
+    },
+    "UpdateBrokerOutput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        }
+      }
+    },
+    "UpdateBrokerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataInput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        }
+      },
+      "required" : [ "BrokerId" ]
+    },
+    "UpdateBrokerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AuthenticationStrategy" : {
+          "shape" : "AuthenticationStrategy",
+          "locationName" : "authenticationStrategy"
+        },
+        "AutoMinorVersionUpgrade" : {
+          "shape" : "__boolean",
+          "locationName" : "autoMinorVersionUpgrade"
+        },
+        "BrokerId" : {
+          "shape" : "__string",
+          "locationName" : "brokerId"
+        },
+        "Configuration" : {
+          "shape" : "ConfigurationId",
+          "locationName" : "configuration"
+        },
+        "EngineVersion" : {
+          "shape" : "__string",
+          "locationName" : "engineVersion"
+        },
+        "HostInstanceType" : {
+          "shape" : "__string",
+          "locationName" : "hostInstanceType"
+        },
+        "LdapServerMetadata" : {
+          "shape" : "LdapServerMetadataOutput",
+          "locationName" : "ldapServerMetadata"
+        },
+        "Logs" : {
+          "shape" : "Logs",
+          "locationName" : "logs"
+        },
+        "SecurityGroups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "securityGroups"
+        }
+      }
+    },
+    "UpdateConfigurationInput" : {
+      "type" : "structure",
+      "members" : {
+        "Data" : {
+          "shape" : "__string",
+          "locationName" : "data"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        }
+      }
+    },
+    "UpdateConfigurationOutput" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Warnings" : {
+          "shape" : "__listOfSanitizationWarning",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "UpdateConfigurationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ConfigurationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "configuration-id"
+        },
+        "Data" : {
+          "shape" : "__string",
+          "locationName" : "data"
+        },
+        "Description" : {
+          "shape" : "__string",
+          "locationName" : "description"
+        }
+      },
+      "required" : [ "ConfigurationId" ]
+    },
+    "UpdateConfigurationResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Arn" : {
+          "shape" : "__string",
+          "locationName" : "arn"
+        },
+        "Created" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "created"
+        },
+        "Id" : {
+          "shape" : "__string",
+          "locationName" : "id"
+        },
+        "LatestRevision" : {
+          "shape" : "ConfigurationRevision",
+          "locationName" : "latestRevision"
+        },
+        "Name" : {
+          "shape" : "__string",
+          "locationName" : "name"
+        },
+        "Warnings" : {
+          "shape" : "__listOfSanitizationWarning",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "UpdateUserInput" : {
+      "type" : "structure",
+      "members" : {
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Password" : {
+          "shape" : "__string",
+          "locationName" : "password"
+        }
+      }
+    },
+    "UpdateUserRequest" : {
+      "type" : "structure",
+      "members" : {
+        "BrokerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "broker-id"
+        },
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Password" : {
+          "shape" : "__string",
+          "locationName" : "password"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "username"
+        }
+      },
+      "required" : [ "Username", "BrokerId" ]
+    },
+    "UpdateUserResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "User" : {
+      "type" : "structure",
+      "members" : {
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "Password" : {
+          "shape" : "__string",
+          "locationName" : "password"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "locationName" : "username"
+        }
+      }
+    },
+    "UserPendingChanges" : {
+      "type" : "structure",
+      "members" : {
+        "ConsoleAccess" : {
+          "shape" : "__boolean",
+          "locationName" : "consoleAccess"
+        },
+        "Groups" : {
+          "shape" : "__listOf__string",
+          "locationName" : "groups"
+        },
+        "PendingChange" : {
+          "shape" : "ChangeType",
+          "locationName" : "pendingChange"
+        }
+      }
+    },
+    "UserSummary" : {
+      "type" : "structure",
+      "members" : {
+        "PendingChange" : {
+          "shape" : "ChangeType",
+          "locationName" : "pendingChange"
+        },
+        "Username" : {
+          "shape" : "__string",
+          "locationName" : "username"
+        }
+      }
+    },
+    "WeeklyStartTime" : {
+      "type" : "structure",
+      "members" : {
+        "DayOfWeek" : {
+          "shape" : "DayOfWeek",
+          "locationName" : "dayOfWeek"
+        },
+        "TimeOfDay" : {
+          "shape" : "__string",
+          "locationName" : "timeOfDay"
+        },
+        "TimeZone" : {
+          "shape" : "__string",
+          "locationName" : "timeZone"
+        }
+      }
+    },
+    "__boolean" : {
+      "type" : "boolean"
+    },
+    "__double" : {
+      "type" : "double"
+    },
+    "__integer" : {
+      "type" : "integer"
+    },
+    "__integerMin5Max100" : {
+      "type" : "integer",
+      "min" : 5,
+      "max" : 100
+    },
+    "__listOfAvailabilityZone" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "AvailabilityZone"
+      }
+    },
+    "__listOfBrokerEngineType" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "BrokerEngineType"
+      }
+    },
+    "__listOfBrokerInstance" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "BrokerInstance"
+      }
+    },
+    "__listOfBrokerInstanceOption" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "BrokerInstanceOption"
+      }
+    },
+    "__listOfBrokerSummary" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "BrokerSummary"
+      }
+    },
+    "__listOfConfiguration" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Configuration"
+      }
+    },
+    "__listOfConfigurationId" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ConfigurationId"
+      }
+    },
+    "__listOfConfigurationRevision" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ConfigurationRevision"
+      }
+    },
+    "__listOfDeploymentMode" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "DeploymentMode"
+      }
+    },
+    "__listOfEngineVersion" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "EngineVersion"
+      }
+    },
+    "__listOfSanitizationWarning" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "SanitizationWarning"
+      }
+    },
+    "__listOfUser" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "User"
+      }
+    },
+    "__listOfUserSummary" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "UserSummary"
+      }
+    },
+    "__listOf__string" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "__long" : {
+      "type" : "long"
+    },
+    "__mapOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__string"
+      }
+    },
+    "__string" : {
+      "type" : "string"
+    },
+    "__timestampIso8601" : {
+      "type" : "timestamp",
+      "timestampFormat" : "iso8601"
+    },
+    "__timestampUnix" : {
+      "type" : "timestamp",
+      "timestampFormat" : "unixTimestamp"
+    }
+  },
+  "authorizers" : {
+    "authorization_strategy" : {
+      "name" : "authorization_strategy",
+      "type" : "provided",
+      "placement" : {
+        "location" : "header",
+        "name" : "Authorization"
+      }
+    }
+  }
+}

--- a/pkg/generate/testdata/models/apis/mq/0000-00-00/docs-2.json
+++ b/pkg/generate/testdata/models/apis/mq/0000-00-00/docs-2.json
@@ -1,0 +1,610 @@
+{
+  "version" : "2.0",
+  "service" : "Amazon MQ is a managed message broker service for Apache ActiveMQ that makes it easy to set up and operate message brokers in the cloud. A message broker allows software applications and components to communicate using various programming languages, operating systems, and formal messaging protocols.",
+  "operations" : {
+    "CreateBroker" : "Creates a broker. Note: This API is asynchronous.",
+    "CreateConfiguration" : "Creates a new configuration for the specified configuration name. Amazon MQ uses the default configuration (the engine type and version).",
+    "CreateTags" : "Add a tag to a resource.",
+    "CreateUser" : "Creates an ActiveMQ user.",
+    "DeleteBroker" : "Deletes a broker. Note: This API is asynchronous.",
+    "DeleteTags" : "Removes a tag from a resource.",
+    "DeleteUser" : "Deletes an ActiveMQ user.",
+    "DescribeBroker" : "Returns information about the specified broker.",
+    "DescribeBrokerEngineTypes" : "Describe available engine types and versions.",
+    "DescribeBrokerInstanceOptions" : "Describe available broker instance options.",
+    "DescribeConfiguration" : "Returns information about the specified configuration.",
+    "DescribeConfigurationRevision" : "Returns the specified configuration revision for the specified configuration.",
+    "DescribeUser" : "Returns information about an ActiveMQ user.",
+    "ListBrokers" : "Returns a list of all brokers.",
+    "ListConfigurationRevisions" : "Returns a list of all revisions for the specified configuration.",
+    "ListConfigurations" : "Returns a list of all configurations.",
+    "ListTags" : "Lists tags for a resource.",
+    "ListUsers" : "Returns a list of all ActiveMQ users.",
+    "RebootBroker" : "Reboots a broker. Note: This API is asynchronous.",
+    "UpdateBroker" : "Adds a pending configuration change to a broker.",
+    "UpdateConfiguration" : "Updates the specified configuration.",
+    "UpdateUser" : "Updates the information for an ActiveMQ user."
+  },
+  "shapes" : {
+    "AuthenticationStrategy" : {
+      "base" : "The authentication strategy used to secure the broker.",
+      "refs" : {
+        "Configuration$AuthenticationStrategy" : "The authentication strategy associated with the configuration.",
+        "CreateBrokerInput$AuthenticationStrategy" : "The authentication strategy used to secure the broker.",
+        "CreateConfigurationInput$AuthenticationStrategy" : "The authentication strategy associated with the configuration.",
+        "CreateConfigurationOutput$AuthenticationStrategy" : "The authentication strategy associated with the configuration.",
+        "DescribeBrokerOutput$AuthenticationStrategy" : "The authentication strategy used to secure the broker.",
+        "DescribeBrokerOutput$PendingAuthenticationStrategy" : "The authentication strategy that will be applied when the broker is rebooted.",
+        "UpdateBrokerInput$AuthenticationStrategy" : "The authentication strategy used to secure the broker.",
+        "UpdateBrokerOutput$AuthenticationStrategy" : "The authentication strategy used to secure the broker."
+      }
+    },
+    "AvailabilityZone" : {
+      "base" : "Name of the availability zone.",
+      "refs" : {
+        "__listOfAvailabilityZone$member" : null
+      }
+    },
+    "BadRequestException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "BrokerEngineType" : {
+      "base" : "Types of broker engines.",
+      "refs" : {
+        "__listOfBrokerEngineType$member" : null
+      }
+    },
+    "BrokerEngineTypeOutput" : {
+      "base" : "Returns a list of broker engine type.",
+      "refs" : { }
+    },
+    "BrokerInstance" : {
+      "base" : "Returns information about all brokers.",
+      "refs" : {
+        "__listOfBrokerInstance$member" : null
+      }
+    },
+    "BrokerInstanceOption" : {
+      "base" : "Option for host instance type.",
+      "refs" : {
+        "__listOfBrokerInstanceOption$member" : null
+      }
+    },
+    "BrokerInstanceOptionsOutput" : {
+      "base" : "Returns a list of broker instance options.",
+      "refs" : { }
+    },
+    "BrokerState" : {
+      "base" : "The status of the broker.",
+      "refs" : {
+        "BrokerSummary$BrokerState" : "The status of the broker.",
+        "DescribeBrokerOutput$BrokerState" : "The status of the broker."
+      }
+    },
+    "BrokerStorageType" : {
+      "base" : "The storage type of the broker.",
+      "refs" : {
+        "BrokerInstanceOption$StorageType" : "The broker's storage type.",
+        "CreateBrokerInput$StorageType" : "The broker's storage type.",
+        "DescribeBrokerOutput$StorageType" : "The broker's storage type."
+      }
+    },
+    "BrokerSummary" : {
+      "base" : "The Amazon Resource Name (ARN) of the broker.",
+      "refs" : {
+        "__listOfBrokerSummary$member" : null
+      }
+    },
+    "ChangeType" : {
+      "base" : "The type of change pending for the ActiveMQ user.",
+      "refs" : {
+        "UserPendingChanges$PendingChange" : "Required. The type of change pending for the ActiveMQ user.",
+        "UserSummary$PendingChange" : "The type of change pending for the ActiveMQ user."
+      }
+    },
+    "Configuration" : {
+      "base" : "Returns information about all configurations.",
+      "refs" : {
+        "__listOfConfiguration$member" : null
+      }
+    },
+    "ConfigurationId" : {
+      "base" : "A list of information about the configuration.",
+      "refs" : {
+        "Configurations$Current" : "The current configuration of the broker.",
+        "Configurations$Pending" : "The pending configuration of the broker.",
+        "CreateBrokerInput$Configuration" : "A list of information about the configuration.",
+        "UpdateBrokerInput$Configuration" : "A list of information about the configuration.",
+        "UpdateBrokerOutput$Configuration" : "The ID of the updated configuration.",
+        "__listOfConfigurationId$member" : null
+      }
+    },
+    "ConfigurationRevision" : {
+      "base" : "Returns information about the specified configuration revision.",
+      "refs" : {
+        "Configuration$LatestRevision" : "Required. The latest revision of the configuration.",
+        "CreateConfigurationOutput$LatestRevision" : "The latest revision of the configuration.",
+        "UpdateConfigurationOutput$LatestRevision" : "The latest revision of the configuration.",
+        "__listOfConfigurationRevision$member" : null
+      }
+    },
+    "Configurations" : {
+      "base" : "Broker configuration information",
+      "refs" : {
+        "DescribeBrokerOutput$Configurations" : "The list of all revisions for the specified configuration."
+      }
+    },
+    "ConflictException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "CreateBrokerInput" : {
+      "base" : "Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+      "refs" : { }
+    },
+    "CreateBrokerOutput" : {
+      "base" : "Returns information about the created broker.",
+      "refs" : { }
+    },
+    "CreateConfigurationInput" : {
+      "base" : "Creates a new configuration for the specified configuration name. Amazon MQ uses the default configuration (the engine type and version).",
+      "refs" : { }
+    },
+    "CreateConfigurationOutput" : {
+      "base" : "Returns information about the created configuration.",
+      "refs" : { }
+    },
+    "CreateUserInput" : {
+      "base" : "Creates a new ActiveMQ user.",
+      "refs" : { }
+    },
+    "DayOfWeek" : {
+      "base" : null,
+      "refs" : {
+        "WeeklyStartTime$DayOfWeek" : "Required. The day of the week."
+      }
+    },
+    "DeleteBrokerOutput" : {
+      "base" : "Returns information about the deleted broker.",
+      "refs" : { }
+    },
+    "DeploymentMode" : {
+      "base" : "The deployment mode of the broker.",
+      "refs" : {
+        "BrokerSummary$DeploymentMode" : "Required. The deployment mode of the broker.",
+        "CreateBrokerInput$DeploymentMode" : "Required. The deployment mode of the broker.",
+        "DescribeBrokerOutput$DeploymentMode" : "Required. The deployment mode of the broker.",
+        "__listOfDeploymentMode$member" : null
+      }
+    },
+    "DescribeBrokerOutput" : {
+      "base" : "The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+      "refs" : { }
+    },
+    "DescribeConfigurationRevisionOutput" : {
+      "base" : "Returns the specified configuration revision for the specified configuration.",
+      "refs" : { }
+    },
+    "DescribeUserOutput" : {
+      "base" : "Returns information about an ActiveMQ user.",
+      "refs" : { }
+    },
+    "EncryptionOptions" : {
+      "base" : "Encryption options for the broker.",
+      "refs" : {
+        "CreateBrokerInput$EncryptionOptions" : "Encryption options for the broker.",
+        "DescribeBrokerOutput$EncryptionOptions" : "Encryption options for the broker."
+      }
+    },
+    "EngineType" : {
+      "base" : "The type of broker engine. Note: Currently, Amazon MQ supports only ActiveMQ.",
+      "refs" : {
+        "BrokerEngineType$EngineType" : "The type of broker engine.",
+        "BrokerInstanceOption$EngineType" : "The type of broker engine.",
+        "Configuration$EngineType" : "Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.",
+        "CreateBrokerInput$EngineType" : "Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.",
+        "CreateConfigurationInput$EngineType" : "Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.",
+        "DescribeBrokerOutput$EngineType" : "Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ."
+      }
+    },
+    "EngineVersion" : {
+      "base" : "Id of the engine version.",
+      "refs" : {
+        "__listOfEngineVersion$member" : null
+      }
+    },
+    "Error" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "ForbiddenException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "InternalServerErrorException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "LdapServerMetadataInput" : {
+      "base" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker.",
+      "refs" : {
+        "CreateBrokerInput$LdapServerMetadata" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker.",
+        "UpdateBrokerInput$LdapServerMetadata" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker."
+      }
+    },
+    "LdapServerMetadataOutput" : {
+      "base" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker.",
+      "refs" : {
+        "DescribeBrokerOutput$LdapServerMetadata" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker.",
+        "DescribeBrokerOutput$PendingLdapServerMetadata" : "The metadata of the LDAP server that will be used to authenticate and authorize connections to the broker once it is rebooted.",
+        "UpdateBrokerOutput$LdapServerMetadata" : "The metadata of the LDAP server used to authenticate and authorize connections to the broker."
+      }
+    },
+    "ListBrokersOutput" : {
+      "base" : "A list of information about all brokers.",
+      "refs" : { }
+    },
+    "ListConfigurationRevisionsOutput" : {
+      "base" : "Returns a list of all revisions for the specified configuration.",
+      "refs" : { }
+    },
+    "ListConfigurationsOutput" : {
+      "base" : "Returns a list of all configurations.",
+      "refs" : { }
+    },
+    "ListUsersOutput" : {
+      "base" : "Returns a list of all ActiveMQ users.",
+      "refs" : { }
+    },
+    "Logs" : {
+      "base" : "The list of information about logs to be enabled for the specified broker.",
+      "refs" : {
+        "CreateBrokerInput$Logs" : "Enables Amazon CloudWatch logging for brokers.",
+        "UpdateBrokerInput$Logs" : "Enables Amazon CloudWatch logging for brokers.",
+        "UpdateBrokerOutput$Logs" : "The list of information about logs to be enabled for the specified broker."
+      }
+    },
+    "LogsSummary" : {
+      "base" : "The list of information about logs currently enabled and pending to be deployed for the specified broker.",
+      "refs" : {
+        "DescribeBrokerOutput$Logs" : "The list of information about logs currently enabled and pending to be deployed for the specified broker."
+      }
+    },
+    "NotFoundException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "PendingLogs" : {
+      "base" : "The list of information about logs to be enabled for the specified broker.",
+      "refs" : {
+        "LogsSummary$Pending" : "The list of information about logs pending to be deployed for the specified broker."
+      }
+    },
+    "SanitizationWarning" : {
+      "base" : "Returns information about the XML element or attribute that was sanitized in the configuration.",
+      "refs" : {
+        "__listOfSanitizationWarning$member" : null
+      }
+    },
+    "SanitizationWarningReason" : {
+      "base" : "The reason for which the XML elements or attributes were sanitized.",
+      "refs" : {
+        "SanitizationWarning$Reason" : "Required. The reason for which the XML elements or attributes were sanitized."
+      }
+    },
+    "Tags" : {
+      "base" : "A map of the key-value pairs for the resource tag.",
+      "refs" : { }
+    },
+    "UnauthorizedException" : {
+      "base" : "Returns information about an error.",
+      "refs" : { }
+    },
+    "UpdateBrokerInput" : {
+      "base" : "Updates the broker using the specified properties.",
+      "refs" : { }
+    },
+    "UpdateBrokerOutput" : {
+      "base" : "Returns information about the updated broker.",
+      "refs" : { }
+    },
+    "UpdateConfigurationInput" : {
+      "base" : "Updates the specified configuration.",
+      "refs" : { }
+    },
+    "UpdateConfigurationOutput" : {
+      "base" : "Returns information about the updated configuration.",
+      "refs" : { }
+    },
+    "UpdateUserInput" : {
+      "base" : "Updates the information for an ActiveMQ user.",
+      "refs" : { }
+    },
+    "User" : {
+      "base" : "An ActiveMQ user associated with the broker.",
+      "refs" : {
+        "__listOfUser$member" : null
+      }
+    },
+    "UserPendingChanges" : {
+      "base" : "Returns information about the status of the changes pending for the ActiveMQ user.",
+      "refs" : {
+        "DescribeUserOutput$Pending" : "The status of the changes pending for the ActiveMQ user."
+      }
+    },
+    "UserSummary" : {
+      "base" : "Returns a list of all ActiveMQ users.",
+      "refs" : {
+        "__listOfUserSummary$member" : null
+      }
+    },
+    "WeeklyStartTime" : {
+      "base" : "The scheduled time period relative to UTC during which Amazon MQ begins to apply pending updates or patches to the broker.",
+      "refs" : {
+        "CreateBrokerInput$MaintenanceWindowStartTime" : "The parameters that determine the WeeklyStartTime.",
+        "DescribeBrokerOutput$MaintenanceWindowStartTime" : "The parameters that determine the WeeklyStartTime."
+      }
+    },
+    "__boolean" : {
+      "base" : null,
+      "refs" : {
+        "CreateBrokerInput$AutoMinorVersionUpgrade" : "Required. Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.",
+        "CreateBrokerInput$PubliclyAccessible" : "Required. Enables connections from applications outside of the VPC that hosts the broker's subnets.",
+        "CreateUserInput$ConsoleAccess" : "Enables access to the the ActiveMQ Web Console for the ActiveMQ user.",
+        "DescribeBrokerOutput$AutoMinorVersionUpgrade" : "Required. Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.",
+        "DescribeBrokerOutput$PubliclyAccessible" : "Required. Enables connections from applications outside of the VPC that hosts the broker's subnets.",
+        "DescribeUserOutput$ConsoleAccess" : "Enables access to the the ActiveMQ Web Console for the ActiveMQ user.",
+        "EncryptionOptions$UseAwsOwnedKey" : "Enables the use of an AWS owned CMK using AWS Key Management Service (KMS).",
+        "LdapServerMetadataInput$RoleSearchSubtree" : "The directory search scope for the role. If set to true, scope is to search the entire sub-tree.",
+        "LdapServerMetadataInput$UserSearchSubtree" : "The directory search scope for the user. If set to true, scope is to search the entire sub-tree.",
+        "LdapServerMetadataOutput$RoleSearchSubtree" : "The directory search scope for the role. If set to true, scope is to search the entire sub-tree.",
+        "LdapServerMetadataOutput$UserSearchSubtree" : "The directory search scope for the user. If set to true, scope is to search the entire sub-tree.",
+        "Logs$Audit" : "Enables audit logging. Every user management action made using JMX or the ActiveMQ Web Console is logged.",
+        "Logs$General" : "Enables general logging.",
+        "LogsSummary$Audit" : "Enables audit logging. Every user management action made using JMX or the ActiveMQ Web Console is logged.",
+        "LogsSummary$General" : "Enables general logging.",
+        "PendingLogs$Audit" : "Enables audit logging. Every user management action made using JMX or the ActiveMQ Web Console is logged.",
+        "PendingLogs$General" : "Enables general logging.",
+        "UpdateBrokerInput$AutoMinorVersionUpgrade" : "Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.",
+        "UpdateBrokerOutput$AutoMinorVersionUpgrade" : "The new value of automatic upgrades to new minor version for brokers.",
+        "UpdateUserInput$ConsoleAccess" : "Enables access to the the ActiveMQ Web Console for the ActiveMQ user.",
+        "User$ConsoleAccess" : "Enables access to the the ActiveMQ Web Console for the ActiveMQ user.",
+        "UserPendingChanges$ConsoleAccess" : "Enables access to the the ActiveMQ Web Console for the ActiveMQ user."
+      }
+    },
+    "__integer" : {
+      "base" : null,
+      "refs" : {
+        "ConfigurationId$Revision" : "The revision number of the configuration.",
+        "ConfigurationRevision$Revision" : "Required. The revision number of the configuration.",
+        "ListConfigurationRevisionsOutput$MaxResults" : "The maximum number of configuration revisions that can be returned per page (20 by default). This value must be an integer from 5 to 100.",
+        "ListConfigurationsOutput$MaxResults" : "The maximum number of configurations that Amazon MQ can return per page (20 by default). This value must be an integer from 5 to 100."
+      }
+    },
+    "__integerMin5Max100" : {
+      "base" : null,
+      "refs" : {
+        "BrokerEngineTypeOutput$MaxResults" : "Required. The maximum number of engine types that can be returned per page (20 by default). This value must be an integer from 5 to 100.",
+        "BrokerInstanceOptionsOutput$MaxResults" : "Required. The maximum number of instance options that can be returned per page (20 by default). This value must be an integer from 5 to 100.",
+        "ListUsersOutput$MaxResults" : "Required. The maximum number of ActiveMQ users that can be returned per page (20 by default). This value must be an integer from 5 to 100."
+      }
+    },
+    "__listOfAvailabilityZone" : {
+      "base" : null,
+      "refs" : {
+        "BrokerInstanceOption$AvailabilityZones" : "The list of available az."
+      }
+    },
+    "__listOfBrokerEngineType" : {
+      "base" : null,
+      "refs" : {
+        "BrokerEngineTypeOutput$BrokerEngineTypes" : "List of available engine types and versions."
+      }
+    },
+    "__listOfBrokerInstance" : {
+      "base" : null,
+      "refs" : {
+        "DescribeBrokerOutput$BrokerInstances" : "A list of information about allocated brokers."
+      }
+    },
+    "__listOfBrokerInstanceOption" : {
+      "base" : null,
+      "refs" : {
+        "BrokerInstanceOptionsOutput$BrokerInstanceOptions" : "List of available broker instance options."
+      }
+    },
+    "__listOfBrokerSummary" : {
+      "base" : null,
+      "refs" : {
+        "ListBrokersOutput$BrokerSummaries" : "A list of information about all brokers."
+      }
+    },
+    "__listOfConfiguration" : {
+      "base" : null,
+      "refs" : {
+        "ListConfigurationsOutput$Configurations" : "The list of all revisions for the specified configuration."
+      }
+    },
+    "__listOfConfigurationId" : {
+      "base" : null,
+      "refs" : {
+        "Configurations$History" : "The history of configurations applied to the broker."
+      }
+    },
+    "__listOfConfigurationRevision" : {
+      "base" : null,
+      "refs" : {
+        "ListConfigurationRevisionsOutput$Revisions" : "The list of all revisions for the specified configuration."
+      }
+    },
+    "__listOfDeploymentMode" : {
+      "base" : null,
+      "refs" : {
+        "BrokerInstanceOption$SupportedDeploymentModes" : "The list of supported deployment modes."
+      }
+    },
+    "__listOfEngineVersion" : {
+      "base" : null,
+      "refs" : {
+        "BrokerEngineType$EngineVersions" : "The list of engine versions."
+      }
+    },
+    "__listOfSanitizationWarning" : {
+      "base" : null,
+      "refs" : {
+        "UpdateConfigurationOutput$Warnings" : "The list of the first 20 warnings about the configuration XML elements or attributes that were sanitized."
+      }
+    },
+    "__listOfUser" : {
+      "base" : null,
+      "refs" : {
+        "CreateBrokerInput$Users" : "Required. The list of ActiveMQ users (persons or applications) who can access queues and topics. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long."
+      }
+    },
+    "__listOfUserSummary" : {
+      "base" : null,
+      "refs" : {
+        "DescribeBrokerOutput$Users" : "The list of all ActiveMQ usernames for the specified broker.",
+        "ListUsersOutput$Users" : "Required. The list of all ActiveMQ usernames for the specified broker."
+      }
+    },
+    "__listOf__string" : {
+      "base" : null,
+      "refs" : {
+        "BrokerInstance$Endpoints" : "The broker's wire-level protocol endpoints.",
+        "BrokerInstanceOption$SupportedEngineVersions" : "The list of supported engine versions.",
+        "CreateBrokerInput$SecurityGroups" : "The list of security groups (1 minimum, 5 maximum) that authorizes connections to brokers.",
+        "CreateBrokerInput$SubnetIds" : "The list of groups (2 maximum) that define which subnets and IP ranges the broker can use from different Availability Zones. A SINGLE_INSTANCE deployment requires one subnet (for example, the default subnet). An ACTIVE_STANDBY_MULTI_AZ deployment requires two subnets.",
+        "CreateUserInput$Groups" : "The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "DescribeBrokerOutput$PendingSecurityGroups" : "The list of pending security groups to authorize connections to brokers.",
+        "DescribeBrokerOutput$SecurityGroups" : "The list of security groups (1 minimum, 5 maximum) that authorizes connections to brokers.",
+        "DescribeBrokerOutput$SubnetIds" : "The list of groups (2 maximum) that define which subnets and IP ranges the broker can use from different Availability Zones. A SINGLE_INSTANCE deployment requires one subnet (for example, the default subnet). An ACTIVE_STANDBY_MULTI_AZ deployment requires two subnets.",
+        "DescribeUserOutput$Groups" : "The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "LdapServerMetadataInput$Hosts" : "Fully qualified domain name of the LDAP server. Optional failover server.",
+        "LdapServerMetadataOutput$Hosts" : "Fully qualified domain name of the LDAP server. Optional failover server.",
+        "UpdateBrokerInput$SecurityGroups" : "The list of security groups (1 minimum, 5 maximum) that authorizes connections to brokers.",
+        "UpdateBrokerOutput$SecurityGroups" : "The list of security groups (1 minimum, 5 maximum) that authorizes connections to brokers.",
+        "UpdateUserInput$Groups" : "The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "User$Groups" : "The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "UserPendingChanges$Groups" : "The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long."
+      }
+    },
+    "__mapOf__string" : {
+      "base" : null,
+      "refs" : {
+        "Configuration$Tags" : "The list of all tags associated with this configuration.",
+        "CreateBrokerInput$Tags" : "Create tags when creating the broker.",
+        "CreateConfigurationInput$Tags" : "Create tags when creating the configuration.",
+        "DescribeBrokerOutput$Tags" : "The list of all tags associated with this broker.",
+        "Tags$Tags" : "The key-value pair for the resource tag."
+      }
+    },
+    "__string" : {
+      "base" : null,
+      "refs" : {
+        "AvailabilityZone$Name" : "Id for the availability zone.",
+        "BrokerEngineTypeOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "BrokerInstance$ConsoleURL" : "The URL of the broker's ActiveMQ Web Console.",
+        "BrokerInstance$IpAddress" : "The IP address of the Elastic Network Interface (ENI) attached to the broker.",
+        "BrokerInstanceOption$HostInstanceType" : "The type of broker instance.",
+        "BrokerInstanceOptionsOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "BrokerSummary$BrokerArn" : "The Amazon Resource Name (ARN) of the broker.",
+        "BrokerSummary$BrokerId" : "The unique ID that Amazon MQ generates for the broker.",
+        "BrokerSummary$BrokerName" : "The name of the broker. This value must be unique in your AWS account, 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not contain whitespaces, brackets, wildcard characters, or special characters.",
+        "BrokerSummary$HostInstanceType" : "The broker's instance type.",
+        "Configuration$Arn" : "Required. The ARN of the configuration.",
+        "Configuration$Description" : "Required. The description of the configuration.",
+        "Configuration$EngineVersion" : "Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "Configuration$Id" : "Required. The unique ID that Amazon MQ generates for the configuration.",
+        "Configuration$Name" : "Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.",
+        "ConfigurationId$Id" : "Required. The unique ID that Amazon MQ generates for the configuration.",
+        "ConfigurationRevision$Description" : "The description of the configuration revision.",
+        "CreateBrokerInput$BrokerName" : "Required. The name of the broker. This value must be unique in your AWS account, 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not contain whitespaces, brackets, wildcard characters, or special characters.",
+        "CreateBrokerInput$CreatorRequestId" : "The unique ID that the requester receives for the created broker. Amazon MQ passes your ID with the API action. Note: We recommend using a Universally Unique Identifier (UUID) for the creatorRequestId. You may omit the creatorRequestId if your application doesn't require idempotency.",
+        "CreateBrokerInput$EngineVersion" : "Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "CreateBrokerInput$HostInstanceType" : "Required. The broker's instance type.",
+        "CreateBrokerOutput$BrokerArn" : "The Amazon Resource Name (ARN) of the broker.",
+        "CreateBrokerOutput$BrokerId" : "The unique ID that Amazon MQ generates for the broker.",
+        "CreateConfigurationInput$EngineVersion" : "Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "CreateConfigurationInput$Name" : "Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.",
+        "CreateConfigurationOutput$Arn" : "Required. The Amazon Resource Name (ARN) of the configuration.",
+        "CreateConfigurationOutput$Id" : "Required. The unique ID that Amazon MQ generates for the configuration.",
+        "CreateConfigurationOutput$Name" : "Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.",
+        "CreateUserInput$Password" : "Required. The password of the user. This value must be at least 12 characters long, must contain at least 4 unique characters, and must not contain commas.",
+        "DeleteBrokerOutput$BrokerId" : "The unique ID that Amazon MQ generates for the broker.",
+        "DescribeBrokerOutput$BrokerArn" : "The Amazon Resource Name (ARN) of the broker.",
+        "DescribeBrokerOutput$BrokerId" : "The unique ID that Amazon MQ generates for the broker.",
+        "DescribeBrokerOutput$BrokerName" : "The name of the broker. This value must be unique in your AWS account, 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not contain whitespaces, brackets, wildcard characters, or special characters.",
+        "DescribeBrokerOutput$EngineVersion" : "The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "DescribeBrokerOutput$HostInstanceType" : "The broker's instance type.",
+        "DescribeBrokerOutput$PendingEngineVersion" : "The version of the broker engine to upgrade to. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "DescribeBrokerOutput$PendingHostInstanceType" : "The host instance type of the broker to upgrade to. For a list of supported instance types, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html#broker-instance-types",
+        "DescribeConfigurationRevisionOutput$ConfigurationId" : "Required. The unique ID that Amazon MQ generates for the configuration.",
+        "DescribeConfigurationRevisionOutput$Data" : "Required. The base64-encoded XML configuration.",
+        "DescribeConfigurationRevisionOutput$Description" : "The description of the configuration.",
+        "DescribeUserOutput$BrokerId" : "Required. The unique ID that Amazon MQ generates for the broker.",
+        "DescribeUserOutput$Username" : "Required. The username of the ActiveMQ user. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "EncryptionOptions$KmsKeyId" : "The symmetric customer master key (CMK) to use for the AWS Key Management Service (KMS). This key is used to encrypt your data at rest. If not provided, Amazon MQ will use a default CMK to encrypt your data.",
+        "EngineVersion$Name" : "Id for the version.",
+        "Error$ErrorAttribute" : "The attribute which caused the error.",
+        "Error$Message" : "The explanation of the error.",
+        "LdapServerMetadataInput$RoleBase" : "Fully qualified name of the directory to search for a user’s groups.",
+        "LdapServerMetadataInput$RoleName" : "Specifies the LDAP attribute that identifies the group name attribute in the object returned from the group membership query.",
+        "LdapServerMetadataInput$RoleSearchMatching" : "The search criteria for groups.",
+        "LdapServerMetadataInput$ServiceAccountPassword" : "Service account password.",
+        "LdapServerMetadataInput$ServiceAccountUsername" : "Service account username.",
+        "LdapServerMetadataInput$UserBase" : "Fully qualified name of the directory where you want to search for users.",
+        "LdapServerMetadataInput$UserRoleName" : "Specifies the name of the LDAP attribute for the user group membership.",
+        "LdapServerMetadataInput$UserSearchMatching" : "The search criteria for users.",
+        "LdapServerMetadataOutput$RoleBase" : "Fully qualified name of the directory to search for a user’s groups.",
+        "LdapServerMetadataOutput$RoleName" : "Specifies the LDAP attribute that identifies the group name attribute in the object returned from the group membership query.",
+        "LdapServerMetadataOutput$RoleSearchMatching" : "The search criteria for groups.",
+        "LdapServerMetadataOutput$ServiceAccountUsername" : "Service account username.",
+        "LdapServerMetadataOutput$UserBase" : "Fully qualified name of the directory where you want to search for users.",
+        "LdapServerMetadataOutput$UserRoleName" : "Specifies the name of the LDAP attribute for the user group membership.",
+        "LdapServerMetadataOutput$UserSearchMatching" : "The search criteria for users.",
+        "ListBrokersOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "ListConfigurationRevisionsOutput$ConfigurationId" : "The unique ID that Amazon MQ generates for the configuration.",
+        "ListConfigurationRevisionsOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "ListConfigurationsOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "ListUsersOutput$BrokerId" : "Required. The unique ID that Amazon MQ generates for the broker.",
+        "ListUsersOutput$NextToken" : "The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.",
+        "LogsSummary$AuditLogGroup" : "The location of the CloudWatch Logs log group where audit logs are sent.",
+        "LogsSummary$GeneralLogGroup" : "The location of the CloudWatch Logs log group where general logs are sent.",
+        "SanitizationWarning$AttributeName" : "The name of the XML attribute that has been sanitized.",
+        "SanitizationWarning$ElementName" : "The name of the XML element that has been sanitized.",
+        "UpdateBrokerInput$EngineVersion" : "The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "UpdateBrokerInput$HostInstanceType" : "The host instance type of the broker to upgrade to. For a list of supported instance types, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html#broker-instance-types",
+        "UpdateBrokerOutput$BrokerId" : "Required. The unique ID that Amazon MQ generates for the broker.",
+        "UpdateBrokerOutput$EngineVersion" : "The version of the broker engine to upgrade to. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html",
+        "UpdateBrokerOutput$HostInstanceType" : "The host instance type of the broker to upgrade to. For a list of supported instance types, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html#broker-instance-types",
+        "UpdateConfigurationInput$Data" : "Required. The base64-encoded XML configuration.",
+        "UpdateConfigurationInput$Description" : "The description of the configuration.",
+        "UpdateConfigurationOutput$Arn" : "Required. The Amazon Resource Name (ARN) of the configuration.",
+        "UpdateConfigurationOutput$Id" : "Required. The unique ID that Amazon MQ generates for the configuration.",
+        "UpdateConfigurationOutput$Name" : "Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.",
+        "UpdateUserInput$Password" : "The password of the user. This value must be at least 12 characters long, must contain at least 4 unique characters, and must not contain commas.",
+        "User$Password" : "Required. The password of the ActiveMQ user. This value must be at least 12 characters long, must contain at least 4 unique characters, and must not contain commas.",
+        "User$Username" : "Required. The username of the ActiveMQ user. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "UserSummary$Username" : "Required. The username of the ActiveMQ user. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.",
+        "WeeklyStartTime$TimeOfDay" : "Required. The time, in 24-hour format.",
+        "WeeklyStartTime$TimeZone" : "The time zone, UTC by default, in either the Country/City format, or the UTC offset format.",
+        "__listOf__string$member" : null,
+        "__mapOf__string$member" : null
+      }
+    },
+    "__timestampIso8601" : {
+      "base" : null,
+      "refs" : {
+        "BrokerSummary$Created" : "The time when the broker was created.",
+        "Configuration$Created" : "Required. The date and time of the configuration revision.",
+        "ConfigurationRevision$Created" : "Required. The date and time of the configuration revision.",
+        "CreateConfigurationOutput$Created" : "Required. The date and time of the configuration.",
+        "DescribeBrokerOutput$Created" : "The time when the broker was created.",
+        "DescribeConfigurationRevisionOutput$Created" : "Required. The date and time of the configuration.",
+        "UpdateConfigurationOutput$Created" : "Required. The date and time of the configuration."
+      }
+    }
+  }
+}

--- a/pkg/generate/testdata/models/apis/mq/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/mq/0000-00-00/generator.yaml
@@ -1,0 +1,11 @@
+ignore:
+  resources:
+    - Configuration
+    - User
+resources:
+  Broker:
+    hooks:
+      sdk_update_pre_build_request:
+        code: if err := rm.requeueIfNotRunning(latest); err != nil { return nil, err }
+      sdk_delete_pre_build_request:
+        template_path: sdk_delete_pre_build_request.go.tpl

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import "os"
+
+// FileExists returns True if the supplied file path exists, false otherwise
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}

--- a/templates/pkg/resource/sdk_find_get_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_find_get_attributes.go.tpl
@@ -3,6 +3,9 @@ func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
+{{- if $hookCode := Hook .CRD "sdk_get_attributes_pre_build_request" }}
+{{ $hookCode }}
+{{- end }}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -16,6 +19,9 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko" 1 }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
+{{- if $hookCode := Hook .CRD "sdk_get_attributes_post_request" }}
+{{ $hookCode }}
+{{- end }}
 	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "{{ .CRD.Ops.GetAttributes.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
@@ -28,6 +34,9 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+{{- if $hookCode := Hook .CRD "sdk_get_attributes_pre_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	rm.setStatusDefaults(ko)
 	return &resource{ko}, nil
 }

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -3,12 +3,18 @@ func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
+{{- if $hookCode := Hook .CRD "sdk_read_many_pre_build_request" }}
+{{ $hookCode }}
+{{- end }}
 	input, err := rm.newListRequestPayload(r)
 	if err != nil {
 		return nil, err
 	}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
+{{- if $hookCode := Hook .CRD "sdk_read_many_post_request" }}
+{{ $hookCode }}
+{{- end }}
 	rm.metrics.RecordAPICall("READ_MANY", "{{ .CRD.Ops.ReadMany.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
@@ -20,6 +26,9 @@ func (rm *resourceManager) sdkFind(
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
+{{- if $hookCode := Hook .CRD "sdk_read_many_pre_set_output" }}
+{{ $hookCode }}
+{{- end }}
 {{ $setCode }}
 	rm.setStatusDefaults(ko)
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.ReadMany }}

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -3,6 +3,9 @@ func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
+{{- if $hookCode := Hook .CRD "sdk_read_one_pre_build_request" }}
+{{ $hookCode }}
+{{- end }}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -16,6 +19,9 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
+{{- if $hookCode := Hook .CRD "sdk_read_one_post_request" }}
+{{ $hookCode }}
+{{- end }}
 	rm.metrics.RecordAPICall("READ_ONE", "{{ .CRD.Ops.ReadOne.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
@@ -27,6 +33,9 @@ func (rm *resourceManager) sdkFind(
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
+{{- if $hookCode := Hook .CRD "sdk_read_one_pre_set_output" }}
+{{ $hookCode }}
+{{- end }}
 {{ $setCode }}
 	rm.setStatusDefaults(ko)
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.ReadOne }}


### PR DESCRIPTION
This patch adds support for a generic callback system into the generator
config that allows controller implementors to specify some code that
should be injected at specific named points in a template. I expect that
eventually this generic hook system will be more useful, flexible and
extensible than the hodge-podge of custom callback methods and overrides
currently in the generator config.

The `pkg/generate/config.ResourceConfig` struct now has a `Hooks` field
of type `map[string]*HookConfig`, with the map keys being named hook
points, e.g. "sdk_update_pre_build_request".

There are two ways to inject code at hook points: inline and via a
template path. The inline method uses the `HookConfig.Code` field which
should contain the Go code that gets injected at a named hook point. The
`HookConfig.TemplatePath` field is used to refer to a template file at a
specific path. The template file is searched for in any of the
TemplateSet's base template paths.

Here's an example of a generator config snippet that uses the inline
code injection method (`HookConfig.Code`) to add a piece of custom code
to be executed in the sdk_update.go.tpl right before the code in the
resource manager's `sdkUpdate` method calls the
`newUpdateRequestPayload()` function:

```yaml
resources:
  Broker:
    hooks:
      sdk_update_pre_build_request:
        code: if err := rm.requeueIfNotRunning(latest); err != nil { return nil, err }
```

Here is the snippet from the templates/pkg/resource/sdk_update.go.tpl
file that shows how we can add these generic named hooks into our
templates at various places:

```
{{- if $hookCode := .CRD.HookCode sdk_update_pre_build_request }}
{{ $hookCode }}
{{ end -}}
```

The controller implementor need only implement the little
`requeueIfNotRunning` function, with the function signature described
in the generator config code block. We no longer need to have function
signatures match for custom callback code since the function signature
for callback code is up to the dev writing the generator.yaml config
file.

Here is an example of the `HookConfig.TemplatePath` being used to refer
to a template file containing some code that is injected at a named hook
point:

```yaml
resources:
  Broker:
    hooks:
      sdk_update_pre_build_request:
        template_path: sdk_update_pre_build_request.go.tpl
```

A controller implementor would simply need to populate a
`sdk_update_pre_build_request.go.tpl` file with the code to be included
at the hook point.

This patch introduces the following hook points in the ACK controller
resource manager code paths:

* sdk_read_one_pre_build_request
* sdk_read_many_pre_build_request
* sdk_get_attributes_pre_build_request
* sdk_create_pre_build_request
* sdk_update_pre_build_request
* sdk_delete_pre_build_request
* sdk_read_one_post_request
* sdk_read_many_post_request
* sdk_get_attributes_post_request
* sdk_create_post_request
* sdk_update_post_request
* sdk_delete_post_request
* sdk_read_one_pre_set_output
* sdk_read_many_pre_set_output
* sdk_get_attributes_pre_set_output
* sdk_create_pre_set_output
* sdk_update_pre_set_output

The "pre_build_request" hooks are called BEFORE the call to construct
the Input shape that is used in the API operation and therefore BEFORE
any call to validate that Input shape.

The "post_request" hooks are called IMMEDIATELY AFTER the API operation
aws-sdk-go client call.  These hooks will have access to a Go variable
named `resp` that refers to the aws-sdk-go client response and a Go
variable named `respErr` that refers to any error returned from the
aws-sdk-go client call.

The "pre_set_output" hooks are called BEFORE the code that processes the
Outputshape (the pkg/generate/code.SetOutput function). These hooks will
have access to a Go variable named `ko` that represents the concrete
Kubernetes CR object that will be returned from the main method
(sdkFind, sdkCreate, etc). This `ko` variable will have been defined
immediately before the "pre_set_output" hooks as a copy of the resource
that is supplied to the main method, like so:

```go
	// Merge in the information we read from the API call above to the copy of
	// the original Kubernetes object we passed to the function
	ko := r.ko.DeepCopy()
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
