### PR TITLE
Use camel case name in SpecIdentifierField

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -365,7 +365,7 @@ func (r *CRD) SpecIdentifierField() *string {
 	}
 	for memberName := range r.SpecFields {
 		if util.InStrings(memberName, lookup) {
-			return &memberName
+			return &r.SpecFields[memberName].Names.Camel
 		}
 	}
 	return nil


### PR DESCRIPTION
In `crd.go.tpl` template file `field.Names.Camel` is used this results in `replicationGroupID` to be used as spec param rather than `replicationGroupId`.

Updating this method to be consistent with `crd.go.tpl` and to unblock elasticache code generation. 

Without fix

```
func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
	if identifier.NameOrID == nil {
		return ackerrors.MissingNameIdentifier
	}
	r.ko.Spec.ReplicationGroupId = identifier.NameOrID
	return nil
}
```

With fix

```
func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
	if identifier.NameOrID == nil {
		return ackerrors.MissingNameIdentifier
	}
	r.ko.Spec.ReplicationGroupID = identifier.NameOrID
	return nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
