### PR TITLE
Replace hardcoded APIVersion with contextual APIVersion

### DIFF
--- a/templates/config/samples/sample.yaml.tpl
+++ b/templates/config/samples/sample.yaml.tpl
@@ -1,6 +1,6 @@
 {{- range .Samples -}}
 ---
-apiVersion: s3.services.k8s.aws/v1alpha1
+apiVersion: {{$.APIGroup}}/{{$.APIVersion}}
 kind: {{.Kind}}
 metadata:
   name: example


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

Hi folks! 

**Description of changes:**

I inadvertently left in a hard-coded reference to the S3 APIVersion for the samples that are auto-generated from olmconfig. The result is that I was ending up with samples for kinds that weren't organized under the correct contextual APIVersion (in my case, I've been testing OLM generation against SageMaker as it has a wide variety of CRDs).

Discovered this bug in relation to the work being done here: https://github.com/aws-controllers-k8s/community/issues/744 though it's not directly related to the goal of that issue (i.e. that bug should not be closed in relation to this PR).

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
👍 