### PR TITLE
Update Operator SDK scorecard image tags and disable two scorecard test tags

### DIFF
--- a/templates/config/scorecard/patches/basic.config.yaml
+++ b/templates/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/templates/config/scorecard/patches/olm.config.yaml
+++ b/templates/config/scorecard/patches/olm.config.yaml
@@ -18,16 +18,21 @@
     labels:
       suite: olm
       test: olm-crds-have-validation-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
-    - scorecard-test
-    - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.7.1
-    labels:
-      suite: olm
-      test: olm-crds-have-resources-test
+## This test is disabled as the current state of the ACK
+## is such that the controllers themselves don't manage
+## other resources (e.g. pods, deployments) in the cluster
+## where they are deployed.
+## This test is not currently a requirement for certification.
+# - op: add
+#   path: /stages/0/tests/-
+#   value:
+#     entrypoint:
+#     - scorecard-test
+#     - olm-crds-have-resources
+#     image: quay.io/operator-framework/scorecard-test:v1.7.1
+#     labels:
+#       suite: olm
+#       test: olm-crds-have-resources-test
 - op: add
   path: /stages/0/tests/-
   value:
@@ -38,13 +43,18 @@
     labels:
       suite: olm
       test: olm-spec-descriptors-test
-- op: add
-  path: /stages/0/tests/-
-  value:
-    entrypoint:
-    - scorecard-test
-    - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.7.1
-    labels:
-      suite: olm
-      test: olm-status-descriptors-test
+## This test is disabled as the status descriptor annotations are
+## derived from API markers on the *Status type definitions, or scaffolded
+## by the olm generator which cannot currently be done with the 
+## input data provided to the olm generator.
+## This test is not currently a requirement for certification.
+# - op: add
+#   path: /stages/0/tests/-
+#   value:
+#     entrypoint:
+#     - scorecard-test
+#     - olm-status-descriptors
+#     image: quay.io/operator-framework/scorecard-test:v1.7.1
+#     labels:
+#       suite: olm
+#       test: olm-status-descriptors-test

--- a/templates/config/scorecard/patches/olm.config.yaml
+++ b/templates/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
     labels:
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The Operator SDK Scorecard tests run against an OLM bundle to help validate that the contents looks appropriate. The scorecard container appears to be built with an image tag corresponding with the version of Operator SDK that's used.

The dependency installation script has been updated - https://github.com/aws-controllers-k8s/community/pull/762 - and this PR updates the code generated to match.

In addition two of the built-in tests are currently out of scope for the code-generator logic.
* **olm-crds-have-resources-test** - I believe this to be out of scope because this is a cloud integration operator, and therefore each controller is unlikely to have local resources that OLM should need to represent via the console.
* **olm-status-descriptors-test** - This _is_ useful, but at the moment there's no easy way of determining what status descriptors should be used to represent status entry without adding additional markers to the API definitions. This might be something we can look to integrate in the future, but as I don't believe it's a strict requirement of operator certification, I think we can skip it for now.

I've commented them instead of removing them so that we can consider integrating them in the future. 

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
👍 
