### PR TITLE
Add additional keys as identifiers

### DIFF
--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -3,9 +3,14 @@
 package {{ .CRD.Names.Snake }}
 
 import (
+	"reflect"
+	"strings"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+{{- if $idField := .CRD.SpecIdentifierField }}
 	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
+{{- end }}
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
@@ -67,7 +72,8 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 }
 
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
-// resource identifier
+// resource identifier and any additional spec fields that may be required for
+// describing the resource.
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
 {{- if $idField := .CRD.SpecIdentifierField }}
 	if identifier.NameOrID == nil {
@@ -75,7 +81,29 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Spec.{{ $idField }} = identifier.NameOrID
 {{- else }}
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
 	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 {{- end }}
+
+	if len(identifier.AdditionalKeys) == 0 {
+		return nil
+	}
+
+	specRef := reflect.Indirect(reflect.ValueOf(&r.ko.Spec))
+	specType := specRef.Type()
+
+	// Iterate over spec fields and associate corresponding json tags
+	for i := 0; i < specRef.NumField(); i++ {
+		// Get only the first field in the json tag (the field name)
+		jsonTag := strings.Split(specType.Field(i).Tag.Get("json"), ",")[0]
+		val, ok := identifier.AdditionalKeys[jsonTag]
+		if ok {
+			// Set the corresponding field with the value from the mapping
+			specRef.FieldByName(specType.Field(i).Name).Set(reflect.ValueOf(val))
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/766

Description of changes:
When setting identifiers on a given resource, dynamically add all additional keys according to their json tag names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
