### PR TITLE
Use ExportedName property of operation calls instead of Name

### DIFF
--- a/templates/crossplane/apis/types.go.tpl
+++ b/templates/crossplane/apis/types.go.tpl
@@ -5,18 +5,15 @@
 package {{ .APIVersion }}
 
 import (
-	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
-	_ = ackv1alpha1.AWSAccountID("")
 )
-{{- range $typeDef := .TypeDefs }}
+
+{{ range $typeDef := .TypeDefs }}
 
 {{ template "type_def" $typeDef }}
 {{- end -}}

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -67,7 +67,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	if err := e.preObserve(ctx, cr, input); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "pre-observe failed")
 	}
-	resp, err := e.client.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.ReadOne.ExportedName }}WithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalObservation{ResourceExists: false}, awsclient.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
@@ -76,7 +76,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	if err := e.preObserve(ctx, cr, input); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "pre-observe failed")
 	}
-	resp, err := e.client.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.GetAttributes.ExportedName }}WithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalObservation{ResourceExists: false}, awsclient.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
@@ -85,7 +85,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	if err := e.preObserve(ctx, cr, input); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "pre-observe failed")
 	}
-	resp, err := e.client.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.ReadMany.ExportedName }}WithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalObservation{ResourceExists: false}, awsclient.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
@@ -124,7 +124,7 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	if err := e.preCreate(ctx, cr, input); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "pre-create failed")
 	}
-	resp, err := e.client.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.Create.ExportedName }}WithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
@@ -142,7 +142,7 @@ func (e *external) Update(ctx context.Context, mg cpresource.Managed) (managed.E
 	if err := e.preUpdate(ctx, cr, input); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, "pre-update failed")
 	}
-	resp, err := e.client.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.Update.ExportedName }}WithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
 	}
@@ -167,7 +167,7 @@ func (e *external) Delete(ctx context.Context, mg cpresource.Managed) error {
 	if ignore {
 		return nil
 	}
-	resp, err := e.client.{{ .CRD.Ops.Delete.Name }}WithContext(ctx, input)
+	resp, err := e.client.{{ .CRD.Ops.Delete.ExportedName }}WithContext(ctx, input)
 	return e.postDelete(ctx, cr, resp, awsclient.Wrap(cpresource.Ignore(IsNotFound, err), errDelete))
 	{{- else }}
 	return e.delete(ctx, mg)

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -63,11 +63,11 @@ func (rm *resourceManager) sdkCreate(
 {{ $hookCode }} 
 {{- end }}	
 {{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko" 1 false }}
-	{{ if not ( Empty $createCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
+	{{ if not ( Empty $createCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_create_post_request" }}
 {{ $hookCode }}
 {{- end }}
-	rm.metrics.RecordAPICall("CREATE", "{{ .CRD.Ops.Create.Name }}", respErr)
+	rm.metrics.RecordAPICall("CREATE", "{{ .CRD.Ops.Create.ExportedName }}", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}

--- a/templates/pkg/resource/sdk_find_get_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_find_get_attributes.go.tpl
@@ -21,11 +21,11 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko" 1 }}
-	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
+	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_get_attributes_post_request" }}
 {{ $hookCode }}
 {{- end }}
-	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "{{ .CRD.Ops.GetAttributes.Name }}", respErr)
+	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "{{ .CRD.Ops.GetAttributes.ExportedName }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
 			return nil, ackerr.NotFound

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -14,11 +14,11 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 true }}
-	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
+	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_many_post_request" }}
 {{ $hookCode }}
 {{- end }}
-	rm.metrics.RecordAPICall("READ_MANY", "{{ .CRD.Ops.ReadMany.Name }}", respErr)
+	rm.metrics.RecordAPICall("READ_MANY", "{{ .CRD.Ops.ReadMany.ExportedName }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
 			return nil, ackerr.NotFound

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -21,11 +21,11 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko" 1 true }}
-	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
+	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_one_post_request" }}
 {{ $hookCode }}
 {{- end }}
-	rm.metrics.RecordAPICall("READ_ONE", "{{ .CRD.Ops.ReadOne.Name }}", respErr)
+	rm.metrics.RecordAPICall("READ_ONE", "{{ .CRD.Ops.ReadOne.ExportedName }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
 			return nil, ackerr.NotFound

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -24,11 +24,11 @@ func (rm *resourceManager) sdkUpdate(
 {{ $hookCode }} 
 {{- end }}
 {{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 false }}
-	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
+	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_update_post_request" }}
 {{ $hookCode }}
 {{- end }}
-	rm.metrics.RecordAPICall("UPDATE", "{{ .CRD.Ops.Update.Name }}", respErr)
+	rm.metrics.RecordAPICall("UPDATE", "{{ .CRD.Ops.Update.ExportedName }}", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -21,8 +21,8 @@ func (rm *resourceManager) sdkUpdate(
 	// contain any useful information. Instead, below, we'll be returning a
 	// DeepCopy of the supplied desired state, which should be fine because
 	// that desired state has been constructed from a call to GetAttributes...
-	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.Name }}WithContext(ctx, input)
-	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "{{ .CRD.Ops.SetAttributes.Name }}", respErr)
+	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.ExportedName }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "{{ .CRD.Ops.SetAttributes.ExportedName }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessagePrefixCheck .CRD 404 }}{
 			// Technically, this means someone deleted the backend resource in


### PR DESCRIPTION
Description of changes: `Name` can return the name of the call with a date as we experienced in `CloudFront` service (like `GetDistribution2020_05_31WithContext`). Tested this statement with `rds` service and no change was seen.

I made the change in both ACK and Crossplane pipelines. It shouldn't affect the existing controllers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
