### PR TITLE
Fix resource delta code generation

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -220,6 +220,7 @@ func compareNil(
 	case "list", "blob":
 		// for slice types, there is no nilability test. Instead, the normal
 		// value test checks length of slices.
+		return ""
 	case "boolean", "string", "character", "byte", "short", "integer", "long",
 		"float", "double", "timestamp", "structure", "map", "jsonvalue":
 		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
@@ -365,6 +366,7 @@ func compareMap(
 		// TODO(jaypipes): Implement this by walking the keys and struct values
 		// and comparing each struct individually, building up the fieldPath
 		// appropriately...
+		return ""
 	default:
 		panic("Unsupported shape type in generate.code.compareMap: " + shape.Type)
 	}

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -169,11 +169,13 @@ func CompareResource(
 				indentLevel,
 			)
 		}
-		// }
-		out += fmt.Sprintf(
-			"%s}\n", indent,
-		)
-		indentLevel--
+		if nilCode != "" {
+			// }
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
+			indentLevel--
+		}
 	}
 	return out
 }
@@ -218,7 +220,6 @@ func compareNil(
 	case "list", "blob":
 		// for slice types, there is no nilability test. Instead, the normal
 		// value test checks length of slices.
-		return ""
 	case "boolean", "string", "character", "byte", "short", "integer", "long",
 		"float", "double", "timestamp", "structure", "map", "jsonvalue":
 		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
@@ -431,6 +432,7 @@ func compareSlice(
 		// TODO(jaypipes): Implement this by walking the slice of struct values
 		// and comparing each struct individually, building up the fieldPath
 		// appropriately...
+		return ""
 	default:
 		panic("Unsupported shape type in generate.code.compareSlice: " + shape.Type)
 	}
@@ -582,11 +584,13 @@ func compareStruct(
 				indentLevel,
 			)
 		}
-		// }
-		out += fmt.Sprintf(
-			"%s}\n", indent,
-		)
-		indentLevel--
+		if nilCode != "" {
+			// }
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
+			indentLevel--
+		}
 	}
 	return out
 }


### PR DESCRIPTION
Issue N/A

Changes:
- Fix resourec delta code generation when `nilCode` is empty
- Return an empty string for non implemented cases

Description:

When generating sagemaker controller using `make build-controller SERVICE=sagemaker` we can observe the following error:
```
Building Kubernetes API objects for sagemaker
Generating deepcopy code for sagemaker
Generating custom resource definitions for sagemaker
Building service controller for sagemaker
Error: template: /home/amine/source/github.com/aws-controllers-k8s/code-generator/templates/pkg/resource/delta.go.tpl:21:3: executing "/home/amine/source/github.com/aws-controllers-k8s/code-generator/templates/pkg/resource/delta.go.tpl" at <GoCodeCompare .CRD "delta" "a.ko" "b.ko" 1>: error calling GoCodeCompare: strings: negative Repeat count
make: *** [Makefile:31: build-controller] Error 1
exit status 2
```
The reason behind this error was the `code.CompareResource` function that decreases `indentLevel` and added a closing bracket for a code that is not generated. The concerned block of code is `else if * != nil && * != nil {` statement generated when `nilCode` is not empty - see: https://github.com/aws-controllers-k8s/code-generator/blob/99008660b665867ec69d7829be819411ee90b6cf/pkg/generate/code/compare.go#L109-L118
To solve this problem we need to add a closing bracket and decrease `indentLevel` only when `nilCode` is not empty.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
