### PR TITLE
add doc support to nested field types

### DIFF
--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -356,6 +356,7 @@ func (g *Generator) GetTypeDefs() ([]*ackmodel.TypeDef, error) {
 			continue
 		}
 		tdefs = append(tdefs, &ackmodel.TypeDef{
+			Shape: shape,
 			Names: tdefNames,
 			Attrs: attrs,
 		})

--- a/pkg/model/type_def.go
+++ b/pkg/model/type_def.go
@@ -14,6 +14,8 @@
 package model
 
 import (
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
 	"github.com/aws-controllers-k8s/code-generator/pkg/names"
 )
 
@@ -29,4 +31,5 @@ const (
 type TypeDef struct {
 	Names names.Names
 	Attrs map[string]*Attr
+	Shape *awssdkmodel.Shape
 }

--- a/templates/apis/type_def.go.tpl
+++ b/templates/apis/type_def.go.tpl
@@ -1,6 +1,12 @@
 {{- define "type_def" -}}
+{{- if .Shape.Documentation }}
+{{ .Shape.Documentation }}
+{{- end }}
 type {{ .Names.Camel }} struct {
 {{- range $attrName, $attr := .Attrs }}
+	{{- if $attr.Shape.Documentation }}
+	{{ $attr.Shape.Documentation }}
+	{{- end }}
 	{{ $attr.Names.Camel }} {{ $attr.GoType }} `json:"{{ $attr.Names.CamelLower }},omitempty"`
 {{- end }}
 }


### PR DESCRIPTION
Adds documentation to the nested field types in `apis/$VERSION/types.go`
output for the structs and the fields within those structs. The fields
within the structs are modeled with the `pkg/model.Attr` struct, so I
added a `Shape` field to that in order to bring in the aws-sdk-go
`private/model/api.Shape` that has a `Documentation` field on it...

Tested on ECR controller and works properly even for nested fields:

```
[jaypipes@thelio ecr-controller]$ git diff apis/v1alpha1/types.go
diff --git a/apis/v1alpha1/types.go b/apis/v1alpha1/types.go
index d384431..39c4f13 100644
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -16,35 +16,81 @@
+// The encryption configuration for the repository. This determines how the
+// contents of your repository are encrypted at rest.
+//
+// By default, when no encryption configuration is set or the AES256 encryption
+// type is used, Amazon ECR uses server-side encryption with Amazon S3-managed
+// encryption keys which encrypts your data at rest using an AES-256 encryption
+// algorithm. This does not require any action on your part.
+//
+// For more control over the encryption of the contents of your repository,
+// you can use server-side encryption with customer master keys (CMKs) stored
+// in AWS Key Management Service (AWS KMS) to encrypt your images. For more
+// information, see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+// in the Amazon Elastic Container Registry User Guide.
 type EncryptionConfiguration struct {
        EncryptionType *string `json:"encryptionType,omitempty"`
        KMSKey         *string `json:"kmsKey,omitempty"`
 }
 
+// An object representing an Amazon ECR image.
 type Image struct {
        RegistryID     *string `json:"registryID,omitempty"`
        RepositoryName *string `json:"repositoryName,omitempty"`
 }
 
+// An object that describes an image returned by a DescribeImages operation.
 type ImageDetail struct {
        RegistryID     *string `json:"registryID,omitempty"`
        RepositoryName *string `json:"repositoryName,omitempty"`
 }
 
+// Contains information about an image scan finding.
 type ImageScanFinding struct {
        URI *string `json:"uri,omitempty"`
 }
 
+// The image scanning configuration for a repository.
 type ImageScanningConfiguration struct {
        ScanOnPush *bool `json:"scanOnPush,omitempty"`
 }
 
+// An array of objects representing the details of a replication destination.
+type ReplicationDestination struct {
+       RegistryID *string `json:"registryID,omitempty"`
+}
+
+// An object representing a repository.
 type Repository_SDK struct {
-       CreatedAt                  *metav1.Time                `json:"createdAt,omitempty"`
-       EncryptionConfiguration    *EncryptionConfiguration    `json:"encryptionConfiguration,omitempty"`
+       CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+       // The encryption configuration for the repository. This determines how the
+       // contents of your repository are encrypted at rest.
+       //
+       // By default, when no encryption configuration is set or the AES256 encryption
+       // type is used, Amazon ECR uses server-side encryption with Amazon S3-managed
+       // encryption keys which encrypts your data at rest using an AES-256 encryption
+       // algorithm. This does not require any action on your part.
+       //
+       // For more control over the encryption of the contents of your repository,
+       // you can use server-side encryption with customer master keys (CMKs) stored
+       // in AWS Key Management Service (AWS KMS) to encrypt your images. For more
+       // information, see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+       // in the Amazon Elastic Container Registry User Guide.
+       EncryptionConfiguration *EncryptionConfiguration `json:"encryptionConfiguration,omitempty"`
+       // The image scanning configuration for a repository.
        ImageScanningConfiguration *ImageScanningConfiguration `json:"imageScanningConfiguration,omitempty"`
        ImageTagMutability         *string                     `json:"imageTagMutability,omitempty"`
        RegistryID                 *string                     `json:"registryID,omitempty"`
@@ -53,6 +99,10 @@ type Repository_SDK struct {
        RepositoryURI              *string                     `json:"repositoryURI,omitempty"`
 }
 
+// The metadata that you apply to a resource to help you categorize and organize
+// them. Each tag consists of a key and an optional value, both of which you
+// define. Tag keys can have a maximum character length of 128 characters, and
+// tag values can have a maximum length of 256 characters.
 type Tag struct {
        Key   *string `json:"key,omitempty"`
        Value *string `json:"value,omitempty"`
```

Related: aws-controllers-k8s/community#723

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
