### PR TITLE
Fix case and spelling of CSV icon-related keys and adjust description template var for a cleaner olmconfig

### DIFF
--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -25,8 +25,7 @@ spec:
       displayName: {{.Kind}}
       description: {{.Kind}} represents the state of an AWS {{$.ServiceID}} {{.Kind}} resource.
     {{- end}}
-  description: |
-    {{ .Description }}
+  description: '{{ .Description }}'
   displayName: {{ .DisplayName}}
   icon:
   {{- range .Icon}}

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -30,8 +30,8 @@ spec:
   displayName: {{ .DisplayName}}
   icon:
   {{- range .Icon}}
-  - base64Data: {{ .Data }}
-    medatype: {{ .MediaType }}
+  - base64data: {{ .Data }}
+    mediatype: {{ .MediaType }}
   {{- end}}
   install:
     spec:


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**
No Issue created in association with this as it's a fairly minor bugfix.

**Description of changes:**

The `ClusterServiceVersion.spec.icon[0]` values had a spelling/case error that was preventing the bundles from being generated with the right values. This corrects those two bugs.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
:+1:
