### PR TITLE
Add check for CRD list types in model.HasConflictingTypeName

### DIFF
--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -274,6 +274,7 @@ func (a *SDKAPI) HasConflictingTypeName(typeName string, cfg *ackgenconfig.Confi
 	cleanTypeName := names.New(typeName).Camel
 	crdNames := a.CRDNames(cfg)
 	crdResourceNames := []string{}
+	crdListResourceNames := []string{}
 	crdSpecNames := []string{}
 	crdStatusNames := []string{}
 
@@ -282,10 +283,12 @@ func (a *SDKAPI) HasConflictingTypeName(typeName string, cfg *ackgenconfig.Confi
 		crdResourceNames = append(crdResourceNames, cleanResourceName)
 		crdSpecNames = append(crdSpecNames, cleanResourceName+"Spec")
 		crdStatusNames = append(crdStatusNames, cleanResourceName+"Status")
+		crdListResourceNames = append(crdListResourceNames, cleanResourceName+"List")
 	}
 	return util.InStrings(cleanTypeName, crdResourceNames) ||
 		util.InStrings(cleanTypeName, crdSpecNames) ||
-		util.InStrings(cleanTypeName, crdStatusNames)
+		util.InStrings(cleanTypeName, crdStatusNames) ||
+		util.InStrings(cleanTypeName, crdListResourceNames)
 }
 
 // ServiceID returns the exact `metadata.serviceId` attribute for the AWS


### PR DESCRIPTION
Issue #, if available:

Description of changes:
When generating controllers for the CloudFront API using the crossplane pipeline, I realized that we do not account for CRD List types (e.g., `DistributionList`) in `model.HasConflictingTypeName`, which results in such types being declared multiple times in generated code. This PR attempts to prevent this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
