### PR TITLE
hook for post_set_output

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -45,6 +45,11 @@ code paths:
 * sdk_get_attributes_pre_set_output
 * sdk_create_pre_set_output
 * sdk_update_pre_set_output
+* sdk_read_one_post_set_output
+* sdk_read_many_post_set_output
+* sdk_get_attributes_post_set_output
+* sdk_create_post_set_output
+* sdk_update_post_set_output
 
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE
@@ -69,6 +74,11 @@ that is supplied to the main method, like so:
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 ```
+
+The "post_set_output" hooks are called AFTER the the information from the API call
+is merged with the copy of the original Kubernetes object. These hooks will
+have access to the updated Kubernetes object `ko`, the response of the API call
+(and the original Kubernetes CR object if its sdkUpdate)
 */
 
 // ResourceHookCode returns a string with custom callback code for a resource

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -83,6 +83,9 @@ func (rm *resourceManager) sdkCreate(
 			return nil, err
 		}
 	{{ end }}
+{{- if $hookCode := Hook .CRD "sdk_create_post_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_find_get_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_find_get_attributes.go.tpl
@@ -38,6 +38,9 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 	rm.setStatusDefaults(ko)
+{{- if $hookCode := Hook .CRD "sdk_get_attributes_post_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -38,6 +38,9 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 {{ end }}
+{{- if $hookCode := Hook .CRD "sdk_read_many_post_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -45,6 +45,9 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 {{ end }}
+{{- if $hookCode := Hook .CRD "sdk_read_one_post_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -45,6 +45,9 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 {{ end }}
+{{- if $hookCode := Hook .CRD "sdk_update_post_set_output" }}
+{{ $hookCode }}
+{{- end }}
 	return &resource{ko}, nil
 }
 


### PR DESCRIPTION
### Description of changes:
Adds a hook for post_set_output

### Testing
Locally using sagemaker controller
```
TrainingJob:
    ...
    hooks:
      sdk_delete_pre_build_request:
        template_path: training_job/sdk_delete_pre_build_request.go.tpl
      sdk_create_post_set_output:
        template_path: training_job/sdk_create_post_set_output.go.tpl
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
