### PR TITLE
Use AWS_SDK_GO_VERSION to set the cache version used to generate APIs/CRDs

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -142,6 +142,7 @@ fi
 
 if [ -n "$AWS_SDK_GO_VERSION" ]; then
     ag_args="$ag_args --aws-sdk-go-version $AWS_SDK_GO_VERSION"
+    apis_args="$apis_args --aws-sdk-go-version $AWS_SDK_GO_VERSION"
 fi
 
 echo "Building Kubernetes API objects for $SERVICE"


### PR DESCRIPTION
Followup to: #8 

Description of changes:
- Use `AWS_SDK_GO_VERSION` to set the cache version used to generate APIs/CRDs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
