### PR TITLE
Refactor MapStringStringEqual to MapStringStringPEqual

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -315,7 +315,7 @@ func compareScalar(
 //
 // Output code will look something like this:
 //
-//   if !ackcompare.MapStringStringEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+//   if !ackcompare.MapStringStringPEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 //     delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 //   }
 func compareMap(
@@ -357,9 +357,9 @@ func compareMap(
 
 	switch valType {
 	case "string":
-		// if !ackcompare.MapStringStringEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		// if !ackcompare.MapStringStringPEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 		out += fmt.Sprintf(
-			"%sif !ackcompare.MapStringStringEqual(%s, %s) {\n",
+			"%sif !ackcompare.MapStringStringPEqual(%s, %s) {\n",
 			indent, firstResVarName, secondResVarName,
 		)
 	case "structure":


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/729

Description of changes: Refactor `MapStringStringEqual` references to `MapStringStringPEqual`, so that it compares the string pointers rather than expecting pure strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
