### PR TITLE
adds code generation for field comparisons

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -93,6 +93,9 @@ var (
 		"GoCodeSetDeleteInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
+			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
+		},
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},
@@ -130,6 +133,7 @@ func Controller(
 
 	// First add all the CRD pkg/resource templates
 	targets := []string{
+		"delta.go.tpl",
 		"descriptor.go.tpl",
 		"identifiers.go.tpl",
 		"manager.go.tpl",

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -1,0 +1,586 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/names"
+)
+
+// CompareResource returns the Go code that traverses a set of two Resources,
+// adding differences between the two Resources to an `ackcompare.Delta`
+//
+// By default, we produce Go code that only looks at the fields in a resource's
+// Spec, since those are the fields that represent the desired state of a
+// resource. When we make a ReadOne/ReadMany/GetAttributes call to a backend
+// AWS API, we construct a Resource and set the Spec fields to values contained
+// in the ReadOne/ReadMany/GetAttributes Output shape. This Resource,
+// constructed from the Read operation, is compared to the Resource we got from
+// the Kubernetes API server's event bus. The code that is returned from this
+// function is the code that compares those two Resources.
+func CompareResource(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like "a.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like "b.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := "\n"
+
+	fieldConfigs := cfg.ResourceFields(r.Names.Original)
+
+	// We need a deterministic order to traverse our top-level fields...
+	specFieldNames := []string{}
+	for fieldName := range r.SpecFields {
+		specFieldNames = append(specFieldNames, fieldName)
+	}
+	sort.Strings(specFieldNames)
+
+	for _, fieldName := range specFieldNames {
+		specField := r.SpecFields[fieldName]
+		indent := strings.Repeat("\t", indentLevel)
+		firstResAdaptedVarName := firstResVarName + cfg.PrefixConfig.SpecField
+		firstResAdaptedVarName += "." + specField.Names.Camel
+		secondResAdaptedVarName := secondResVarName + cfg.PrefixConfig.SpecField
+		secondResAdaptedVarName += "." + specField.Names.Camel
+
+		var compareConfig *ackgenconfig.CompareFieldConfig
+		fieldConfig := fieldConfigs[fieldName]
+		if fieldConfig != nil {
+			compareConfig = fieldConfig.Compare
+		}
+
+		if compareConfig != nil && compareConfig.IsIgnored {
+			continue
+		}
+
+		// this is the "path" to the field within the structs being compared.
+		// This is passed down into the compareXXX functions recursively and
+		// appended to with each level of nested structs we recurse into.
+		fieldPath := strings.TrimPrefix(
+			cfg.PrefixConfig.SpecField+"."+specField.Names.Camel, ".",
+		)
+
+		memberShapeRef := specField.ShapeRef
+		memberShape := memberShapeRef.Shape
+
+		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name == nil) {
+		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		// }
+		nilCode := compareNil(
+			compareConfig,
+			memberShape,
+			deltaVarName,
+			firstResAdaptedVarName,
+			secondResAdaptedVarName,
+			fieldPath,
+			indentLevel,
+		)
+
+		if nilCode != "" {
+			// else {
+			out += nilCode + " else {\n"
+			indentLevel++
+		} else {
+			out += "\n"
+		}
+
+		switch memberShape.Type {
+		case "structure":
+			// Recurse through all the struct's fields and subfields, building
+			// nested conditionals and calls to `delta.Add()`...
+			out += compareStruct(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel,
+			)
+		case "list":
+			// Returns Go code that compares all the elements of the slice fields...
+			out += compareSlice(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel,
+			)
+		case "map":
+			// Returns Go code that compares all the elements of the map fields...
+			out += compareMap(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel,
+			)
+		default:
+			//   if *a.ko.Spec.Name != *b.ko.Spec.Name) {
+			//     delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+			//   }
+			out += compareScalar(
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel,
+			)
+		}
+		// }
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
+		indentLevel--
+	}
+	return out
+}
+
+// compareNil outputs Go code that compares two field values for nullability
+// and, if there is a nil difference, adds the difference to a variable
+// represeting the `ackcompare.Delta`
+//
+// Output code will look something like this:
+//
+// if ackcompare.HasNilDifferenceStringP(a.ko.Spec.Name, b.ko.Spec.Name == nil) {
+//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+// }
+func compareNil(
+	// struct informing code generator how to compare the field values
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Author.Name". This does not include the top-level Spec or Status
+	// struct.
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	switch shape.Type {
+	case "list", "blob":
+		// for slice types, there is no nilability test. Instead, the normal
+		// value test checks length of slices.
+		return ""
+	case "boolean", "string", "character", "byte", "short", "integer", "long",
+		"float", "double", "timestamp", "structure", "map", "jsonvalue":
+		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		out += fmt.Sprintf(
+			"%sif ackcompare.HasNilDifference(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+	default:
+		panic("Unsupported shape type in generate.code.compareNil: " + shape.Type)
+	}
+	//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	out += fmt.Sprintf(
+		"%s\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+	)
+	// }
+	out += fmt.Sprintf(
+		"%s}", indent,
+	)
+
+	return out
+}
+
+// compareScalar outputs Go code that compares two scalar values from two
+// resource fields and, if there is a difference, adds the difference to a
+// variable representing an `ackcompare.Delta`.
+//
+// Output code will look something like this:
+//
+//   if *a.ko.Spec.Name != *b.ko.Spec.Name) {
+//     delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+//   }
+func compareScalar(
+	// struct informing code generator how to compare the field values
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Author.Name". This does not include the top-level Spec or Status
+	// struct.
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	switch shape.Type {
+	case "boolean", "string", "character", "byte", "short", "integer", "long", "float", "double":
+		// if *a.ko.Spec.Name != *b.ko.Spec.Name {
+		out += fmt.Sprintf(
+			"%sif *%s != *%s {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+	case "timestamp":
+		// if !a.ko.Spec.CreatedAt.Equal(b.ko.Spec.CreatedAt) {
+		out += fmt.Sprintf(
+			"%sif !%s.Equal(%s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+	default:
+		panic("Unsupported shape type in generate.code.compareScalar: " + shape.Type)
+	}
+	//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	out += fmt.Sprintf(
+		"%s\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+	)
+	// }
+	out += fmt.Sprintf(
+		"%s}\n", indent,
+	)
+
+	return out
+}
+
+// compareMap outputs Go code that compares two map values from two resource
+// fields and, if there is a difference, adds the difference to a variable
+// representing an `ackcompare.Delta`.
+//
+// Output code will look something like this:
+//
+//   if !ackcompare.MapStringStringEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+//     delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+//   }
+func compareMap(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// struct informing code generator how to compare the field values
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Author.Name". This does not include the top-level Spec or Status
+	// struct.
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	keyType := shape.KeyRef.Shape.Type
+
+	if keyType != "string" {
+		panic("generate.code.compareMap cannot deal with non-string key types: " + keyType)
+	}
+
+	valType := shape.ValueRef.Shape.Type
+
+	switch valType {
+	case "string":
+		// if !ackcompare.MapStringStringEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		out += fmt.Sprintf(
+			"%sif !ackcompare.MapStringStringEqual(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+	case "structure":
+		// TODO(jaypipes): Implement this by walking the keys and struct values
+		// and comparing each struct individually, building up the fieldPath
+		// appropriately...
+	default:
+		panic("Unsupported shape type in generate.code.compareMap: " + shape.Type)
+	}
+	//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	out += fmt.Sprintf(
+		"%s\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+	)
+	// }
+	out += fmt.Sprintf(
+		"%s}\n", indent,
+	)
+
+	return out
+}
+
+// compareSlice outputs Go code that compares two slice values from two
+// resource fields and, if there is a difference, adds the difference to a
+// variable representing an `ackcompare.Delta`.
+//
+// Output code will look something like this:
+//
+//   if !ackcompare.SliceStringPEqual(a.ko.Spec.SecurityGroupIDs, b.ko.Spec.SecurityGroupIDs) {
+//     delta.Add("Spec.SecurityGroupIDs", a.ko.Spec.SecurityGroupIDs, b.ko.Spec.SecurityGroupIDs)
+//   }
+func compareSlice(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// struct informing code generator how to compare the field values
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Author.Name". This does not include the top-level Spec or Status
+	// struct.
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	elemType := shape.MemberRef.Shape.Type
+
+	switch elemType {
+	case "string":
+		// if !ackcompare.SliceStringPEqual(a.ko.Spec.SecurityGroupIDs, b.ko.Spec.SecurityGroupIDs) {
+		out += fmt.Sprintf(
+			"%sif !ackcompare.SliceStringPEqual(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+	case "structure":
+		// TODO(jaypipes): Implement this by walking the slice of struct values
+		// and comparing each struct individually, building up the fieldPath
+		// appropriately...
+	default:
+		panic("Unsupported shape type in generate.code.compareSlice: " + shape.Type)
+	}
+	//   delta.Add("Spec.SecurityGroupIDs", a.ko.Spec.SecurityGroupIDs, b.ko.Spec.SecurityGroupIDs)
+	out += fmt.Sprintf(
+		"%s\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+	)
+	// }
+	out += fmt.Sprintf(
+		"%s}\n", indent,
+	)
+
+	return out
+}
+
+// compareStruct outputs Go code that compares two struct values from two
+// resource fields and, if there is a difference, adds the difference to a
+// variable representing an `ackcompare.Delta`.
+func compareStruct(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// struct informing code generator how to compare the field values
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Name". See `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Author.Name". This does not include the top-level Spec or Status
+	// struct.
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+
+	fieldConfigs := cfg.ResourceFields(r.Names.Original)
+
+	for _, memberName := range shape.MemberNames() {
+		memberShapeRef := shape.MemberRefs[memberName]
+		// TODO(jaypipes): This is fragile. We actually need to have a way of
+		// normalizing names in a lossless fashion...
+		memberNames := names.New(memberName)
+		memberNameClean := memberNames.Camel
+
+		// this is the "path" to the field within the structs being compared.
+		// This is passed down into the compareXXX functions recursively and
+		// appended to with each level of nested structs we recurse into.
+		memberFieldPath := fieldPath + "." + memberNameClean
+		indent := strings.Repeat("\t", indentLevel)
+		firstResAdaptedVarName := firstResVarName + "." + memberNameClean
+		secondResAdaptedVarName := secondResVarName + "." + memberNameClean
+
+		var compareConfig *ackgenconfig.CompareFieldConfig
+		fieldConfig := fieldConfigs[memberFieldPath]
+		if fieldConfig != nil {
+			compareConfig = fieldConfig.Compare
+		}
+
+		if compareConfig != nil && compareConfig.IsIgnored {
+			continue
+		}
+
+		memberShape := memberShapeRef.Shape
+
+		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name == nil) {
+		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		// }
+		nilCode := compareNil(
+			compareConfig,
+			memberShape,
+			deltaVarName,
+			firstResAdaptedVarName,
+			secondResAdaptedVarName,
+			memberFieldPath,
+			indentLevel,
+		)
+
+		if nilCode != "" {
+			// else {
+			out += nilCode + " else {\n"
+			indentLevel++
+		} else {
+			out += "\n"
+		}
+		switch memberShape.Type {
+		case "structure":
+			// Recurse through all the struct's fields and subfields, building
+			// nested conditionals and calls to `delta.Add()`...
+			out += compareStruct(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				memberFieldPath,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				indentLevel,
+			)
+		case "list":
+			// Returns Go code that compares all the elements of the slice fields...
+			out += compareSlice(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				memberFieldPath,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				indentLevel,
+			)
+		case "map":
+			// Returns Go code that compares all the elements of the map fields...
+			out += compareMap(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				memberFieldPath,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				indentLevel,
+			)
+		default:
+			//   if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			//     delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+			//   }
+			out += compareScalar(
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				memberFieldPath,
+				indentLevel,
+			)
+		}
+		// }
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
+		indentLevel--
+	}
+	return out
+}

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -107,8 +107,11 @@ func CompareResource(
 		)
 
 		if nilCode != "" {
-			// else {
-			out += nilCode + " else {\n"
+			// else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+			out += fmt.Sprintf(
+				"%s else if %s != nil && %s != nil {\n",
+				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
+			)
 			indentLevel++
 		} else {
 			out += "\n"
@@ -518,8 +521,11 @@ func compareStruct(
 		)
 
 		if nilCode != "" {
-			// else {
-			out += nilCode + " else {\n"
+			// else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+			out += fmt.Sprintf(
+				"%s else if %s != nil && %s != nil {\n",
+				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
+			)
 			indentLevel++
 		} else {
 			out += "\n"

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -1,0 +1,110 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestCompareResource_S3_Bucket(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.ACL, b.ko.Spec.ACL) {
+		delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+	} else {
+		if *a.ko.Spec.ACL != *b.ko.Spec.ACL {
+			delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
+		delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
+	} else {
+		if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
+			delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+		} else {
+			if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
+				delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+			}
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
+		delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+	} else {
+		if *a.ko.Spec.GrantFullControl != *b.ko.Spec.GrantFullControl {
+			delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.GrantRead, b.ko.Spec.GrantRead) {
+		delta.Add("Spec.GrantRead", a.ko.Spec.GrantRead, b.ko.Spec.GrantRead)
+	} else {
+		if *a.ko.Spec.GrantRead != *b.ko.Spec.GrantRead {
+			delta.Add("Spec.GrantRead", a.ko.Spec.GrantRead, b.ko.Spec.GrantRead)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP) {
+		delta.Add("Spec.GrantReadACP", a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP)
+	} else {
+		if *a.ko.Spec.GrantReadACP != *b.ko.Spec.GrantReadACP {
+			delta.Add("Spec.GrantReadACP", a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite) {
+		delta.Add("Spec.GrantWrite", a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite)
+	} else {
+		if *a.ko.Spec.GrantWrite != *b.ko.Spec.GrantWrite {
+			delta.Add("Spec.GrantWrite", a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP) {
+		delta.Add("Spec.GrantWriteACP", a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP)
+	} else {
+		if *a.ko.Spec.GrantWriteACP != *b.ko.Spec.GrantWriteACP {
+			delta.Add("Spec.GrantWriteACP", a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket) {
+		delta.Add("Spec.ObjectLockEnabledForBucket", a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket)
+	} else {
+		if *a.ko.Spec.ObjectLockEnabledForBucket != *b.ko.Spec.ObjectLockEnabledForBucket {
+			delta.Add("Spec.ObjectLockEnabledForBucket", a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket)
+		}
+	}
+`
+	assert.Equal(
+		expected,
+		code.CompareResource(
+			crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+		),
+	)
+}

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -32,20 +32,15 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Bucket")
 	require.NotNil(crd)
 
+	// The ACL field is ignored in the S3 generator config and therefore should
+	// not appear in this output.
 	expected := `
-	if ackcompare.HasNilDifference(a.ko.Spec.ACL, b.ko.Spec.ACL) {
-		delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
-	} else {
-		if *a.ko.Spec.ACL != *b.ko.Spec.ACL {
-			delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
 		delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
-	} else {
+	} else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
 		if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
 			delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
-		} else {
+		} else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil {
 			if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
 				delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
 			}
@@ -53,49 +48,49 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
 		delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
-	} else {
+	} else if a.ko.Spec.GrantFullControl != nil && b.ko.Spec.GrantFullControl != nil {
 		if *a.ko.Spec.GrantFullControl != *b.ko.Spec.GrantFullControl {
 			delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantRead, b.ko.Spec.GrantRead) {
 		delta.Add("Spec.GrantRead", a.ko.Spec.GrantRead, b.ko.Spec.GrantRead)
-	} else {
+	} else if a.ko.Spec.GrantRead != nil && b.ko.Spec.GrantRead != nil {
 		if *a.ko.Spec.GrantRead != *b.ko.Spec.GrantRead {
 			delta.Add("Spec.GrantRead", a.ko.Spec.GrantRead, b.ko.Spec.GrantRead)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP) {
 		delta.Add("Spec.GrantReadACP", a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP)
-	} else {
+	} else if a.ko.Spec.GrantReadACP != nil && b.ko.Spec.GrantReadACP != nil {
 		if *a.ko.Spec.GrantReadACP != *b.ko.Spec.GrantReadACP {
 			delta.Add("Spec.GrantReadACP", a.ko.Spec.GrantReadACP, b.ko.Spec.GrantReadACP)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite) {
 		delta.Add("Spec.GrantWrite", a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite)
-	} else {
+	} else if a.ko.Spec.GrantWrite != nil && b.ko.Spec.GrantWrite != nil {
 		if *a.ko.Spec.GrantWrite != *b.ko.Spec.GrantWrite {
 			delta.Add("Spec.GrantWrite", a.ko.Spec.GrantWrite, b.ko.Spec.GrantWrite)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP) {
 		delta.Add("Spec.GrantWriteACP", a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP)
-	} else {
+	} else if a.ko.Spec.GrantWriteACP != nil && b.ko.Spec.GrantWriteACP != nil {
 		if *a.ko.Spec.GrantWriteACP != *b.ko.Spec.GrantWriteACP {
 			delta.Add("Spec.GrantWriteACP", a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
-	} else {
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
 		if *a.ko.Spec.Name != *b.ko.Spec.Name {
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket) {
 		delta.Add("Spec.ObjectLockEnabledForBucket", a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket)
-	} else {
+	} else if a.ko.Spec.ObjectLockEnabledForBucket != nil && b.ko.Spec.ObjectLockEnabledForBucket != nil {
 		if *a.ko.Spec.ObjectLockEnabledForBucket != *b.ko.Spec.ObjectLockEnabledForBucket {
 			delta.Add("Spec.ObjectLockEnabledForBucket", a.ko.Spec.ObjectLockEnabledForBucket, b.ko.Spec.ObjectLockEnabledForBucket)
 		}

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -105,6 +105,17 @@ type SourceFieldConfig struct {
 	Path string `json:"path"`
 }
 
+// CompareFieldConfig informs the code generator how to compare two values of a
+// field
+type CompareFieldConfig struct {
+	// IsIgnored indicates the field should be ignored when comparing a
+	// resource
+	IsIgnored bool `json:"is_ignored"`
+	// NilEqualsEmptyString indicates a nil string pointer and empty string
+	// should be considered equal for the purposes of comparison
+	NilEqualsEmptyString bool `json:"nil_equals_empty_string"`
+}
+
 // FieldConfig contains instructions to the code generator about how
 // to interpret the value of an Attribute and how to map it to a CRD's Spec or
 // Status field
@@ -142,4 +153,7 @@ type FieldConfig struct {
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`
+	// Compare instructs the code generator how to produce code that compares
+	// the value of the field in two resources
+	Compare *CompareFieldConfig `json:"compare,omitempty"`
 }

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -111,9 +111,9 @@ type CompareFieldConfig struct {
 	// IsIgnored indicates the field should be ignored when comparing a
 	// resource
 	IsIgnored bool `json:"is_ignored"`
-	// NilEqualsEmptyString indicates a nil string pointer and empty string
-	// should be considered equal for the purposes of comparison
-	NilEqualsEmptyString bool `json:"nil_equals_empty_string"`
+	// NilEqualsZeroValue indicates a nil pointer and zero-value pointed-to
+	// value should be considered equal for the purposes of comparison
+	NilEqualsZeroValue bool `json:"nil_equals_zero_value"`
 }
 
 // FieldConfig contains instructions to the code generator about how

--- a/pkg/generate/testdata/models/apis/s3/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/s3/0000-00-00/generator.yaml
@@ -18,3 +18,9 @@ resources:
     list_operation:
       match_fields:
         - Name
+    fields:
+      ACL:
+        # This is to test the ackcompare field ignore functionality. This
+        # should NOT be in a production generator.yaml...
+        compare:
+          is_ignored: true

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -1,0 +1,23 @@
+{{ template "boilerplate" }}
+
+package {{ .CRD.Names.Snake }}
+
+import (
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// newResourceDelta returns a new `ackcompare.Delta` used to compare two
+// resources
+func newResourceDelta(
+    a *resource,
+    b *resource,
+) *ackcompare.Delta {
+    delta := ackcompare.NewDelta()
+    if ((a == nil && b != nil) ||
+            (a != nil && b == nil)) {
+        delta.Add("", a, b)
+        return delta
+    }
+{{ GoCodeCompare .CRD "delta" "a.ko" "b.ko" 1}}
+    return delta
+}

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -5,8 +5,6 @@ package {{ .CRD.Names.Snake }}
 import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sapirt "k8s.io/apimachinery/pkg/runtime"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -52,51 +50,10 @@ func (d *resourceDescriptor) ResourceFromRuntimeObject(
 	}
 }
 
-// Equal returns true if the two supplied AWSResources have the same content.
-// The underlying types of the two supplied AWSResources should be the same. In
-// other words, the Equal() method should be called with the same concrete
-// implementing AWSResource type
-func (d *resourceDescriptor) Equal(
-	a acktypes.AWSResource,
-	b acktypes.AWSResource,
-) bool {
-	ac := a.(*resource)
-	bc := b.(*resource)
-	opts := []cmp.Option{cmpopts.EquateEmpty()}
-	{{- if .CRD.CompareIgnoredFields }}
-	opts = append(opts, cmpopts.IgnoreFields(*ac.ko,
-		{{- range $fieldPath := .CRD.CompareIgnoredFields }}
-		{{ printf "%q" $fieldPath }},
-		{{- end }}
-	))
-	{{- end }}
-	return cmp.Equal(ac.ko, bc.ko, opts...)
-}
-
-// Diff returns a Reporter which provides the difference between two supplied
-// AWSResources. The underlying types of the two supplied AWSResources should
-// be the same. In other words, the Diff() method should be called with the
-// same concrete implementing AWSResource type
-func (d *resourceDescriptor) Diff(
-	a acktypes.AWSResource,
-	b acktypes.AWSResource,
-) *ackcompare.Reporter {
-	ac := a.(*resource)
-	bc := b.(*resource)
-	var diffReporter ackcompare.Reporter
-	opts := []cmp.Option{
-		cmp.Reporter(&diffReporter),
-		cmp.AllowUnexported(svcapitypes.{{ .CRD.Kind }}{}),
-	}
-	{{- if .CRD.CompareIgnoredFields }}
-	opts = append(opts, cmpopts.IgnoreFields(*ac.ko,
-		{{- range $fieldPath := .CRD.CompareIgnoredFields }}
-		{{ printf "%q" $fieldPath }},
-		{{- end }}
-	))
-	{{- end }}
-	cmp.Equal(ac.ko, bc.ko, opts...)
-	return &diffReporter
+// Delta returns an `ackcompare.Delta` object containing the difference between
+// one `AWSResource` and another.
+func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta {
+    return newResourceDelta(a.(*resource), b.(*resource))
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -112,7 +112,7 @@ func (rm *resourceManager) Update(
 	ctx context.Context,
 	resDesired acktypes.AWSResource,
 	resLatest acktypes.AWSResource,
-	diffReporter *ackcompare.Reporter,
+	delta *ackcompare.Delta,
 ) (acktypes.AWSResource, error) {
 	desired := rm.concreteResource(resDesired)
 	latest := rm.concreteResource(resLatest)
@@ -120,7 +120,7 @@ func (rm *resourceManager) Update(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, delta)
 	if err != nil {
 		return rm.onError(latest, err)
 	}

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -11,7 +11,7 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion}}"
 )
 
-// resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
+// resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
 // interface
 type resource struct {
 	// The Kubernetes-native CR representing the resource

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -3,11 +3,11 @@ func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
 	latest *resource,
-	diffReporter *ackcompare.Reporter,
+	delta *ackcompare.Delta,
 ) (*resource, error) {
 {{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
 {{ if $customMethod }}
-	customResp, customRespErr := rm.{{ $customMethod }}(ctx, desired, latest, diffReporter)
+	customResp, customRespErr := rm.{{ $customMethod }}(ctx, desired, latest, delta)
 	if customResp != nil || customRespErr != nil {
 		return customResp, customRespErr
 	}

--- a/templates/pkg/resource/sdk_update_custom.go.tpl
+++ b/templates/pkg/resource/sdk_update_custom.go.tpl
@@ -3,8 +3,8 @@ func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
 	latest *resource,
-	diffReporter *ackcompare.Reporter,
+	delta *ackcompare.Delta,
 ) (*resource, error) {
-	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
+	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, delta)
 }
 {{- end -}}

--- a/templates/pkg/resource/sdk_update_not_implemented.go.tpl
+++ b/templates/pkg/resource/sdk_update_not_implemented.go.tpl
@@ -3,7 +3,7 @@ func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
 	latest *resource,
-	diffReporter *ackcompare.Reporter,
+	delta *ackcompare.Delta,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...
 	return nil, ackerr.NotImplemented

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -3,7 +3,7 @@ func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
 	latest *resource,
-	diffReporter *ackcompare.Reporter,
+	delta *ackcompare.Delta,
 ) (*resource, error) {
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the


### PR DESCRIPTION
 adds code generation for field comparisons

Adds new code generation functions to `pkg/generate/code` that output Go
code that compares fields of various types and calls `delta.Add()` if a
difference is detected.

For fields with underlying scalar types, the generated code looks like
this:

```go
if *a.ko.Spec.Name != *b.ko.Spec.Name) {
        delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
}
```

For non-scalar types, generated code recurses over the fields and/or
calls specialized comparison functions in the runtime library's
`pkg/compare` module. Here is an example of a complex underlying field
type and what the generated code might look like:

```go
if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
        delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
} else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
        if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
                delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
        } else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
                if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
                        delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
                }
        }
}
```

Adds plumbing to the `pkg/resource/depscriptor.go.tpl` template that
implements the `Delta()` method on the
`github.com/aws-controllers-k8s/runtime/pkg/types.AWSResourceDescriptor`
interface-implementing `resource` struct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
