### PR TITLE
[WIP] Add hooks after input request creation, but before request is submitted

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -34,6 +34,12 @@ code paths:
 * sdk_create_pre_build_request
 * sdk_update_pre_build_request
 * sdk_delete_pre_build_request
+* sdk_read_one_post_build_request
+* sdk_read_many_post_build_request
+* sdk_get_attributes_post_build_request
+* sdk_create_post_build_request
+* sdk_update_post_build_request
+* sdk_delete_post_build_request
 * sdk_read_one_post_request
 * sdk_read_many_post_request
 * sdk_get_attributes_post_request
@@ -54,6 +60,9 @@ code paths:
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE
 any call to validate that Input shape.
+
+The "post_build_request" hooks are called AFTER the call to construct 
+the Input shape but BEFORE the API operation. 
 
 The "post_request" hooks are called IMMEDIATELY AFTER the API operation
 aws-sdk-go client call.  These hooks will have access to a Go variable

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -59,6 +59,9 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+{{- if $hookCode := Hook .CRD "sdk_create_post_build_request" }}
+{{ $hookCode }} (ctx, r, input)
+{{- end }}	
 {{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko" 1 false }}
 	{{ if not ( Empty $createCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_create_post_request" }}

--- a/templates/pkg/resource/sdk_find_get_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_find_get_attributes.go.tpl
@@ -17,6 +17,9 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+{{- if $hookCode := Hook .CRD "sdk_get_attributes_post_build_request" }}
+{{ $hookCode }}
+{{- end }}
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko" 1 }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_get_attributes_post_request" }}

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -10,6 +10,9 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+{{- if $hookCode := Hook .CRD "sdk_read_many_post_build_request" }}
+{{ $hookCode }} (ctx, r, input)
+{{- end }}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_many_post_request" }}

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -17,6 +17,9 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+{{- if $hookCode := Hook .CRD "sdk_read_one_post_build_request" }}
+{{ $hookCode }} (ctx, r, input)
+{{- end }}
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_one_post_request" }}
@@ -52,7 +55,7 @@ func (rm *resourceManager) sdkFind(
 }
 
 // requiredFieldsMissingFromReadOneInput returns true if there are any fields
-// for the ReadOne Input shape that are required by not present in the
+// for the ReadOne Input shape that are required but not present in the
 // resource's Spec or Status
 func (rm *resourceManager) requiredFieldsMissingFromReadOneInput(
 	r *resource,

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -20,7 +20,9 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
-
+{{- if $hookCode := Hook .CRD "sdk_update_pre_build_request" }}
+{{ $hookCode }} (ctx, r, input)
+{{- end }}
 {{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 false }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_update_post_request" }}


### PR DESCRIPTION
Issue #, if available:
TBD

Description of changes:
The current version of this code uses `{{ $hookCode }} (ctx, r, input)` but this should be unnecessary hence do-not-merge yet!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
