### PR TITLE
Use `pkg/compare` generated comparison functions in `newResourceDelta`

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -93,8 +93,8 @@ var (
 		"GoCodeSetDeleteInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
-			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
+		"GoCodeCompare": func(r *ackmodel.CRD, svccomparePackageAlias string, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
+			return code.CompareResource(r.Config(), r, svccomparePackageAlias, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
 		"GoCodeIsEqual": func(typeDef *ackmodel.TypeDef, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.IsEqualTypeDef(typeDef, sourceVarName, targetVarName, indentLevel)

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -38,12 +38,8 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
 		delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
 	} else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
-			delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
-		} else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil {
-			if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
-				delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
-			}
+		if !svccompare.IsEqualCreateBucketConfiguration(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
+			delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
@@ -99,7 +95,7 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	assert.Equal(
 		expected,
 		code.CompareResource(
-			crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+			crd.Config(), crd, "svccompare", "delta", "a.ko", "b.ko", 1,
 		),
 	)
 }
@@ -117,20 +113,15 @@ func TestCompareResource_Lambda_CodeSigningConfig(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
 		delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
 	} else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
-
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
-			delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
+		if !svccompare.IsEqualAllowedPublishers(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
+			delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies) {
 		delta.Add("Spec.CodeSigningPolicies", a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies)
 	} else if a.ko.Spec.CodeSigningPolicies != nil && b.ko.Spec.CodeSigningPolicies != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment) {
-			delta.Add("Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment", a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment)
-		} else if a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != nil && b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != nil {
-			if *a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != *b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment {
-				delta.Add("Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment", a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment)
-			}
+		if !svccompare.IsEqualCodeSigningPolicies(a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies) {
+			delta.Add("Spec.CodeSigningPolicies", a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
@@ -144,7 +135,7 @@ func TestCompareResource_Lambda_CodeSigningConfig(t *testing.T) {
 	assert.Equal(
 		expected,
 		code.CompareResource(
-			crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+			crd.Config(), crd, "svccompare", "delta", "a.ko", "b.ko", 1,
 		),
 	)
 }

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -3,6 +3,8 @@
 package {{ .CRD.Names.Snake }}
 
 import (
+	svccompare "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/compare"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 )
 
@@ -18,6 +20,6 @@ func newResourceDelta(
         delta.Add("", a, b)
         return delta
     }
-{{ GoCodeCompare .CRD "delta" "a.ko" "b.ko" 1}}
+{{ GoCodeCompare .CRD "svccompare" "delta" "a.ko" "b.ko" 1}}
     return delta
 }


### PR DESCRIPTION
Part of https://github.com/aws-controllers-k8s/community/issues/757

This patch links `pkg/compare` and `pkg/resource/delta.go`, by importing
and reusing the generated comparison functions in `delta.go`. For now it
only import/reuse struct type comparison functions.

Example of the new generated Go code:

```go
if !svccompare.IsEqualCodeSigningPolicies(a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies) {
	delta.Add("Spec.CodeSigningPolicies", a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies)
}
```

Example of the old generated Go code for the same service/block:
```go
if ackcompare.HasNilDifference(a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment) {
	delta.Add("Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment", a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment)
} else if a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != nil && b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != nil {
	if *a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment != *b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment {
		delta.Add("Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment", a.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment, b.ko.Spec.CodeSigningPolicies.UntrustedArtifactOnDeployment)
	}
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
