### PR TITLE
Update Chart.yaml for split repositories

### DIFF
--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -3,13 +3,15 @@ name: ack-{{ .ServiceIDClean }}-controller
 description: A Helm chart for the ACK service controller for {{ .ServiceIDClean }}
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}
-home: https://github.com/aws/aws-controllers-k8s
+home: https://github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
-  - https://github.com/aws/aws-controllers-k8s
+  - https://github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
 maintainers:
   - name: ACK Admins
-    url: https://github.com/orgs/aws/teams/aws-controllers-for-kubernetes-ack-admins
+    url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
+  - name: {{ .ServiceIDClean }} Admins
+    url:https://github.com/orgs/aws-controllers-k8s/teams/{{ .ServiceIDClean }}-maintainer
 keywords:
   - aws
   - kubernetes


### PR DESCRIPTION
Issue #, if available: None

Description of changes: The helm `Chart.yaml` files still referenced the older repository structure. 
I also added a reference to the maintainer of the service controller team.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
