### PR TITLE
allow "nested fields" to be configured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/mod v0.4.1
 	k8s.io/apimachinery v0.20.1
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 )

--- a/pkg/generate/mq_test.go
+++ b/pkg/generate/mq_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package generate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestMQ_Broker(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "mq")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("Broker", crds)
+	require.NotNil(crd)
+
+	// We want to verify that the `Password` field of the `Spec.Users` field
+	// (which is a `[]*User` type) is findable in the CRD's Fields collection
+	// by the path `Spec.Users..Password` and that the FieldConfig associated
+	// with this Field is marked as a SecretKeyReference.
+	passFieldPath := "Users..Password"
+	passField, found := crd.Fields[passFieldPath]
+	require.True(found)
+	require.NotNil(passField.FieldConfig)
+	assert.True(passField.FieldConfig.IsSecret)
+}

--- a/pkg/generate/testdata/models/apis/mq/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/mq/0000-00-00/generator.yaml
@@ -9,3 +9,6 @@ resources:
         code: if err := rm.requeueIfNotRunning(latest); err != nil { return nil, err }
       sdk_delete_pre_build_request:
         template_path: sdk_delete_pre_build_request.go.tpl
+    fields:
+      Users..Password:
+        is_secret: true


### PR DESCRIPTION
When designing the `pkg/generate/config.FieldConfig` object, we really
only thought about (and tested for) "top-level fields". In other words,
fields that were on the CR's `Spec` or `Status` objects.

However, as we've added more configurability to the code-generator
regarding fields -- including marking fields as printable or secrets --
we're now limited substantially by our initial implementation that only
allows referring to top-level fields.

For example, we cannot mark a field as being a secret field if that
field is a subfield of one of these top-level fields. Concretely, this
means that with the existing generator configuration, we cannot support
configuring AmazonMQ's `Broker` CRD's `Spec.Users.Password` field as a
SecretKeyReference because `Password` is not a top-level field. It is
instead a field *of* a top-level field -- a "nested field" -- and
therefore our simplistic configuration system isn't able to tell the
code generator to replace the `string` Go type with
`*ackv1alpha1.SecretKeyReference` like it [does][secref-inject] for
top-level fields.

[secref-inject]: https://github.com/aws-controllers-k8s/code-generator/blob/94186d92e778792ccba11b5db3478e037256b36b/pkg/model/field.go#L61-L64

The solution to this dilemma is contained in this PR and involves
reworking our generator model in a couple ways:

1) The `pkg/model.CRD` struct now has a `Fields` attribute to go along
   with the existing `SpecFields` and `StatusFields` attributes.
   `CRD.Fields` is a `map[string]*Field` like `SpecFields` and
   `StatusFields`, but unlike those attributes, the `Fields` map keys
   are field *paths* and not the original aws-sdk-go Shape member names.
   When inspecting the AWS service API model as we do in
   `pkg/generate.Generator:GetCRDs()`, we now construct a field path for
   each `pkg/model.Field` object that corresponds to "where" in the CR the
   field is. For example, `Spec.Name` or `Status.BrokerInstances`

2) The `pkg/generate.Generator` has been updated with a
   `processNestedFields()` method to populate the new field-path-keyed
   `CRD.Fields` map with nested fields, making it possible to refer in our
   generator config, by field path, to fields that are not directly in the
   Status or Spec object.

A following patch will update the `Generator.GetTypeDefs()` method to
look up field configuration by this new field-path-based map and replace
`string` with `*ackv1alpha1.SecretKeyReference` when the field is a
secret field (Issue aws-controllers-k8s/community#743).

Issue aws-controllers-k8s/community#748

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
