### PR TITLE
Add code generation for type comparison

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -96,6 +96,9 @@ var (
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeIsEqual": func(typeDef *ackmodel.TypeDef, sourceVarName string, targetVarName string, indentLevel int) string {
+			return code.IsEqualTypeDef(typeDef, sourceVarName, targetVarName, indentLevel)
+		},
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},
@@ -169,6 +172,20 @@ func Controller(
 		return nil, err
 	}
 
+	typeDefs, err := g.GetTypeDefs()
+	if err != nil {
+		return nil, err
+	}
+	equalVars := templateCompareVars{
+		metaVars,
+		typeDefs,
+	}
+
+	// Next add the template for pkg/compare/struct.go file
+	if err = ts.Add("pkg/compare/struct.go", "pkg/compare/struct.go.tpl", equalVars); err != nil {
+		return nil, err
+	}
+
 	// Next add the template for pkg/version/version.go file
 	if err = ts.Add("pkg/version/version.go", "pkg/version/version.go.tpl", nil); err != nil {
 		return nil, err
@@ -202,4 +219,11 @@ func Controller(
 type templateCmdVars struct {
 	templateset.MetaVars
 	SnakeCasedCRDNames []string
+}
+
+// templateCompareVars contains template variables for the template that outputs Go
+// code for equality/comparison helper functions.
+type templateCompareVars struct {
+	templateset.MetaVars
+	TypeDefs []*ackmodel.TypeDef
 }

--- a/pkg/generate/code/equal.go
+++ b/pkg/generate/code/equal.go
@@ -1,0 +1,263 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
+	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/names"
+)
+
+// IsEqualTypeDef returns Go code that checks the equality of two struct types.
+// The generated code returns false at the first spotted difference.
+//
+// Output code will look something like this:
+//
+//  if ackcompare.HasNilDifference(a.CreatedAt, b.CreatedAt) {
+//  	return false
+//  } else if a.CreatedAt != nil && b.CreatedAt != nil {
+//  	if *a.CreatedAt != *b.CreatedAt {
+//  		return false
+//  	}
+//  }
+//  if ackcompare.HasNilDifference(a.EncryptionConfiguration, b.EncryptionConfiguration) {
+//  	return false
+//  } else if a.EncryptionConfiguration != nil && b.EncryptionConfiguration != nil {
+//  	if !IsEqualEncryptionConfiguration(a.EncryptionConfiguration, b.EncryptionConfiguration) {
+//  		return false
+//  	}
+//  }
+func IsEqualTypeDef(
+	typeDef *ackmodel.TypeDef,
+	// String representing the name of the variable that represents the first
+	// object under comparison. This will typically be something like "a"
+	firstVarName string,
+	// String representing the name of the variable that represents the second
+	// object under comparison. This will typically be something like "b".
+	secondVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+
+	// We need a deterministic order to loop over attributes
+	attrsNames := []string{}
+	for attrName := range typeDef.Attrs {
+		attrsNames = append(attrsNames, attrName)
+	}
+	sort.Strings(attrsNames)
+
+	// For each attribute generate the equality check logic
+	for _, attrName := range attrsNames {
+		attr := typeDef.Attrs[attrName]
+		out += isEqualField(attrName, attr.Shape, firstVarName, secondVarName, indentLevel)
+	}
+	return out
+}
+
+// isEqualField outputs Go code that compares two similar fields from different objects.
+// The generated code first checks the nility of the fields and then procede on comparing
+// their value.
+//
+// Output code will look something like this:
+//
+//	if ackcompare.HasNilDifference(a.RepositoryName, b.RepositoryName) {
+//		return false
+//	} else if a.RepositoryName != nil && b.RepositoryName != nil {
+//		if *a.RepositoryName != *b.RepositoryName {
+//			return false
+//		}
+//	}
+func isEqualField(
+	// fieldName is the field to generate the comparison logic for
+	fieldName string,
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that represents the object
+	// under comparison.
+	firstVarName string,
+	// String representing the name of the variable that represents the second
+	// object under comparison.
+	secondVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+
+	memberNames := names.New(fieldName)
+	memberNameClean := memberNames.Camel
+	firstAdaptedVarName := firstVarName + "." + memberNameClean
+	secondAdaptedVarName := secondVarName + "." + memberNameClean
+
+	nilCode := isEqualNil(
+		shape,
+		firstAdaptedVarName,
+		secondAdaptedVarName,
+		indentLevel,
+	)
+	if nilCode != "" {
+		out += fmt.Sprintf(
+			"%s else if %s != nil && %s != nil {\n",
+			nilCode, firstAdaptedVarName, secondAdaptedVarName,
+		)
+		indentLevel++
+	} else {
+		out += "\n"
+	}
+
+	indent := strings.Repeat("\t", indentLevel)
+
+	switch shape.Type {
+	case "structure":
+		// We just re-use the generated functions to compare field of `struct` type
+		out += fmt.Sprintf(
+			"%sif !IsEqual%s(%s, %s) {\n",
+			indent,
+			shape.ShapeName,
+			firstAdaptedVarName,
+			secondAdaptedVarName,
+		)
+		out += fmt.Sprintf("%s\treturn false\n", indent)
+		out += fmt.Sprintf("%s}\n", indent)
+
+	case "list":
+		out += isEqualSlice(
+			shape,
+			firstAdaptedVarName,
+			secondAdaptedVarName,
+			indentLevel,
+		)
+	case "map":
+		out += isEqualMap(
+			shape,
+			firstAdaptedVarName,
+			secondAdaptedVarName,
+			indentLevel,
+		)
+	default:
+		out += fmt.Sprintf(
+			"%sif *%s != *%s {\n",
+			indent,
+			firstAdaptedVarName,
+			secondAdaptedVarName,
+		)
+		out += fmt.Sprintf("%s\treturn false\n", indent)
+		out += fmt.Sprintf("%s}\n", indent)
+	}
+
+	if nilCode != "" {
+		indentLevel--
+		indent := strings.Repeat("\t", indentLevel)
+		out += fmt.Sprintf("%s}\n", indent)
+	}
+	return out
+}
+
+// isEqualNil outputs Go code that compares pointer to struct types for nullability,
+// if there is a nil difference the code return false.
+//
+// Output code will look something like this:
+//
+// if ackcompare.HasNilDifference(a.DataTraceEnabled, b.DataTraceEnabled) {
+//     return false
+// }
+func isEqualNil(
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that represents the object
+	// under comparison.
+	firstVarName string,
+	// String representing the name of the variable that represents the second
+	// object under comparison.
+	secondVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	switch shape.Type {
+	case "list", "blob":
+		// for slice types, there is no nilability test. Instead, the normal
+		// value test checks length of slices.
+		return ""
+	case "boolean", "string", "character", "byte", "short", "integer", "long",
+		"float", "double", "timestamp", "structure", "map", "jsonvalue":
+		out += fmt.Sprintf(
+			"%sif ackcompare.HasNilDifference(%s, %s) {\n",
+			indent, firstVarName, secondVarName,
+		)
+	default:
+		panic("Unsupported shape type in generate.code.compareNil: " + shape.Type)
+	}
+	// return false
+	out += fmt.Sprintf(
+		"%s\treturn false\n",
+		indent,
+	)
+	// }
+	out += fmt.Sprintf(
+		"%s}", indent,
+	)
+	return out
+}
+
+// isEqualSlice outputs Go code that compares two Go slices of the the same value type.
+// at the first spotted difference the code return false, return true if the element
+// are equal.
+// TODO(hilalymh): Modify this function to be configurable: Ordered/Non-Ordered/ExactCountRepeatedElements
+func isEqualSlice(
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that represents the object
+	// under comparison.
+	firstVarName string,
+	// String representing the name of the variable that represents the second
+	// object under comparison.
+	secondVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	indent := strings.Repeat("\t", indentLevel)
+	out := fmt.Sprintf(
+		"%s//TODO(a-hilaly): equality check for slices\n", indent,
+	)
+	return out
+}
+
+// isEqualMap outputs Go code that compares two Go maps of the the same value type.
+// at the first spotted difference the code return false, return true if the maps
+// key/values are equal.
+func isEqualMap(
+	// struct describing the SDK type of the field being compared
+	shape *awssdkmodel.Shape,
+	// String representing the name of the variable that represents the object
+	// under comparison.
+	firstVarName string,
+	// String representing the name of the variable that represents the second
+	// object under comparison.
+	secondVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	indent := strings.Repeat("\t", indentLevel)
+	out := fmt.Sprintf(
+		"%s//TODO(a-hilaly): equality check for maps\n", indent,
+	)
+	return out
+}

--- a/pkg/generate/code/equal_test.go
+++ b/pkg/generate/code/equal_test.go
@@ -1,0 +1,173 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestCompareResource_ApigatewayV2_RouteSettings(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+
+	tdef := testutil.GetTypeDefByName(t, g, "RouteSettings")
+	require.NotNil(tdef)
+
+	expected := `	if ackcompare.HasNilDifference(a.DataTraceEnabled, b.DataTraceEnabled) {
+		return false
+	} else if a.DataTraceEnabled != nil && b.DataTraceEnabled != nil {
+		if *a.DataTraceEnabled != *b.DataTraceEnabled {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.DetailedMetricsEnabled, b.DetailedMetricsEnabled) {
+		return false
+	} else if a.DetailedMetricsEnabled != nil && b.DetailedMetricsEnabled != nil {
+		if *a.DetailedMetricsEnabled != *b.DetailedMetricsEnabled {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.LoggingLevel, b.LoggingLevel) {
+		return false
+	} else if a.LoggingLevel != nil && b.LoggingLevel != nil {
+		if *a.LoggingLevel != *b.LoggingLevel {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.ThrottlingBurstLimit, b.ThrottlingBurstLimit) {
+		return false
+	} else if a.ThrottlingBurstLimit != nil && b.ThrottlingBurstLimit != nil {
+		if *a.ThrottlingBurstLimit != *b.ThrottlingBurstLimit {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.ThrottlingRateLimit, b.ThrottlingRateLimit) {
+		return false
+	} else if a.ThrottlingRateLimit != nil && b.ThrottlingRateLimit != nil {
+		if *a.ThrottlingRateLimit != *b.ThrottlingRateLimit {
+			return false
+		}
+	}
+`
+	assert.Equal(
+		expected,
+		code.IsEqualTypeDef(
+			tdef, "a", "b", 1,
+		),
+	)
+}
+
+func TestCompareResource_ECR_Repository_SDK(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "ecr")
+
+	tdef := testutil.GetTypeDefByName(t, g, "Repository")
+	require.NotNil(tdef)
+
+	expected := `	if ackcompare.HasNilDifference(a.CreatedAt, b.CreatedAt) {
+		return false
+	} else if a.CreatedAt != nil && b.CreatedAt != nil {
+		if *a.CreatedAt != *b.CreatedAt {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.ImageScanningConfiguration, b.ImageScanningConfiguration) {
+		return false
+	} else if a.ImageScanningConfiguration != nil && b.ImageScanningConfiguration != nil {
+		if !IsEqualImageScanningConfiguration(a.ImageScanningConfiguration, b.ImageScanningConfiguration) {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.ImageTagMutability, b.ImageTagMutability) {
+		return false
+	} else if a.ImageTagMutability != nil && b.ImageTagMutability != nil {
+		if *a.ImageTagMutability != *b.ImageTagMutability {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.RegistryID, b.RegistryID) {
+		return false
+	} else if a.RegistryID != nil && b.RegistryID != nil {
+		if *a.RegistryID != *b.RegistryID {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.RepositoryARN, b.RepositoryARN) {
+		return false
+	} else if a.RepositoryARN != nil && b.RepositoryARN != nil {
+		if *a.RepositoryARN != *b.RepositoryARN {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.RepositoryName, b.RepositoryName) {
+		return false
+	} else if a.RepositoryName != nil && b.RepositoryName != nil {
+		if *a.RepositoryName != *b.RepositoryName {
+			return false
+		}
+	}
+	if ackcompare.HasNilDifference(a.RepositoryURI, b.RepositoryURI) {
+		return false
+	} else if a.RepositoryURI != nil && b.RepositoryURI != nil {
+		if *a.RepositoryURI != *b.RepositoryURI {
+			return false
+		}
+	}
+`
+
+	assert.Equal(
+		expected,
+		code.IsEqualTypeDef(
+			tdef, "a", "b", 1,
+		),
+	)
+}
+
+func TestCompareResource_ApigatewayV2_JWTConfiguration(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+
+	tdef := testutil.GetTypeDefByName(t, g, "JWTConfiguration")
+	require.NotNil(tdef)
+
+	expected := `
+	//TODO(a-hilaly): equality check for slices
+	if ackcompare.HasNilDifference(a.Issuer, b.Issuer) {
+		return false
+	} else if a.Issuer != nil && b.Issuer != nil {
+		if *a.Issuer != *b.Issuer {
+			return false
+		}
+	}
+`
+
+	assert.Equal(
+		expected,
+		code.IsEqualTypeDef(
+			tdef, "a", "b", 1,
+		),
+	)
+}

--- a/templates/pkg/compare/struct.go.tpl
+++ b/templates/pkg/compare/struct.go.tpl
@@ -1,0 +1,19 @@
+{{ template "boilerplate" }}
+
+package compare
+
+import (
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/v1alpha1"
+)
+
+{{- range $typeDef := .TypeDefs }}
+
+// IsEqual{{ .Names.Camel }} compares two {{ .Names.Camel }} object pointers. 
+func IsEqual{{ .Names.Camel }}(a, b *svcapitypes.{{ .Names.Camel -}}) bool {
+{{ GoCodeIsEqual $typeDef "a" "b" 1 }}
+	return true
+}
+
+{{- end -}}


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/757

Description of changes:

Adds new code generation functions to `pkg/generate/code` that output Go code that checks the equality of two types. The generated code returns false at the first observed difference. The generated code re-uses the comparison functions for all nested fields of struct type.

This package will be imported and used by the generated `delta.go` file
that helps in comparing CRD fields.

For field of scalar type code looks like:
```go
	if ackcompare.HasNilDifference(a.RegistryID, b.RegistryID) {
		return false
	} else if a.RegistryID != nil && b.RegistryID != nil {
		if *a.RegistryID != *b.RegistryID {
			return false
		}
	}
```

For fields of type struct code look like:

```go
	if ackcompare.HasNilDifference(a.ImageScanningConfiguration, b.ImageScanningConfiguration) {
		return false
	} else if a.ImageScanningConfiguration != nil && b.ImageScanningConfiguration != nil {
		if !IsEqualImageScanningConfiguration(a.ImageScanningConfiguration, b.ImageScanningConfiguration) {
			return false
		}
	}
```

This patch doesn't implement comparison logic for slices and maps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
