### PR TITLE
refer runtime v0.0.5 with Delta() support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.4
+	github.com/aws-controllers-k8s/runtime v0.0.5
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/runtime v0.0.4 h1:FXKrez7/x88wprW8a68uM02vGGuz3VPzEJLQ7AZsaxE=
 github.com/aws-controllers-k8s/runtime v0.0.4/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.0.5 h1:WdcnMNdgagF2MMPQRbDJ5OEzMMgHraCJqvvFj4Sx/5g=
+github.com/aws-controllers-k8s/runtime v0.0.5/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -15,11 +15,14 @@ package ack
 
 import (
 	"testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/require"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 )
 
 type fakeIdentifiers struct{}
@@ -34,6 +37,38 @@ func (ids *fakeIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	return &owner
 }
 
+type fakeDescriptor struct{}
+
+func (fd *fakeDescriptor) GroupKind() *metav1.GroupKind {
+	return nil
+}
+
+func (fd *fakeDescriptor) EmptyRuntimeObject() k8srt.Object {
+	return nil
+}
+
+func (fd *fakeDescriptor) ResourceFromRuntimeObject(o k8srt.Object) acktypes.AWSResource {
+	return nil
+}
+
+func (fd *fakeDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta {
+ 	return nil
+}
+
+func (fd *fakeDescriptor) UpdateCRStatus(acktypes.AWSResource) (bool, error) {
+	return false, nil
+}
+
+func (fd *fakeDescriptor) IsManaged(acktypes.AWSResource) bool {
+	return false
+}
+
+func (fd *fakeDescriptor) MarkManaged(acktypes.AWSResource) {
+}
+
+func (fd *fakeDescriptor) MarkUnmanaged(acktypes.AWSResource) {
+}
+
 // This test is mostly just a hack to introduce a Go module dependency between
 // the ACK runtime library and the code generator. The code generator doesn't
 // actually depend on Go code in the ACK runtime, but it *produces* templated
@@ -42,4 +77,5 @@ func TestRuntimeDependency(t *testing.T) {
 	require := require.New(t)
 
 	require.Implements((*acktypes.AWSResourceIdentifiers)(nil), new(fakeIdentifiers))
+	require.Implements((*acktypes.AWSResourceDescriptor)(nil), new(fakeDescriptor))
 }


### PR DESCRIPTION
Issue #, if available:

`code-generator` refers to `v0.0.4` version of `runtime`.
The `code-generator` templates use new `Delta` functionality.
But as the `Delta` functionality corresponds to `v0.0.5` version of `runtime`; `code-generator` needs to refer to `v0.0.5` version of runtime.

Description of changes:

* Updated `go.mod` file to refer `v0.0.5` version of `runtime`
* Updated unit test to check resource descriptor methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
