### PR TITLE
add multiple template base path functionality

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -85,7 +85,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ts, err := ackgenerate.APIs(g, optTemplatesDir)
+	ts, err := ackgenerate.APIs(g, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -82,7 +82,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ts, err := ackgenerate.Controller(g, optTemplatesDir)
+	ts, err := ackgenerate.Controller(g, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -53,7 +53,6 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(optCacheDir); err != nil {
 		return err
 	}
-	optTemplatesDir = filepath.Join(optTemplatesDir, "crossplane")
 	svcAlias := strings.ToLower(args[0])
 	sdkHelper := model.NewSDKHelper(sdkDir)
 	sdkHelper.APIGroupSuffix = "aws.crossplane.io"
@@ -83,7 +82,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	ts, err := cpgenerate.Crossplane(g, optTemplatesDir)
+	ts, err := cpgenerate.Crossplane(g, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -138,7 +138,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	}
 
 	// generate templates
-	ts, err := olmgenerate.BundleAssets(g, commonMeta, svcConf, version, optTemplatesDir)
+	ts, err := olmgenerate.BundleAssets(g, commonMeta, svcConf, version, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -87,7 +87,7 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	ts, err := ackgenerate.Release(
-		g, optTemplatesDir,
+		g, optTemplateDirs,
 		releaseVersion, optImageRepository, optServiceAccountName,
 	)
 	if err != nil {

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -38,8 +38,8 @@ var (
 	optCacheDir            string
 	optRefreshCache        bool
 	optAWSSDKGoVersion     string
-	defaultTemplatesDir    string
-	optTemplatesDir        string
+	defaultTemplateDirs    []string
+	optTemplateDirs        []string
 	defaultServicesDir     string
 	optServicesDir         string
 	optDryRun              bool
@@ -80,7 +80,7 @@ func init() {
 	for _, tryPath := range tryPaths {
 		if fi, err := os.Stat(tryPath); err == nil {
 			if fi.IsDir() {
-				defaultTemplatesDir = tryPath
+				defaultTemplateDirs = append(defaultTemplateDirs, tryPath)
 				break
 			}
 		}
@@ -100,8 +100,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(
 		&optDryRun, "dry-run", false, "If true, outputs all files to stdout",
 	)
-	rootCmd.PersistentFlags().StringVar(
-		&optTemplatesDir, "templates-dir", defaultTemplatesDir, "Path to directory with templates to use in code generation",
+	rootCmd.PersistentFlags().StringSliceVar(
+		&optTemplateDirs, "template-dirs", defaultTemplateDirs, "Paths to directories with templates to use in code generation. Note that the order in which directories is specified will be used to provide override functionality.",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optServicesDir, "services-dir", defaultServicesDir, "Path to directory to output service-specific code",

--- a/pkg/generate/ack/apis.go
+++ b/pkg/generate/ack/apis.go
@@ -46,7 +46,7 @@ var (
 // generating ACK service controller's apis/ contents
 func APIs(
 	g *generate.Generator,
-	templateBasePath string,
+	templateBasePaths []string,
 ) (*templateset.TemplateSet, error) {
 	enumDefs, err := g.GetEnumDefs()
 	if err != nil {
@@ -62,7 +62,7 @@ func APIs(
 	}
 
 	ts := templateset.New(
-		templateBasePath,
+		templateBasePaths,
 		apisIncludePaths,
 		apisCopyPaths,
 		apisFuncMap,

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -112,7 +112,7 @@ var (
 // for generating ACK service controller implementations
 func Controller(
 	g *generate.Generator,
-	templateBasePath string,
+	templateBasePaths []string,
 ) (*templateset.TemplateSet, error) {
 	crds, err := g.GetCRDs()
 	if err != nil {
@@ -120,7 +120,7 @@ func Controller(
 	}
 
 	ts := templateset.New(
-		templateBasePath,
+		templateBasePaths,
 		controllerIncludePaths,
 		controllerCopyPaths,
 		controllerFuncMap,

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -47,7 +47,7 @@ var (
 // generating an ACK service controller release (Helm artifacts, etc)
 func Release(
 	g *generate.Generator,
-	templateBasePath string,
+	templateBasePaths []string,
 	// releaseVersion is the SemVer string describing the release that the Helm
 	// chart will install
 	releaseVersion string,
@@ -59,7 +59,7 @@ func Release(
 	serviceAccountName string,
 ) (*templateset.TemplateSet, error) {
 	ts := templateset.New(
-		templateBasePath,
+		templateBasePaths,
 		releaseIncludePaths,
 		releaseCopyPaths,
 		releaseFuncMap,

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -27,18 +27,18 @@ import (
 
 var (
 	apisTemplatePaths = []string{
-		"apis/doc.go.tpl",
-		"apis/enums.go.tpl",
-		"apis/groupversion_info.go.tpl",
-		"apis/types.go.tpl",
+		"crossplane/apis/doc.go.tpl",
+		"crossplane/apis/enums.go.tpl",
+		"crossplane/apis/groupversion_info.go.tpl",
+		"crossplane/apis/types.go.tpl",
 	}
 	includePaths = []string{
-		"boilerplate.go.tpl",
-		"apis/enum_def.go.tpl",
-		"apis/type_def.go.tpl",
-		"pkg/sdk_find_read_one.go.tpl",
-		"pkg/sdk_find_read_many.go.tpl",
-		"pkg/sdk_find_get_attributes.go.tpl",
+		"crossplane/boilerplate.go.tpl",
+		"crossplane/apis/enum_def.go.tpl",
+		"crossplane/apis/type_def.go.tpl",
+		"crossplane/pkg/sdk_find_read_one.go.tpl",
+		"crossplane/pkg/sdk_find_read_many.go.tpl",
+		"crossplane/pkg/sdk_find_get_attributes.go.tpl",
 	}
 	copyPaths = []string{}
 	funcMap   = ttpl.FuncMap{
@@ -111,7 +111,7 @@ type templateCRDVars struct {
 // generating Crossplane API types and controller code for an AWS service API
 func Crossplane(
 	g *generate.Generator,
-	templateBasePath string,
+	templateBasePaths []string,
 ) (*templateset.TemplateSet, error) {
 	enumDefs, err := g.GetEnumDefs()
 	if err != nil {
@@ -127,7 +127,7 @@ func Crossplane(
 	}
 
 	ts := templateset.New(
-		templateBasePath,
+		templateBasePaths,
 		includePaths,
 		copyPaths,
 		funcMap,

--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -43,11 +43,11 @@ func BundleAssets(
 	commonMeta CommonMetadata,
 	serviceConfig ServiceConfig,
 	vers string,
-	templateBasePath string,
+	templateBasePaths []string,
 ) (*templateset.TemplateSet, error) {
 
 	ts := templateset.New(
-		templateBasePath,
+		templateBasePaths,
 		csvIncludePaths,
 		csvCopyPaths,
 		csvFuncMap,


### PR DESCRIPTION
We want different teams to have the ability to specify template
overrides for their specific controller or generated codebase.

There are a number of use cases where having the ability to specify
multiple "template search paths" will be useful.

Imagine that the ElastiCache ACK controller team wants to change their
boilerplate.txt content to mention something specific to ElastiCache.
Instead of adding a bunch of conditional statements to the code
generator or new fields to the generator configuration object (which is
already complicated), what if the maintainer team could add their custom
boilerplate text to a `templates/boilerplate.txt` file in the
elasticache-controller source repository and call `ack-generate`
commands like this:

```bash
CODE_GEN_REPO=$GOPATH/src/github.com/aws-controllers-k8s/code-generator
CONTROLLER_REPO=$GOPATH/src/github.com/aws-controllers-k8s/elasticache-controller
ack-generate apis --template-dirs $CONTROLLER_REPO/templates,$CODE_GEN_REPO/templates`
```

and the code generator would simply pick up the boilerplate.txt file in
the elasticache-controller repository and use that instead of the one in
the code-generator repo.

Another use case might be for a service controller team to experiment
with some Go code changes to the standard template files without needing
to modify any code in the code-generator repo itself.

For example, let's say that the S3 controller requires a radically different
set of Go code for its update code path than all the other controllers
and we want to test some ideas but not update the code-generator repo
itself. We could add a `templates/pkg/resource/sdk_update.go.tpl` file
to the s3-controller repository, rebuild the controller and iterate more
quickly.

Finally, there is the use case of having templates containing "hook
code" that is specific to one service controller. Imagine the following
generator config snippet:

```yaml
resources:
  Broker:
    hooks:
      set_update_pre_build_update_request:
        templatePath: hooks/sdk_update_pre_build_update_request.go.tpl
```

And in the service controller, we had a file
`templates/hooks/sdk_update_pre_build_update_request.go.tpl` with the
contents:

```go
if err := rm.requeueIfNotRunning; err != nil {
        return nil, err
}
```

We could call the `ack-generate` passing in multiple template search
base paths like shown above and in this way, we could have
service-specific code placed inside the service controller source
repositories and have our code generation be much more flexible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
