### PR TITLE
add docstrings to CRD fields

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -16,6 +16,9 @@ import (
 // {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Spec struct {
 	{{- range $fieldName, $field := .CRD.SpecFields }}
+	{{- if $field.ShapeRef }}
+	{{ $field.ShapeRef.Documentation }}
+	{{- end }}
 	{{ if $field.IsRequired }} // +kubebuilder:validation:Required
 	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }}"`
 	{{- else }} {{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"` {{ end }}
@@ -34,6 +37,9 @@ type {{ .CRD.Kind }}Status struct {
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
+	{{- if $field.ShapeRef }}
+	{{ $field.ShapeRef.Documentation }}
+	{{- end }}
 	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
 {{- end }}
 }


### PR DESCRIPTION
Uses the aws-sdk-go private/model/api.Shape.Documentation functionality
to write out docstrings for individual fields used in a CRD. Crossplane
was already doing this; ACK CRDs are now caught up.

Issue aws-controllers-k8s/community#723

Tested locally with S3 controller and works like a charm.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
