### PR TITLE
Using '_' variable for working around the unused import build time error.

### DIFF
--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -12,6 +12,11 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion}}"
 )
 
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
+)
+
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
 // interface
 type resource struct {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Using '_' variable for working around the unused import build time error.

Sometimes the following code does not use the block with `ackerrors.MissingNameIdentifier` in resource.go.tpl and generates the build time errors.

```
func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
{{- if $idField := .CRD.SpecIdentifierField }}
	if identifier.NameOrID == nil {
		return ackerrors.MissingNameIdentifier
	}
	r.ko.Spec.{{ $idField }} = identifier.NameOrID
{{- else }}
	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
{{- end }}
	return nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
