### PR TITLE
pin code-generator to runtime v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.5
+	github.com/aws-controllers-k8s/runtime v0.1.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.0.4 h1:FXKrez7/x88wprW8a68uM02vGGuz3VPzEJLQ7AZsaxE=
-github.com/aws-controllers-k8s/runtime v0.0.4/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws-controllers-k8s/runtime v0.0.5 h1:WdcnMNdgagF2MMPQRbDJ5OEzMMgHraCJqvvFj4Sx/5g=
-github.com/aws-controllers-k8s/runtime v0.0.5/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.1.0 h1:XTBQf7hn0792yuCRy58IZpbZoGMrGCpSK2mZXkof5W4=
+github.com/aws-controllers-k8s/runtime v0.1.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -15,14 +15,15 @@ package ack
 
 import (
 	"testing"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/require"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 type fakeIdentifiers struct{}
@@ -52,7 +53,7 @@ func (fd *fakeDescriptor) ResourceFromRuntimeObject(o k8srt.Object) acktypes.AWS
 }
 
 func (fd *fakeDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta {
- 	return nil
+	return nil
 }
 
 func (fd *fakeDescriptor) UpdateCRStatus(acktypes.AWSResource) (bool, error) {
@@ -67,6 +68,9 @@ func (fd *fakeDescriptor) MarkManaged(acktypes.AWSResource) {
 }
 
 func (fd *fakeDescriptor) MarkUnmanaged(acktypes.AWSResource) {
+}
+
+func (fd *fakeDescriptor) MarkAdopted(acktypes.AWSResource) {
 }
 
 // This test is mostly just a hack to introduce a Go module dependency between


### PR DESCRIPTION
Updates our go.mod reference to runtime v0.1.0 (adopted resource
reconciler) and updates our runtime_test.go to implement the runtime
v0.1.0 AWSResourceDescriptor interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
