### PR TITLE
handle renamed fields in SetResource generation

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -197,7 +197,12 @@ func SetResource(
 		var found bool
 		var targetMemberShapeRef *awssdkmodel.ShapeRef
 		targetAdaptedVarName := targetVarName
-		f, found = r.SpecFields[memberName]
+
+		// Check that the field has potentially been renamed
+		renamedName, _ := r.InputFieldRename(
+			op.Name, memberName,
+		)
+		f, found = r.SpecFields[renamedName]
 		if found {
 			targetAdaptedVarName += cfg.PrefixConfig.SpecField
 			if !performSpecUpdate {
@@ -452,7 +457,11 @@ func setResourceReadMany(
 		var found bool
 		var targetMemberShapeRef *awssdkmodel.ShapeRef
 		targetAdaptedVarName := targetVarName
-		f, found = r.SpecFields[memberName]
+		// Check that the field has potentially been renamed
+		renamedName, _ := r.InputFieldRename(
+			op.Name, memberName,
+		)
+		f, found = r.SpecFields[renamedName]
 		if found {
 			targetAdaptedVarName += cfg.PrefixConfig.SpecField
 		} else {

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -174,8 +174,14 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 			if memberShapeRef.Shape == nil {
 				return nil, ErrNilShapePointer
 			}
-			memberNames := names.New(memberName)
-			if _, found := crd.SpecFields[memberName]; found {
+			// Check that the field in the output shape isn't the same as
+			// fields in the input shape (where the input shape has potentially
+			// been renamed)
+			renamedName, _ := crd.InputFieldRename(
+				createOp.Name, memberName,
+			)
+			memberNames := names.New(renamedName)
+			if _, found := crd.SpecFields[renamedName]; found {
 				// We don't put fields that are already in the Spec struct into
 				// the Status struct
 				continue

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -116,7 +116,7 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 				createOp.Name, memberName,
 			)
 			memberNames := names.New(renamedName)
-			memberNames.ModelOrginal = memberName
+			memberNames.ModelOriginal = memberName
 			if memberName == "Attributes" && g.cfg.UnpacksAttributesMap(crdName) {
 				crd.UnpackAttributes()
 				continue

--- a/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
@@ -1,3 +1,18 @@
 ignore:
   shape_names:
     - DBSecurityGroupMembershipList
+resources:
+  DBSubnetGroup:
+    renames:
+      operations:
+        DescribeDBSubnetGroups:
+          input_fields:
+            DBSubnetGroupName: Name
+            DBSubnetGroupDescription: Description
+        CreateDBSubnetGroup:
+          input_fields:
+            DBSubnetGroupName: Name
+            DBSubnetGroupDescription: Description
+        DeleteDBSubnetGroup:
+          input_fields:
+            DBSubnetGroupName: Name

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -42,7 +42,7 @@ func (f *Field) IsRequired() bool {
 	if f.FieldConfig != nil && f.FieldConfig.IsRequired != nil {
 		return *f.FieldConfig.IsRequired
 	}
-	return util.InStrings(f.Names.ModelOrginal, f.CRD.Ops.Create.InputRef.Shape.Required)
+	return util.InStrings(f.Names.ModelOriginal, f.CRD.Ops.Create.InputRef.Shape.Required)
 }
 
 // newField returns a pointer to a new Field object

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -147,12 +147,12 @@ var goKeywords = []string{
 }
 
 type Names struct {
-	ModelOrginal string
-	Original     string
-	Camel        string
-	CamelLower   string
-	Lower        string
-	Snake        string
+	ModelOriginal string
+	Original      string
+	Camel         string
+	CamelLower    string
+	Lower         string
+	Snake         string
 }
 
 func New(original string) Names {


### PR DESCRIPTION
If fields were renamed in some operations, the code generated for
`SetResource()` was not properly looking up the renamed field. This
patch updates `SetResource()` to first check if the field has 
renamed for the referred Operation and if so, look up the CRDField
object in the CRD.SpecFields collection instead of the StatusFields
collection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
