### PR TITLE
Adding ClusterIP service in helm chart to expose controller metrics.

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -33,6 +33,7 @@ var (
 		"helm/templates/_helpers.tpl",
 		"helm/templates/cluster-role-binding.yaml",
 		"helm/templates/deployment.yaml",
+		"helm/templates/service.yaml",
 		"helm/templates/service-account.yaml",
 	}
 	releaseFuncMap = ttpl.FuncMap{

--- a/templates/helm/templates/service.yaml
+++ b/templates/helm/templates/service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    k8s-app: {{ include "app.name" . }}
+    helm.sh/chart: {{ include "chart.name-version" . }}
+    control-plane: controller
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    k8s-app: {{ include "app.name" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+  type: {{ .Values.service.type }}
+  ports:
+  - name: metricsport
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{{- end }}

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -16,6 +16,10 @@ deployment:
   labels: {}
   containerPort: 8080
 
+service:
+  create: false
+  type: "ClusterIP"
+
 resources:
   requests:
     memory: "64Mi"


### PR DESCRIPTION
Description of changes:

Adding ClusterIP service in helm chart to expose controller metrics.

It is much simpler and easier to update prometheus scraping configuration with a static endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
