### PR TITLE
panic if matchFieldName config contains an element that is not part of Spec or Status fields

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -416,6 +416,18 @@ func setResourceReadMany(
 	// operation by checking for matching values in these fields.
 	matchFieldNames := r.ListOpMatchFieldNames()
 
+	for _, matchFieldName := range matchFieldNames {
+		_, foundSpec := r.SpecFields[matchFieldName]
+		_, foundStatus := r.StatusFields[matchFieldName]
+		if !foundSpec && !foundStatus {
+			msg := fmt.Sprintf(
+				"Match field name %s is not in %s Spec or Status fields",
+				matchFieldName, r.Names.Camel,
+			)
+			panic(msg)
+		}
+	}
+
 	// found := false
 	out += fmt.Sprintf("%sfound := false\n", indent)
 	// for _, elem := range resp.CacheClusters {


### PR DESCRIPTION
Part of https://github.com/aws-controllers-k8s/community/issues/773

Description of changes:
- panic if `list_operation.matchFields` configuration contains an element that is not part of Spec or Status fields

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
