### PR TITLE
Update ElastiCache CodeGen test based on new SDK

### DIFF
--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -706,199 +706,263 @@ func TestSetResource_ECR_Repository_ReadMany(t *testing.T) {
 	)
 }
 
-func TestSetResource_Elasticache_CacheCluster_Create(t *testing.T) {
+func TestSetResource_Elasticache_ReplicationGroup_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
 	g := testutil.NewGeneratorForService(t, "elasticache")
 
-	crd := testutil.GetCRDByName(t, g, "CacheCluster")
+	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
 
 	expected := `
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	if resp.CacheCluster.ARN != nil {
-		arn := ackv1alpha1.AWSResourceName(*resp.CacheCluster.ARN)
+	if resp.ReplicationGroup.ARN != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.ReplicationGroup.ARN)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
-	if resp.CacheCluster.AtRestEncryptionEnabled != nil {
-		ko.Status.AtRestEncryptionEnabled = resp.CacheCluster.AtRestEncryptionEnabled
-	} else {
-		ko.Status.AtRestEncryptionEnabled = nil
-	}
-	if resp.CacheCluster.AuthTokenEnabled != nil {
-		ko.Status.AuthTokenEnabled = resp.CacheCluster.AuthTokenEnabled
+	if resp.ReplicationGroup.AuthTokenEnabled != nil {
+		ko.Status.AuthTokenEnabled = resp.ReplicationGroup.AuthTokenEnabled
 	} else {
 		ko.Status.AuthTokenEnabled = nil
 	}
-	if resp.CacheCluster.AuthTokenLastModifiedDate != nil {
-		ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*resp.CacheCluster.AuthTokenLastModifiedDate}
+	if resp.ReplicationGroup.AuthTokenLastModifiedDate != nil {
+		ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*resp.ReplicationGroup.AuthTokenLastModifiedDate}
 	} else {
 		ko.Status.AuthTokenLastModifiedDate = nil
 	}
-	if resp.CacheCluster.CacheClusterCreateTime != nil {
-		ko.Status.CacheClusterCreateTime = &metav1.Time{*resp.CacheCluster.CacheClusterCreateTime}
+	if resp.ReplicationGroup.AutomaticFailover != nil {
+		ko.Status.AutomaticFailover = resp.ReplicationGroup.AutomaticFailover
 	} else {
-		ko.Status.CacheClusterCreateTime = nil
+		ko.Status.AutomaticFailover = nil
 	}
-	if resp.CacheCluster.CacheClusterStatus != nil {
-		ko.Status.CacheClusterStatus = resp.CacheCluster.CacheClusterStatus
+	if resp.ReplicationGroup.ClusterEnabled != nil {
+		ko.Status.ClusterEnabled = resp.ReplicationGroup.ClusterEnabled
 	} else {
-		ko.Status.CacheClusterStatus = nil
+		ko.Status.ClusterEnabled = nil
 	}
-	if resp.CacheCluster.CacheNodes != nil {
-		f9 := []*svcapitypes.CacheNode{}
-		for _, f9iter := range resp.CacheCluster.CacheNodes {
-			f9elem := &svcapitypes.CacheNode{}
-			if f9iter.CacheNodeCreateTime != nil {
-				f9elem.CacheNodeCreateTime = &metav1.Time{*f9iter.CacheNodeCreateTime}
-			}
-			if f9iter.CacheNodeId != nil {
-				f9elem.CacheNodeID = f9iter.CacheNodeId
-			}
-			if f9iter.CacheNodeStatus != nil {
-				f9elem.CacheNodeStatus = f9iter.CacheNodeStatus
-			}
-			if f9iter.CustomerAvailabilityZone != nil {
-				f9elem.CustomerAvailabilityZone = f9iter.CustomerAvailabilityZone
-			}
-			if f9iter.Endpoint != nil {
-				f9elemf4 := &svcapitypes.Endpoint{}
-				if f9iter.Endpoint.Address != nil {
-					f9elemf4.Address = f9iter.Endpoint.Address
-				}
-				if f9iter.Endpoint.Port != nil {
-					f9elemf4.Port = f9iter.Endpoint.Port
-				}
-				f9elem.Endpoint = f9elemf4
-			}
-			if f9iter.ParameterGroupStatus != nil {
-				f9elem.ParameterGroupStatus = f9iter.ParameterGroupStatus
-			}
-			if f9iter.SourceCacheNodeId != nil {
-				f9elem.SourceCacheNodeID = f9iter.SourceCacheNodeId
-			}
-			f9 = append(f9, f9elem)
+	if resp.ReplicationGroup.ConfigurationEndpoint != nil {
+		f7 := &svcapitypes.Endpoint{}
+		if resp.ReplicationGroup.ConfigurationEndpoint.Address != nil {
+			f7.Address = resp.ReplicationGroup.ConfigurationEndpoint.Address
 		}
-		ko.Status.CacheNodes = f9
-	} else {
-		ko.Status.CacheNodes = nil
-	}
-	if resp.CacheCluster.CacheParameterGroup != nil {
-		f10 := &svcapitypes.CacheParameterGroupStatus_SDK{}
-		if resp.CacheCluster.CacheParameterGroup.CacheNodeIdsToReboot != nil {
-			f10f0 := []*string{}
-			for _, f10f0iter := range resp.CacheCluster.CacheParameterGroup.CacheNodeIdsToReboot {
-				var f10f0elem string
-				f10f0elem = *f10f0iter
-				f10f0 = append(f10f0, &f10f0elem)
-			}
-			f10.CacheNodeIDsToReboot = f10f0
+		if resp.ReplicationGroup.ConfigurationEndpoint.Port != nil {
+			f7.Port = resp.ReplicationGroup.ConfigurationEndpoint.Port
 		}
-		if resp.CacheCluster.CacheParameterGroup.CacheParameterGroupName != nil {
-			f10.CacheParameterGroupName = resp.CacheCluster.CacheParameterGroup.CacheParameterGroupName
-		}
-		if resp.CacheCluster.CacheParameterGroup.ParameterApplyStatus != nil {
-			f10.ParameterApplyStatus = resp.CacheCluster.CacheParameterGroup.ParameterApplyStatus
-		}
-		ko.Status.CacheParameterGroup = f10
-	} else {
-		ko.Status.CacheParameterGroup = nil
-	}
-	if resp.CacheCluster.CacheSecurityGroups != nil {
-		f11 := []*svcapitypes.CacheSecurityGroupMembership{}
-		for _, f11iter := range resp.CacheCluster.CacheSecurityGroups {
-			f11elem := &svcapitypes.CacheSecurityGroupMembership{}
-			if f11iter.CacheSecurityGroupName != nil {
-				f11elem.CacheSecurityGroupName = f11iter.CacheSecurityGroupName
-			}
-			if f11iter.Status != nil {
-				f11elem.Status = f11iter.Status
-			}
-			f11 = append(f11, f11elem)
-		}
-		ko.Status.CacheSecurityGroups = f11
-	} else {
-		ko.Status.CacheSecurityGroups = nil
-	}
-	if resp.CacheCluster.ClientDownloadLandingPage != nil {
-		ko.Status.ClientDownloadLandingPage = resp.CacheCluster.ClientDownloadLandingPage
-	} else {
-		ko.Status.ClientDownloadLandingPage = nil
-	}
-	if resp.CacheCluster.ConfigurationEndpoint != nil {
-		f14 := &svcapitypes.Endpoint{}
-		if resp.CacheCluster.ConfigurationEndpoint.Address != nil {
-			f14.Address = resp.CacheCluster.ConfigurationEndpoint.Address
-		}
-		if resp.CacheCluster.ConfigurationEndpoint.Port != nil {
-			f14.Port = resp.CacheCluster.ConfigurationEndpoint.Port
-		}
-		ko.Status.ConfigurationEndpoint = f14
+		ko.Status.ConfigurationEndpoint = f7
 	} else {
 		ko.Status.ConfigurationEndpoint = nil
 	}
-	if resp.CacheCluster.NotificationConfiguration != nil {
-		f17 := &svcapitypes.NotificationConfiguration{}
-		if resp.CacheCluster.NotificationConfiguration.TopicArn != nil {
-			f17.TopicARN = resp.CacheCluster.NotificationConfiguration.TopicArn
-		}
-		if resp.CacheCluster.NotificationConfiguration.TopicStatus != nil {
-			f17.TopicStatus = resp.CacheCluster.NotificationConfiguration.TopicStatus
-		}
-		ko.Status.NotificationConfiguration = f17
+	if resp.ReplicationGroup.Description != nil {
+		ko.Status.Description = resp.ReplicationGroup.Description
 	} else {
-		ko.Status.NotificationConfiguration = nil
+		ko.Status.Description = nil
 	}
-	if resp.CacheCluster.PendingModifiedValues != nil {
-		f19 := &svcapitypes.PendingModifiedValues{}
-		if resp.CacheCluster.PendingModifiedValues.AuthTokenStatus != nil {
-			f19.AuthTokenStatus = resp.CacheCluster.PendingModifiedValues.AuthTokenStatus
+	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
+		f9 := &svcapitypes.GlobalReplicationGroupInfo{}
+		if resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupId != nil {
+			f9.GlobalReplicationGroupID = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupId
 		}
-		if resp.CacheCluster.PendingModifiedValues.CacheNodeIdsToRemove != nil {
-			f19f1 := []*string{}
-			for _, f19f1iter := range resp.CacheCluster.PendingModifiedValues.CacheNodeIdsToRemove {
-				var f19f1elem string
-				f19f1elem = *f19f1iter
-				f19f1 = append(f19f1, &f19f1elem)
+		if resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole != nil {
+			f9.GlobalReplicationGroupMemberRole = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
+		}
+		ko.Status.GlobalReplicationGroupInfo = f9
+	} else {
+		ko.Status.GlobalReplicationGroupInfo = nil
+	}
+	if resp.ReplicationGroup.MemberClusters != nil {
+		f12 := []*string{}
+		for _, f12iter := range resp.ReplicationGroup.MemberClusters {
+			var f12elem string
+			f12elem = *f12iter
+			f12 = append(f12, &f12elem)
+		}
+		ko.Status.MemberClusters = f12
+	} else {
+		ko.Status.MemberClusters = nil
+	}
+	if resp.ReplicationGroup.MemberClustersOutpostArns != nil {
+		f13 := []*string{}
+		for _, f13iter := range resp.ReplicationGroup.MemberClustersOutpostArns {
+			var f13elem string
+			f13elem = *f13iter
+			f13 = append(f13, &f13elem)
+		}
+		ko.Status.MemberClustersOutpostARNs = f13
+	} else {
+		ko.Status.MemberClustersOutpostARNs = nil
+	}
+	if resp.ReplicationGroup.MultiAZ != nil {
+		ko.Status.MultiAZ = resp.ReplicationGroup.MultiAZ
+	} else {
+		ko.Status.MultiAZ = nil
+	}
+	if resp.ReplicationGroup.NodeGroups != nil {
+		f15 := []*svcapitypes.NodeGroup{}
+		for _, f15iter := range resp.ReplicationGroup.NodeGroups {
+			f15elem := &svcapitypes.NodeGroup{}
+			if f15iter.NodeGroupId != nil {
+				f15elem.NodeGroupID = f15iter.NodeGroupId
 			}
-			f19.CacheNodeIDsToRemove = f19f1
+			if f15iter.NodeGroupMembers != nil {
+				f15elemf1 := []*svcapitypes.NodeGroupMember{}
+				for _, f15elemf1iter := range f15iter.NodeGroupMembers {
+					f15elemf1elem := &svcapitypes.NodeGroupMember{}
+					if f15elemf1iter.CacheClusterId != nil {
+						f15elemf1elem.CacheClusterID = f15elemf1iter.CacheClusterId
+					}
+					if f15elemf1iter.CacheNodeId != nil {
+						f15elemf1elem.CacheNodeID = f15elemf1iter.CacheNodeId
+					}
+					if f15elemf1iter.CurrentRole != nil {
+						f15elemf1elem.CurrentRole = f15elemf1iter.CurrentRole
+					}
+					if f15elemf1iter.PreferredAvailabilityZone != nil {
+						f15elemf1elem.PreferredAvailabilityZone = f15elemf1iter.PreferredAvailabilityZone
+					}
+					if f15elemf1iter.PreferredOutpostArn != nil {
+						f15elemf1elem.PreferredOutpostARN = f15elemf1iter.PreferredOutpostArn
+					}
+					if f15elemf1iter.ReadEndpoint != nil {
+						f15elemf1elemf5 := &svcapitypes.Endpoint{}
+						if f15elemf1iter.ReadEndpoint.Address != nil {
+							f15elemf1elemf5.Address = f15elemf1iter.ReadEndpoint.Address
+						}
+						if f15elemf1iter.ReadEndpoint.Port != nil {
+							f15elemf1elemf5.Port = f15elemf1iter.ReadEndpoint.Port
+						}
+						f15elemf1elem.ReadEndpoint = f15elemf1elemf5
+					}
+					f15elemf1 = append(f15elemf1, f15elemf1elem)
+				}
+				f15elem.NodeGroupMembers = f15elemf1
+			}
+			if f15iter.PrimaryEndpoint != nil {
+				f15elemf2 := &svcapitypes.Endpoint{}
+				if f15iter.PrimaryEndpoint.Address != nil {
+					f15elemf2.Address = f15iter.PrimaryEndpoint.Address
+				}
+				if f15iter.PrimaryEndpoint.Port != nil {
+					f15elemf2.Port = f15iter.PrimaryEndpoint.Port
+				}
+				f15elem.PrimaryEndpoint = f15elemf2
+			}
+			if f15iter.ReaderEndpoint != nil {
+				f15elemf3 := &svcapitypes.Endpoint{}
+				if f15iter.ReaderEndpoint.Address != nil {
+					f15elemf3.Address = f15iter.ReaderEndpoint.Address
+				}
+				if f15iter.ReaderEndpoint.Port != nil {
+					f15elemf3.Port = f15iter.ReaderEndpoint.Port
+				}
+				f15elem.ReaderEndpoint = f15elemf3
+			}
+			if f15iter.Slots != nil {
+				f15elem.Slots = f15iter.Slots
+			}
+			if f15iter.Status != nil {
+				f15elem.Status = f15iter.Status
+			}
+			f15 = append(f15, f15elem)
 		}
-		if resp.CacheCluster.PendingModifiedValues.CacheNodeType != nil {
-			f19.CacheNodeType = resp.CacheCluster.PendingModifiedValues.CacheNodeType
+		ko.Status.NodeGroups = f15
+	} else {
+		ko.Status.NodeGroups = nil
+	}
+	if resp.ReplicationGroup.PendingModifiedValues != nil {
+		f16 := &svcapitypes.ReplicationGroupPendingModifiedValues{}
+		if resp.ReplicationGroup.PendingModifiedValues.AuthTokenStatus != nil {
+			f16.AuthTokenStatus = resp.ReplicationGroup.PendingModifiedValues.AuthTokenStatus
 		}
-		if resp.CacheCluster.PendingModifiedValues.EngineVersion != nil {
-			f19.EngineVersion = resp.CacheCluster.PendingModifiedValues.EngineVersion
+		if resp.ReplicationGroup.PendingModifiedValues.AutomaticFailoverStatus != nil {
+			f16.AutomaticFailoverStatus = resp.ReplicationGroup.PendingModifiedValues.AutomaticFailoverStatus
 		}
-		if resp.CacheCluster.PendingModifiedValues.NumCacheNodes != nil {
-			f19.NumCacheNodes = resp.CacheCluster.PendingModifiedValues.NumCacheNodes
+		if resp.ReplicationGroup.PendingModifiedValues.LogDeliveryConfigurations != nil {
+			f16f2 := []*svcapitypes.PendingLogDeliveryConfiguration{}
+			for _, f16f2iter := range resp.ReplicationGroup.PendingModifiedValues.LogDeliveryConfigurations {
+				f16f2elem := &svcapitypes.PendingLogDeliveryConfiguration{}
+				if f16f2iter.DestinationDetails != nil {
+					f16f2elemf0 := &svcapitypes.DestinationDetails{}
+					if f16f2iter.DestinationDetails.CloudWatchLogsDetails != nil {
+						f16f2elemf0f0 := &svcapitypes.CloudWatchLogsDestinationDetails{}
+						if f16f2iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+							f16f2elemf0f0.LogGroup = f16f2iter.DestinationDetails.CloudWatchLogsDetails.LogGroup
+						}
+						f16f2elemf0.CloudWatchLogsDetails = f16f2elemf0f0
+					}
+					if f16f2iter.DestinationDetails.KinesisFirehoseDetails != nil {
+						f16f2elemf0f1 := &svcapitypes.KinesisFirehoseDestinationDetails{}
+						if f16f2iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+							f16f2elemf0f1.DeliveryStream = f16f2iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream
+						}
+						f16f2elemf0.KinesisFirehoseDetails = f16f2elemf0f1
+					}
+					f16f2elem.DestinationDetails = f16f2elemf0
+				}
+				if f16f2iter.DestinationType != nil {
+					f16f2elem.DestinationType = f16f2iter.DestinationType
+				}
+				if f16f2iter.LogFormat != nil {
+					f16f2elem.LogFormat = f16f2iter.LogFormat
+				}
+				if f16f2iter.LogType != nil {
+					f16f2elem.LogType = f16f2iter.LogType
+				}
+				f16f2 = append(f16f2, f16f2elem)
+			}
+			f16.LogDeliveryConfigurations = f16f2
 		}
-		ko.Status.PendingModifiedValues = f19
+		if resp.ReplicationGroup.PendingModifiedValues.PrimaryClusterId != nil {
+			f16.PrimaryClusterID = resp.ReplicationGroup.PendingModifiedValues.PrimaryClusterId
+		}
+		if resp.ReplicationGroup.PendingModifiedValues.Resharding != nil {
+			f16f4 := &svcapitypes.ReshardingStatus{}
+			if resp.ReplicationGroup.PendingModifiedValues.Resharding.SlotMigration != nil {
+				f16f4f0 := &svcapitypes.SlotMigration{}
+				if resp.ReplicationGroup.PendingModifiedValues.Resharding.SlotMigration.ProgressPercentage != nil {
+					f16f4f0.ProgressPercentage = resp.ReplicationGroup.PendingModifiedValues.Resharding.SlotMigration.ProgressPercentage
+				}
+				f16f4.SlotMigration = f16f4f0
+			}
+			f16.Resharding = f16f4
+		}
+		if resp.ReplicationGroup.PendingModifiedValues.UserGroups != nil {
+			f16f5 := &svcapitypes.UserGroupsUpdateStatus{}
+			if resp.ReplicationGroup.PendingModifiedValues.UserGroups.UserGroupIdsToAdd != nil {
+				f16f5f0 := []*string{}
+				for _, f16f5f0iter := range resp.ReplicationGroup.PendingModifiedValues.UserGroups.UserGroupIdsToAdd {
+					var f16f5f0elem string
+					f16f5f0elem = *f16f5f0iter
+					f16f5f0 = append(f16f5f0, &f16f5f0elem)
+				}
+				f16f5.UserGroupIDsToAdd = f16f5f0
+			}
+			if resp.ReplicationGroup.PendingModifiedValues.UserGroups.UserGroupIdsToRemove != nil {
+				f16f5f1 := []*string{}
+				for _, f16f5f1iter := range resp.ReplicationGroup.PendingModifiedValues.UserGroups.UserGroupIdsToRemove {
+					var f16f5f1elem string
+					f16f5f1elem = *f16f5f1iter
+					f16f5f1 = append(f16f5f1, &f16f5f1elem)
+				}
+				f16f5.UserGroupIDsToRemove = f16f5f1
+			}
+			f16.UserGroups = f16f5
+		}
+		ko.Status.PendingModifiedValues = f16
 	} else {
 		ko.Status.PendingModifiedValues = nil
 	}
-	if resp.CacheCluster.SecurityGroups != nil {
-		f23 := []*svcapitypes.SecurityGroupMembership{}
-		for _, f23iter := range resp.CacheCluster.SecurityGroups {
-			f23elem := &svcapitypes.SecurityGroupMembership{}
-			if f23iter.SecurityGroupId != nil {
-				f23elem.SecurityGroupID = f23iter.SecurityGroupId
-			}
-			if f23iter.Status != nil {
-				f23elem.Status = f23iter.Status
-			}
-			f23 = append(f23, f23elem)
-		}
-		ko.Status.SecurityGroups = f23
+	if resp.ReplicationGroup.SnapshottingClusterId != nil {
+		ko.Status.SnapshottingClusterID = resp.ReplicationGroup.SnapshottingClusterId
 	} else {
-		ko.Status.SecurityGroups = nil
+		ko.Status.SnapshottingClusterID = nil
 	}
-	if resp.CacheCluster.TransitEncryptionEnabled != nil {
-		ko.Status.TransitEncryptionEnabled = resp.CacheCluster.TransitEncryptionEnabled
+	if resp.ReplicationGroup.Status != nil {
+		ko.Status.Status = resp.ReplicationGroup.Status
 	} else {
-		ko.Status.TransitEncryptionEnabled = nil
+		ko.Status.Status = nil
 	}
 `
 	assert.Equal(
@@ -907,18 +971,18 @@ func TestSetResource_Elasticache_CacheCluster_Create(t *testing.T) {
 	)
 }
 
-func TestSetResource_Elasticache_CacheCluster_ReadMany(t *testing.T) {
+func TestSetResource_Elasticache_ReplicationGroup_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
 	g := testutil.NewGeneratorForService(t, "elasticache")
 
-	crd := testutil.GetCRDByName(t, g, "CacheCluster")
+	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
 
 	expected := `
 	found := false
-	for _, elem := range resp.CacheClusters {
+	for _, elem := range resp.ReplicationGroups {
 		if elem.ARN != nil {
 			if ko.Status.ACKResourceMetadata == nil {
 				ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -927,9 +991,9 @@ func TestSetResource_Elasticache_CacheCluster_ReadMany(t *testing.T) {
 			ko.Status.ACKResourceMetadata.ARN = &tmpARN
 		}
 		if elem.AtRestEncryptionEnabled != nil {
-			ko.Status.AtRestEncryptionEnabled = elem.AtRestEncryptionEnabled
+			ko.Spec.AtRestEncryptionEnabled = elem.AtRestEncryptionEnabled
 		} else {
-			ko.Status.AtRestEncryptionEnabled = nil
+			ko.Spec.AtRestEncryptionEnabled = nil
 		}
 		if elem.AuthTokenEnabled != nil {
 			ko.Status.AuthTokenEnabled = elem.AuthTokenEnabled
@@ -941,212 +1005,278 @@ func TestSetResource_Elasticache_CacheCluster_ReadMany(t *testing.T) {
 		} else {
 			ko.Status.AuthTokenLastModifiedDate = nil
 		}
-		if elem.AutoMinorVersionUpgrade != nil {
-			ko.Spec.AutoMinorVersionUpgrade = elem.AutoMinorVersionUpgrade
+		if elem.AutomaticFailover != nil {
+			ko.Status.AutomaticFailover = elem.AutomaticFailover
 		} else {
-			ko.Spec.AutoMinorVersionUpgrade = nil
-		}
-		if elem.CacheClusterCreateTime != nil {
-			ko.Status.CacheClusterCreateTime = &metav1.Time{*elem.CacheClusterCreateTime}
-		} else {
-			ko.Status.CacheClusterCreateTime = nil
-		}
-		if elem.CacheClusterId != nil {
-			ko.Spec.CacheClusterID = elem.CacheClusterId
-		} else {
-			ko.Spec.CacheClusterID = nil
-		}
-		if elem.CacheClusterStatus != nil {
-			ko.Status.CacheClusterStatus = elem.CacheClusterStatus
-		} else {
-			ko.Status.CacheClusterStatus = nil
+			ko.Status.AutomaticFailover = nil
 		}
 		if elem.CacheNodeType != nil {
 			ko.Spec.CacheNodeType = elem.CacheNodeType
 		} else {
 			ko.Spec.CacheNodeType = nil
 		}
-		if elem.CacheNodes != nil {
-			f9 := []*svcapitypes.CacheNode{}
-			for _, f9iter := range elem.CacheNodes {
-				f9elem := &svcapitypes.CacheNode{}
-				if f9iter.CacheNodeCreateTime != nil {
-					f9elem.CacheNodeCreateTime = &metav1.Time{*f9iter.CacheNodeCreateTime}
-				}
-				if f9iter.CacheNodeId != nil {
-					f9elem.CacheNodeID = f9iter.CacheNodeId
-				}
-				if f9iter.CacheNodeStatus != nil {
-					f9elem.CacheNodeStatus = f9iter.CacheNodeStatus
-				}
-				if f9iter.CustomerAvailabilityZone != nil {
-					f9elem.CustomerAvailabilityZone = f9iter.CustomerAvailabilityZone
-				}
-				if f9iter.Endpoint != nil {
-					f9elemf4 := &svcapitypes.Endpoint{}
-					if f9iter.Endpoint.Address != nil {
-						f9elemf4.Address = f9iter.Endpoint.Address
-					}
-					if f9iter.Endpoint.Port != nil {
-						f9elemf4.Port = f9iter.Endpoint.Port
-					}
-					f9elem.Endpoint = f9elemf4
-				}
-				if f9iter.ParameterGroupStatus != nil {
-					f9elem.ParameterGroupStatus = f9iter.ParameterGroupStatus
-				}
-				if f9iter.SourceCacheNodeId != nil {
-					f9elem.SourceCacheNodeID = f9iter.SourceCacheNodeId
-				}
-				f9 = append(f9, f9elem)
-			}
-			ko.Status.CacheNodes = f9
+		if elem.ClusterEnabled != nil {
+			ko.Status.ClusterEnabled = elem.ClusterEnabled
 		} else {
-			ko.Status.CacheNodes = nil
-		}
-		if elem.CacheParameterGroup != nil {
-			f10 := &svcapitypes.CacheParameterGroupStatus_SDK{}
-			if elem.CacheParameterGroup.CacheNodeIdsToReboot != nil {
-				f10f0 := []*string{}
-				for _, f10f0iter := range elem.CacheParameterGroup.CacheNodeIdsToReboot {
-					var f10f0elem string
-					f10f0elem = *f10f0iter
-					f10f0 = append(f10f0, &f10f0elem)
-				}
-				f10.CacheNodeIDsToReboot = f10f0
-			}
-			if elem.CacheParameterGroup.CacheParameterGroupName != nil {
-				f10.CacheParameterGroupName = elem.CacheParameterGroup.CacheParameterGroupName
-			}
-			if elem.CacheParameterGroup.ParameterApplyStatus != nil {
-				f10.ParameterApplyStatus = elem.CacheParameterGroup.ParameterApplyStatus
-			}
-			ko.Status.CacheParameterGroup = f10
-		} else {
-			ko.Status.CacheParameterGroup = nil
-		}
-		if elem.CacheSecurityGroups != nil {
-			f11 := []*svcapitypes.CacheSecurityGroupMembership{}
-			for _, f11iter := range elem.CacheSecurityGroups {
-				f11elem := &svcapitypes.CacheSecurityGroupMembership{}
-				if f11iter.CacheSecurityGroupName != nil {
-					f11elem.CacheSecurityGroupName = f11iter.CacheSecurityGroupName
-				}
-				if f11iter.Status != nil {
-					f11elem.Status = f11iter.Status
-				}
-				f11 = append(f11, f11elem)
-			}
-			ko.Status.CacheSecurityGroups = f11
-		} else {
-			ko.Status.CacheSecurityGroups = nil
-		}
-		if elem.CacheSubnetGroupName != nil {
-			ko.Spec.CacheSubnetGroupName = elem.CacheSubnetGroupName
-		} else {
-			ko.Spec.CacheSubnetGroupName = nil
-		}
-		if elem.ClientDownloadLandingPage != nil {
-			ko.Status.ClientDownloadLandingPage = elem.ClientDownloadLandingPage
-		} else {
-			ko.Status.ClientDownloadLandingPage = nil
+			ko.Status.ClusterEnabled = nil
 		}
 		if elem.ConfigurationEndpoint != nil {
-			f14 := &svcapitypes.Endpoint{}
+			f7 := &svcapitypes.Endpoint{}
 			if elem.ConfigurationEndpoint.Address != nil {
-				f14.Address = elem.ConfigurationEndpoint.Address
+				f7.Address = elem.ConfigurationEndpoint.Address
 			}
 			if elem.ConfigurationEndpoint.Port != nil {
-				f14.Port = elem.ConfigurationEndpoint.Port
+				f7.Port = elem.ConfigurationEndpoint.Port
 			}
-			ko.Status.ConfigurationEndpoint = f14
+			ko.Status.ConfigurationEndpoint = f7
 		} else {
 			ko.Status.ConfigurationEndpoint = nil
 		}
-		if elem.Engine != nil {
-			ko.Spec.Engine = elem.Engine
+		if elem.Description != nil {
+			ko.Status.Description = elem.Description
 		} else {
-			ko.Spec.Engine = nil
+			ko.Status.Description = nil
 		}
-		if elem.EngineVersion != nil {
-			ko.Spec.EngineVersion = elem.EngineVersion
-		} else {
-			ko.Spec.EngineVersion = nil
-		}
-		if elem.NotificationConfiguration != nil {
-			f17 := &svcapitypes.NotificationConfiguration{}
-			if elem.NotificationConfiguration.TopicArn != nil {
-				f17.TopicARN = elem.NotificationConfiguration.TopicArn
+		if elem.GlobalReplicationGroupInfo != nil {
+			f9 := &svcapitypes.GlobalReplicationGroupInfo{}
+			if elem.GlobalReplicationGroupInfo.GlobalReplicationGroupId != nil {
+				f9.GlobalReplicationGroupID = elem.GlobalReplicationGroupInfo.GlobalReplicationGroupId
 			}
-			if elem.NotificationConfiguration.TopicStatus != nil {
-				f17.TopicStatus = elem.NotificationConfiguration.TopicStatus
+			if elem.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole != nil {
+				f9.GlobalReplicationGroupMemberRole = elem.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 			}
-			ko.Status.NotificationConfiguration = f17
+			ko.Status.GlobalReplicationGroupInfo = f9
 		} else {
-			ko.Status.NotificationConfiguration = nil
+			ko.Status.GlobalReplicationGroupInfo = nil
 		}
-		if elem.NumCacheNodes != nil {
-			ko.Spec.NumCacheNodes = elem.NumCacheNodes
+		if elem.KmsKeyId != nil {
+			ko.Spec.KMSKeyID = elem.KmsKeyId
 		} else {
-			ko.Spec.NumCacheNodes = nil
+			ko.Spec.KMSKeyID = nil
+		}
+		if elem.LogDeliveryConfigurations != nil {
+			f11 := []*svcapitypes.LogDeliveryConfigurationRequest{}
+			for _, f11iter := range elem.LogDeliveryConfigurations {
+				f11elem := &svcapitypes.LogDeliveryConfigurationRequest{}
+				if f11iter.DestinationDetails != nil {
+					f11elemf0 := &svcapitypes.DestinationDetails{}
+					if f11iter.DestinationDetails.CloudWatchLogsDetails != nil {
+						f11elemf0f0 := &svcapitypes.CloudWatchLogsDestinationDetails{}
+						if f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+							f11elemf0f0.LogGroup = f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup
+						}
+						f11elemf0.CloudWatchLogsDetails = f11elemf0f0
+					}
+					if f11iter.DestinationDetails.KinesisFirehoseDetails != nil {
+						f11elemf0f1 := &svcapitypes.KinesisFirehoseDestinationDetails{}
+						if f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+							f11elemf0f1.DeliveryStream = f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream
+						}
+						f11elemf0.KinesisFirehoseDetails = f11elemf0f1
+					}
+					f11elem.DestinationDetails = f11elemf0
+				}
+				if f11iter.DestinationType != nil {
+					f11elem.DestinationType = f11iter.DestinationType
+				}
+				if f11iter.LogFormat != nil {
+					f11elem.LogFormat = f11iter.LogFormat
+				}
+				if f11iter.LogType != nil {
+					f11elem.LogType = f11iter.LogType
+				}
+				f11 = append(f11, f11elem)
+			}
+			ko.Spec.LogDeliveryConfigurations = f11
+		} else {
+			ko.Spec.LogDeliveryConfigurations = nil
+		}
+		if elem.MemberClusters != nil {
+			f12 := []*string{}
+			for _, f12iter := range elem.MemberClusters {
+				var f12elem string
+				f12elem = *f12iter
+				f12 = append(f12, &f12elem)
+			}
+			ko.Status.MemberClusters = f12
+		} else {
+			ko.Status.MemberClusters = nil
+		}
+		if elem.MemberClustersOutpostArns != nil {
+			f13 := []*string{}
+			for _, f13iter := range elem.MemberClustersOutpostArns {
+				var f13elem string
+				f13elem = *f13iter
+				f13 = append(f13, &f13elem)
+			}
+			ko.Status.MemberClustersOutpostARNs = f13
+		} else {
+			ko.Status.MemberClustersOutpostARNs = nil
+		}
+		if elem.MultiAZ != nil {
+			ko.Status.MultiAZ = elem.MultiAZ
+		} else {
+			ko.Status.MultiAZ = nil
+		}
+		if elem.NodeGroups != nil {
+			f15 := []*svcapitypes.NodeGroup{}
+			for _, f15iter := range elem.NodeGroups {
+				f15elem := &svcapitypes.NodeGroup{}
+				if f15iter.NodeGroupId != nil {
+					f15elem.NodeGroupID = f15iter.NodeGroupId
+				}
+				if f15iter.NodeGroupMembers != nil {
+					f15elemf1 := []*svcapitypes.NodeGroupMember{}
+					for _, f15elemf1iter := range f15iter.NodeGroupMembers {
+						f15elemf1elem := &svcapitypes.NodeGroupMember{}
+						if f15elemf1iter.CacheClusterId != nil {
+							f15elemf1elem.CacheClusterID = f15elemf1iter.CacheClusterId
+						}
+						if f15elemf1iter.CacheNodeId != nil {
+							f15elemf1elem.CacheNodeID = f15elemf1iter.CacheNodeId
+						}
+						if f15elemf1iter.CurrentRole != nil {
+							f15elemf1elem.CurrentRole = f15elemf1iter.CurrentRole
+						}
+						if f15elemf1iter.PreferredAvailabilityZone != nil {
+							f15elemf1elem.PreferredAvailabilityZone = f15elemf1iter.PreferredAvailabilityZone
+						}
+						if f15elemf1iter.PreferredOutpostArn != nil {
+							f15elemf1elem.PreferredOutpostARN = f15elemf1iter.PreferredOutpostArn
+						}
+						if f15elemf1iter.ReadEndpoint != nil {
+							f15elemf1elemf5 := &svcapitypes.Endpoint{}
+							if f15elemf1iter.ReadEndpoint.Address != nil {
+								f15elemf1elemf5.Address = f15elemf1iter.ReadEndpoint.Address
+							}
+							if f15elemf1iter.ReadEndpoint.Port != nil {
+								f15elemf1elemf5.Port = f15elemf1iter.ReadEndpoint.Port
+							}
+							f15elemf1elem.ReadEndpoint = f15elemf1elemf5
+						}
+						f15elemf1 = append(f15elemf1, f15elemf1elem)
+					}
+					f15elem.NodeGroupMembers = f15elemf1
+				}
+				if f15iter.PrimaryEndpoint != nil {
+					f15elemf2 := &svcapitypes.Endpoint{}
+					if f15iter.PrimaryEndpoint.Address != nil {
+						f15elemf2.Address = f15iter.PrimaryEndpoint.Address
+					}
+					if f15iter.PrimaryEndpoint.Port != nil {
+						f15elemf2.Port = f15iter.PrimaryEndpoint.Port
+					}
+					f15elem.PrimaryEndpoint = f15elemf2
+				}
+				if f15iter.ReaderEndpoint != nil {
+					f15elemf3 := &svcapitypes.Endpoint{}
+					if f15iter.ReaderEndpoint.Address != nil {
+						f15elemf3.Address = f15iter.ReaderEndpoint.Address
+					}
+					if f15iter.ReaderEndpoint.Port != nil {
+						f15elemf3.Port = f15iter.ReaderEndpoint.Port
+					}
+					f15elem.ReaderEndpoint = f15elemf3
+				}
+				if f15iter.Slots != nil {
+					f15elem.Slots = f15iter.Slots
+				}
+				if f15iter.Status != nil {
+					f15elem.Status = f15iter.Status
+				}
+				f15 = append(f15, f15elem)
+			}
+			ko.Status.NodeGroups = f15
+		} else {
+			ko.Status.NodeGroups = nil
 		}
 		if elem.PendingModifiedValues != nil {
-			f19 := &svcapitypes.PendingModifiedValues{}
+			f16 := &svcapitypes.ReplicationGroupPendingModifiedValues{}
 			if elem.PendingModifiedValues.AuthTokenStatus != nil {
-				f19.AuthTokenStatus = elem.PendingModifiedValues.AuthTokenStatus
+				f16.AuthTokenStatus = elem.PendingModifiedValues.AuthTokenStatus
 			}
-			if elem.PendingModifiedValues.CacheNodeIdsToRemove != nil {
-				f19f1 := []*string{}
-				for _, f19f1iter := range elem.PendingModifiedValues.CacheNodeIdsToRemove {
-					var f19f1elem string
-					f19f1elem = *f19f1iter
-					f19f1 = append(f19f1, &f19f1elem)
+			if elem.PendingModifiedValues.AutomaticFailoverStatus != nil {
+				f16.AutomaticFailoverStatus = elem.PendingModifiedValues.AutomaticFailoverStatus
+			}
+			if elem.PendingModifiedValues.LogDeliveryConfigurations != nil {
+				f16f2 := []*svcapitypes.PendingLogDeliveryConfiguration{}
+				for _, f16f2iter := range elem.PendingModifiedValues.LogDeliveryConfigurations {
+					f16f2elem := &svcapitypes.PendingLogDeliveryConfiguration{}
+					if f16f2iter.DestinationDetails != nil {
+						f16f2elemf0 := &svcapitypes.DestinationDetails{}
+						if f16f2iter.DestinationDetails.CloudWatchLogsDetails != nil {
+							f16f2elemf0f0 := &svcapitypes.CloudWatchLogsDestinationDetails{}
+							if f16f2iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+								f16f2elemf0f0.LogGroup = f16f2iter.DestinationDetails.CloudWatchLogsDetails.LogGroup
+							}
+							f16f2elemf0.CloudWatchLogsDetails = f16f2elemf0f0
+						}
+						if f16f2iter.DestinationDetails.KinesisFirehoseDetails != nil {
+							f16f2elemf0f1 := &svcapitypes.KinesisFirehoseDestinationDetails{}
+							if f16f2iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+								f16f2elemf0f1.DeliveryStream = f16f2iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream
+							}
+							f16f2elemf0.KinesisFirehoseDetails = f16f2elemf0f1
+						}
+						f16f2elem.DestinationDetails = f16f2elemf0
+					}
+					if f16f2iter.DestinationType != nil {
+						f16f2elem.DestinationType = f16f2iter.DestinationType
+					}
+					if f16f2iter.LogFormat != nil {
+						f16f2elem.LogFormat = f16f2iter.LogFormat
+					}
+					if f16f2iter.LogType != nil {
+						f16f2elem.LogType = f16f2iter.LogType
+					}
+					f16f2 = append(f16f2, f16f2elem)
 				}
-				f19.CacheNodeIDsToRemove = f19f1
+				f16.LogDeliveryConfigurations = f16f2
 			}
-			if elem.PendingModifiedValues.CacheNodeType != nil {
-				f19.CacheNodeType = elem.PendingModifiedValues.CacheNodeType
+			if elem.PendingModifiedValues.PrimaryClusterId != nil {
+				f16.PrimaryClusterID = elem.PendingModifiedValues.PrimaryClusterId
 			}
-			if elem.PendingModifiedValues.EngineVersion != nil {
-				f19.EngineVersion = elem.PendingModifiedValues.EngineVersion
+			if elem.PendingModifiedValues.Resharding != nil {
+				f16f4 := &svcapitypes.ReshardingStatus{}
+				if elem.PendingModifiedValues.Resharding.SlotMigration != nil {
+					f16f4f0 := &svcapitypes.SlotMigration{}
+					if elem.PendingModifiedValues.Resharding.SlotMigration.ProgressPercentage != nil {
+						f16f4f0.ProgressPercentage = elem.PendingModifiedValues.Resharding.SlotMigration.ProgressPercentage
+					}
+					f16f4.SlotMigration = f16f4f0
+				}
+				f16.Resharding = f16f4
 			}
-			if elem.PendingModifiedValues.NumCacheNodes != nil {
-				f19.NumCacheNodes = elem.PendingModifiedValues.NumCacheNodes
+			if elem.PendingModifiedValues.UserGroups != nil {
+				f16f5 := &svcapitypes.UserGroupsUpdateStatus{}
+				if elem.PendingModifiedValues.UserGroups.UserGroupIdsToAdd != nil {
+					f16f5f0 := []*string{}
+					for _, f16f5f0iter := range elem.PendingModifiedValues.UserGroups.UserGroupIdsToAdd {
+						var f16f5f0elem string
+						f16f5f0elem = *f16f5f0iter
+						f16f5f0 = append(f16f5f0, &f16f5f0elem)
+					}
+					f16f5.UserGroupIDsToAdd = f16f5f0
+				}
+				if elem.PendingModifiedValues.UserGroups.UserGroupIdsToRemove != nil {
+					f16f5f1 := []*string{}
+					for _, f16f5f1iter := range elem.PendingModifiedValues.UserGroups.UserGroupIdsToRemove {
+						var f16f5f1elem string
+						f16f5f1elem = *f16f5f1iter
+						f16f5f1 = append(f16f5f1, &f16f5f1elem)
+					}
+					f16f5.UserGroupIDsToRemove = f16f5f1
+				}
+				f16.UserGroups = f16f5
 			}
-			ko.Status.PendingModifiedValues = f19
+			ko.Status.PendingModifiedValues = f16
 		} else {
 			ko.Status.PendingModifiedValues = nil
-		}
-		if elem.PreferredAvailabilityZone != nil {
-			ko.Spec.PreferredAvailabilityZone = elem.PreferredAvailabilityZone
-		} else {
-			ko.Spec.PreferredAvailabilityZone = nil
-		}
-		if elem.PreferredMaintenanceWindow != nil {
-			ko.Spec.PreferredMaintenanceWindow = elem.PreferredMaintenanceWindow
-		} else {
-			ko.Spec.PreferredMaintenanceWindow = nil
 		}
 		if elem.ReplicationGroupId != nil {
 			ko.Spec.ReplicationGroupID = elem.ReplicationGroupId
 		} else {
 			ko.Spec.ReplicationGroupID = nil
-		}
-		if elem.SecurityGroups != nil {
-			f23 := []*svcapitypes.SecurityGroupMembership{}
-			for _, f23iter := range elem.SecurityGroups {
-				f23elem := &svcapitypes.SecurityGroupMembership{}
-				if f23iter.SecurityGroupId != nil {
-					f23elem.SecurityGroupID = f23iter.SecurityGroupId
-				}
-				if f23iter.Status != nil {
-					f23elem.Status = f23iter.Status
-				}
-				f23 = append(f23, f23elem)
-			}
-			ko.Status.SecurityGroups = f23
-		} else {
-			ko.Status.SecurityGroups = nil
 		}
 		if elem.SnapshotRetentionLimit != nil {
 			ko.Spec.SnapshotRetentionLimit = elem.SnapshotRetentionLimit
@@ -1158,10 +1288,31 @@ func TestSetResource_Elasticache_CacheCluster_ReadMany(t *testing.T) {
 		} else {
 			ko.Spec.SnapshotWindow = nil
 		}
-		if elem.TransitEncryptionEnabled != nil {
-			ko.Status.TransitEncryptionEnabled = elem.TransitEncryptionEnabled
+		if elem.SnapshottingClusterId != nil {
+			ko.Status.SnapshottingClusterID = elem.SnapshottingClusterId
 		} else {
-			ko.Status.TransitEncryptionEnabled = nil
+			ko.Status.SnapshottingClusterID = nil
+		}
+		if elem.Status != nil {
+			ko.Status.Status = elem.Status
+		} else {
+			ko.Status.Status = nil
+		}
+		if elem.TransitEncryptionEnabled != nil {
+			ko.Spec.TransitEncryptionEnabled = elem.TransitEncryptionEnabled
+		} else {
+			ko.Spec.TransitEncryptionEnabled = nil
+		}
+		if elem.UserGroupIds != nil {
+			f23 := []*string{}
+			for _, f23iter := range elem.UserGroupIds {
+				var f23elem string
+				f23elem = *f23iter
+				f23 = append(f23, &f23elem)
+			}
+			ko.Spec.UserGroupIDs = f23
+		} else {
+			ko.Spec.UserGroupIDs = nil
 		}
 		found = true
 		break

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -739,27 +739,33 @@ func TestSetSDK_ECR_Repository_Create(t *testing.T) {
 	)
 }
 
-func TestSetSDK_Elasticache_CacheCluster_Create(t *testing.T) {
+func TestSetSDK_Elasticache_ReplicationGroup_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
 	g := testutil.NewGeneratorForService(t, "elasticache")
 
-	crd := testutil.GetCRDByName(t, g, "CacheCluster")
+	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
 
 	expected := `
-	if r.ko.Spec.AZMode != nil {
-		res.SetAZMode(*r.ko.Spec.AZMode)
+	if r.ko.Spec.AtRestEncryptionEnabled != nil {
+		res.SetAtRestEncryptionEnabled(*r.ko.Spec.AtRestEncryptionEnabled)
 	}
 	if r.ko.Spec.AuthToken != nil {
-		res.SetAuthToken(*r.ko.Spec.AuthToken)
+		tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.AuthToken)
+		if err != nil {
+			return nil, err
+		}
+		if tmpSecret != "" {
+			res.SetAuthToken(tmpSecret)
+		}
 	}
 	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
 	}
-	if r.ko.Spec.CacheClusterID != nil {
-		res.SetCacheClusterId(*r.ko.Spec.CacheClusterID)
+	if r.ko.Spec.AutomaticFailoverEnabled != nil {
+		res.SetAutomaticFailoverEnabled(*r.ko.Spec.AutomaticFailoverEnabled)
 	}
 	if r.ko.Spec.CacheNodeType != nil {
 		res.SetCacheNodeType(*r.ko.Spec.CacheNodeType)
@@ -785,50 +791,144 @@ func TestSetSDK_Elasticache_CacheCluster_Create(t *testing.T) {
 	if r.ko.Spec.EngineVersion != nil {
 		res.SetEngineVersion(*r.ko.Spec.EngineVersion)
 	}
+	if r.ko.Spec.KMSKeyID != nil {
+		res.SetKmsKeyId(*r.ko.Spec.KMSKeyID)
+	}
+	if r.ko.Spec.LogDeliveryConfigurations != nil {
+		f11 := []*svcsdk.LogDeliveryConfigurationRequest{}
+		for _, f11iter := range r.ko.Spec.LogDeliveryConfigurations {
+			f11elem := &svcsdk.LogDeliveryConfigurationRequest{}
+			if f11iter.DestinationDetails != nil {
+				f11elemf0 := &svcsdk.DestinationDetails{}
+				if f11iter.DestinationDetails.CloudWatchLogsDetails != nil {
+					f11elemf0f0 := &svcsdk.CloudWatchLogsDestinationDetails{}
+					if f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+						f11elemf0f0.SetLogGroup(*f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup)
+					}
+					f11elemf0.SetCloudWatchLogsDetails(f11elemf0f0)
+				}
+				if f11iter.DestinationDetails.KinesisFirehoseDetails != nil {
+					f11elemf0f1 := &svcsdk.KinesisFirehoseDestinationDetails{}
+					if f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+						f11elemf0f1.SetDeliveryStream(*f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
+					}
+					f11elemf0.SetKinesisFirehoseDetails(f11elemf0f1)
+				}
+				f11elem.SetDestinationDetails(f11elemf0)
+			}
+			if f11iter.DestinationType != nil {
+				f11elem.SetDestinationType(*f11iter.DestinationType)
+			}
+			if f11iter.Enabled != nil {
+				f11elem.SetEnabled(*f11iter.Enabled)
+			}
+			if f11iter.LogFormat != nil {
+				f11elem.SetLogFormat(*f11iter.LogFormat)
+			}
+			if f11iter.LogType != nil {
+				f11elem.SetLogType(*f11iter.LogType)
+			}
+			f11 = append(f11, f11elem)
+		}
+		res.SetLogDeliveryConfigurations(f11)
+	}
+	if r.ko.Spec.MultiAZEnabled != nil {
+		res.SetMultiAZEnabled(*r.ko.Spec.MultiAZEnabled)
+	}
+	if r.ko.Spec.NodeGroupConfiguration != nil {
+		f13 := []*svcsdk.NodeGroupConfiguration{}
+		for _, f13iter := range r.ko.Spec.NodeGroupConfiguration {
+			f13elem := &svcsdk.NodeGroupConfiguration{}
+			if f13iter.NodeGroupID != nil {
+				f13elem.SetNodeGroupId(*f13iter.NodeGroupID)
+			}
+			if f13iter.PrimaryAvailabilityZone != nil {
+				f13elem.SetPrimaryAvailabilityZone(*f13iter.PrimaryAvailabilityZone)
+			}
+			if f13iter.PrimaryOutpostARN != nil {
+				f13elem.SetPrimaryOutpostArn(*f13iter.PrimaryOutpostARN)
+			}
+			if f13iter.ReplicaAvailabilityZones != nil {
+				f13elemf3 := []*string{}
+				for _, f13elemf3iter := range f13iter.ReplicaAvailabilityZones {
+					var f13elemf3elem string
+					f13elemf3elem = *f13elemf3iter
+					f13elemf3 = append(f13elemf3, &f13elemf3elem)
+				}
+				f13elem.SetReplicaAvailabilityZones(f13elemf3)
+			}
+			if f13iter.ReplicaCount != nil {
+				f13elem.SetReplicaCount(*f13iter.ReplicaCount)
+			}
+			if f13iter.ReplicaOutpostARNs != nil {
+				f13elemf5 := []*string{}
+				for _, f13elemf5iter := range f13iter.ReplicaOutpostARNs {
+					var f13elemf5elem string
+					f13elemf5elem = *f13elemf5iter
+					f13elemf5 = append(f13elemf5, &f13elemf5elem)
+				}
+				f13elem.SetReplicaOutpostArns(f13elemf5)
+			}
+			if f13iter.Slots != nil {
+				f13elem.SetSlots(*f13iter.Slots)
+			}
+			f13 = append(f13, f13elem)
+		}
+		res.SetNodeGroupConfiguration(f13)
+	}
 	if r.ko.Spec.NotificationTopicARN != nil {
 		res.SetNotificationTopicArn(*r.ko.Spec.NotificationTopicARN)
 	}
-	if r.ko.Spec.NumCacheNodes != nil {
-		res.SetNumCacheNodes(*r.ko.Spec.NumCacheNodes)
+	if r.ko.Spec.NumCacheClusters != nil {
+		res.SetNumCacheClusters(*r.ko.Spec.NumCacheClusters)
+	}
+	if r.ko.Spec.NumNodeGroups != nil {
+		res.SetNumNodeGroups(*r.ko.Spec.NumNodeGroups)
 	}
 	if r.ko.Spec.Port != nil {
 		res.SetPort(*r.ko.Spec.Port)
 	}
-	if r.ko.Spec.PreferredAvailabilityZone != nil {
-		res.SetPreferredAvailabilityZone(*r.ko.Spec.PreferredAvailabilityZone)
-	}
-	if r.ko.Spec.PreferredAvailabilityZones != nil {
-		f14 := []*string{}
-		for _, f14iter := range r.ko.Spec.PreferredAvailabilityZones {
-			var f14elem string
-			f14elem = *f14iter
-			f14 = append(f14, &f14elem)
+	if r.ko.Spec.PreferredCacheClusterAZs != nil {
+		f18 := []*string{}
+		for _, f18iter := range r.ko.Spec.PreferredCacheClusterAZs {
+			var f18elem string
+			f18elem = *f18iter
+			f18 = append(f18, &f18elem)
 		}
-		res.SetPreferredAvailabilityZones(f14)
+		res.SetPreferredCacheClusterAZs(f18)
 	}
 	if r.ko.Spec.PreferredMaintenanceWindow != nil {
 		res.SetPreferredMaintenanceWindow(*r.ko.Spec.PreferredMaintenanceWindow)
+	}
+	if r.ko.Spec.PrimaryClusterID != nil {
+		res.SetPrimaryClusterId(*r.ko.Spec.PrimaryClusterID)
+	}
+	if r.ko.Spec.ReplicasPerNodeGroup != nil {
+		res.SetReplicasPerNodeGroup(*r.ko.Spec.ReplicasPerNodeGroup)
+	}
+	if r.ko.Spec.ReplicationGroupDescription != nil {
+		res.SetReplicationGroupDescription(*r.ko.Spec.ReplicationGroupDescription)
 	}
 	if r.ko.Spec.ReplicationGroupID != nil {
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
 	}
 	if r.ko.Spec.SecurityGroupIDs != nil {
-		f17 := []*string{}
-		for _, f17iter := range r.ko.Spec.SecurityGroupIDs {
-			var f17elem string
-			f17elem = *f17iter
-			f17 = append(f17, &f17elem)
+		f24 := []*string{}
+		for _, f24iter := range r.ko.Spec.SecurityGroupIDs {
+			var f24elem string
+			f24elem = *f24iter
+			f24 = append(f24, &f24elem)
 		}
-		res.SetSecurityGroupIds(f17)
+		res.SetSecurityGroupIds(f24)
 	}
 	if r.ko.Spec.SnapshotARNs != nil {
-		f18 := []*string{}
-		for _, f18iter := range r.ko.Spec.SnapshotARNs {
-			var f18elem string
-			f18elem = *f18iter
-			f18 = append(f18, &f18elem)
+		f25 := []*string{}
+		for _, f25iter := range r.ko.Spec.SnapshotARNs {
+			var f25elem string
+			f25elem = *f25iter
+			f25 = append(f25, &f25elem)
 		}
-		res.SetSnapshotArns(f18)
+		res.SetSnapshotArns(f25)
 	}
 	if r.ko.Spec.SnapshotName != nil {
 		res.SetSnapshotName(*r.ko.Spec.SnapshotName)
@@ -840,18 +940,30 @@ func TestSetSDK_Elasticache_CacheCluster_Create(t *testing.T) {
 		res.SetSnapshotWindow(*r.ko.Spec.SnapshotWindow)
 	}
 	if r.ko.Spec.Tags != nil {
-		f22 := []*svcsdk.Tag{}
-		for _, f22iter := range r.ko.Spec.Tags {
-			f22elem := &svcsdk.Tag{}
-			if f22iter.Key != nil {
-				f22elem.SetKey(*f22iter.Key)
+		f29 := []*svcsdk.Tag{}
+		for _, f29iter := range r.ko.Spec.Tags {
+			f29elem := &svcsdk.Tag{}
+			if f29iter.Key != nil {
+				f29elem.SetKey(*f29iter.Key)
 			}
-			if f22iter.Value != nil {
-				f22elem.SetValue(*f22iter.Value)
+			if f29iter.Value != nil {
+				f29elem.SetValue(*f29iter.Value)
 			}
-			f22 = append(f22, f22elem)
+			f29 = append(f29, f29elem)
 		}
-		res.SetTags(f22)
+		res.SetTags(f29)
+	}
+	if r.ko.Spec.TransitEncryptionEnabled != nil {
+		res.SetTransitEncryptionEnabled(*r.ko.Spec.TransitEncryptionEnabled)
+	}
+	if r.ko.Spec.UserGroupIDs != nil {
+		f31 := []*string{}
+		for _, f31iter := range r.ko.Spec.UserGroupIDs {
+			var f31elem string
+			f31elem = *f31iter
+			f31 = append(f31, &f31elem)
+		}
+		res.SetUserGroupIds(f31)
 	}
 `
 	assert.Equal(
@@ -860,13 +972,13 @@ func TestSetSDK_Elasticache_CacheCluster_Create(t *testing.T) {
 	)
 }
 
-func TestSetSDK_Elasticache_CacheCluster_ReadMany(t *testing.T) {
+func TestSetSDK_Elasticache_ReplicationGroup_ReadMany(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
 	g := testutil.NewGeneratorForService(t, "elasticache")
 
-	crd := testutil.GetCRDByName(t, g, "CacheCluster")
+	crd := testutil.GetCRDByName(t, g, "ReplicationGroup")
 	require.NotNil(crd)
 
 	// Elasticache doesn't have a ReadOne operation; only a List/ReadMany
@@ -874,8 +986,8 @@ func TestSetSDK_Elasticache_CacheCluster_ReadMany(t *testing.T) {
 	// DescribeCacheClustersInput and processing of the
 	// DescribeCacheClustersOutput shapes is correct.
 	expected := `
-	if r.ko.Spec.CacheClusterID != nil {
-		res.SetCacheClusterId(*r.ko.Spec.CacheClusterID)
+	if r.ko.Spec.ReplicationGroupID != nil {
+		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
 	}
 `
 	assert.Equal(
@@ -925,8 +1037,43 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 		}
 		res.SetCacheSecurityGroupNames(f7)
 	}
-	if r.ko.Spec.EngineVersion != nil {
-		res.SetEngineVersion(*r.ko.Spec.EngineVersion)
+	if r.ko.Spec.LogDeliveryConfigurations != nil {
+		f8 := []*svcsdk.LogDeliveryConfigurationRequest{}
+		for _, f8iter := range r.ko.Spec.LogDeliveryConfigurations {
+			f8elem := &svcsdk.LogDeliveryConfigurationRequest{}
+			if f8iter.DestinationDetails != nil {
+				f8elemf0 := &svcsdk.DestinationDetails{}
+				if f8iter.DestinationDetails.CloudWatchLogsDetails != nil {
+					f8elemf0f0 := &svcsdk.CloudWatchLogsDestinationDetails{}
+					if f8iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+						f8elemf0f0.SetLogGroup(*f8iter.DestinationDetails.CloudWatchLogsDetails.LogGroup)
+					}
+					f8elemf0.SetCloudWatchLogsDetails(f8elemf0f0)
+				}
+				if f8iter.DestinationDetails.KinesisFirehoseDetails != nil {
+					f8elemf0f1 := &svcsdk.KinesisFirehoseDestinationDetails{}
+					if f8iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+						f8elemf0f1.SetDeliveryStream(*f8iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
+					}
+					f8elemf0.SetKinesisFirehoseDetails(f8elemf0f1)
+				}
+				f8elem.SetDestinationDetails(f8elemf0)
+			}
+			if f8iter.DestinationType != nil {
+				f8elem.SetDestinationType(*f8iter.DestinationType)
+			}
+			if f8iter.Enabled != nil {
+				f8elem.SetEnabled(*f8iter.Enabled)
+			}
+			if f8iter.LogFormat != nil {
+				f8elem.SetLogFormat(*f8iter.LogFormat)
+			}
+			if f8iter.LogType != nil {
+				f8elem.SetLogType(*f8iter.LogType)
+			}
+			f8 = append(f8, f8elem)
+		}
+		res.SetLogDeliveryConfigurations(f8)
 	}
 	if r.ko.Spec.MultiAZEnabled != nil {
 		res.SetMultiAZEnabled(*r.ko.Spec.MultiAZEnabled)
@@ -945,15 +1092,6 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 	}
 	if r.ko.Spec.ReplicationGroupID != nil {
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
-	}
-	if r.ko.Spec.SecurityGroupIDs != nil {
-		f17 := []*string{}
-		for _, f17iter := range r.ko.Spec.SecurityGroupIDs {
-			var f17elem string
-			f17elem = *f17iter
-			f17 = append(f17, &f17elem)
-		}
-		res.SetSecurityGroupIds(f17)
 	}
 	if r.ko.Spec.SnapshotRetentionLimit != nil {
 		res.SetSnapshotRetentionLimit(*r.ko.Spec.SnapshotRetentionLimit)

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
-func TestElasticache_CacheCluster(t *testing.T) {
+func TestElasticache_ReplicationGroup(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -31,41 +31,41 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	crds, err := g.GetCRDs()
 	require.Nil(err)
 
-	crd := getCRDByName("CacheCluster", crds)
+	crd := getCRDByName("ReplicationGroup", crds)
 	require.NotNil(crd)
 
-	assert.Equal("CacheCluster", crd.Names.Camel)
-	assert.Equal("cacheCluster", crd.Names.CamelLower)
-	assert.Equal("cache_cluster", crd.Names.Snake)
+	assert.Equal("ReplicationGroup", crd.Names.Camel)
+	assert.Equal("replicationGroup", crd.Names.CamelLower)
+	assert.Equal("replication_group", crd.Names.Snake)
 
 	// The DescribeCacheClusters operation has the following definition:
 	//
-	//    "DescribeCacheClusters":{
-	//      "name":"DescribeCacheClusters",
-	//      "http":{
-	//        "method":"POST",
-	//        "requestUri":"/"
-	//      },
-	//      "input":{"shape":"DescribeCacheClustersMessage"},
-	//      "output":{
-	//        "shape":"CacheClusterMessage",
-	//        "resultWrapper":"DescribeCacheClustersResult"
-	//      },
-	//      "errors":[
-	//        {"shape":"CacheClusterNotFoundFault"},
-	//        {"shape":"InvalidParameterValueException"},
-	//        {"shape":"InvalidParameterCombinationException"}
-	//      ]
-	//    },
+	//	"DescribeReplicationGroups":{
+	//		"name":"DescribeReplicationGroups",
+	//			"http":{
+	//			"method":"POST",
+	//				"requestUri":"/"
+	//		},
+	//		"input":{"shape":"DescribeReplicationGroupsMessage"},
+	//		"output":{
+	//			"shape":"ReplicationGroupMessage",
+	//				"resultWrapper":"DescribeReplicationGroupsResult"
+	//		},
+	//		"errors":[
+	//			{"shape":"ReplicationGroupNotFoundFault"},
+	//			{"shape":"InvalidParameterValueException"},
+	//			{"shape":"InvalidParameterCombinationException"}
+	//		]
+	//	}
 	//
-	// Where the CacheClusterNotFoundFault shape looks like this:
+	// Where the ReplicationGroupNotFoundFault shape looks like this:
 	//
-	//    "CacheClusterNotFoundFault":{
+	//    "ReplicationGroupNotFoundFault":{
 	//      "type":"structure",
 	//      "members":{
 	//      },
 	//      "error":{
-	//        "code":"CacheClusterNotFound",
+	//        "code":"ReplicationGroupNotFoundFault",
 	//        "httpStatusCode":404,
 	//        "senderFault":true
 	//      },
@@ -73,15 +73,15 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	//    },
 	//
 	// Which indicates that the error is a 404 and is our NotFoundException
-	// error with a "code" value of CacheClusterNotFound
-	assert.Equal("CacheClusterNotFound", crd.ExceptionCode(404))
+	// error with a "code" value of ReplicationGroupNotFoundFault
+	assert.Equal("ReplicationGroupNotFoundFault", crd.ExceptionCode(404))
 
-	// The Elasticache CacheCluster API has CUD+L operations:
+	// The Elasticache ReplicationGroup API has CUD+L operations:
 	//
-	// * CreateCacheCluster
-	// * DeleteCacheCluster
-	// * UpdateCacheCluster
-	// * GetCacheClusters
+	// * CreateReplicationGroup
+	// * DeleteReplicationGroup
+	// * ModifyReplicationGroup
+	// * DescribeReplicationGroup
 	require.NotNil(crd.Ops)
 
 	assert.NotNil(crd.Ops.Create)
@@ -100,22 +100,29 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	statusFields := crd.StatusFields
 
 	expSpecFieldCamel := []string{
-		"AZMode",
+		"AtRestEncryptionEnabled",
 		"AuthToken",
 		"AutoMinorVersionUpgrade",
-		"CacheClusterID",
+		"AutomaticFailoverEnabled",
 		"CacheNodeType",
 		"CacheParameterGroupName",
 		"CacheSecurityGroupNames",
 		"CacheSubnetGroupName",
 		"Engine",
 		"EngineVersion",
+		"KMSKeyID",
+		"LogDeliveryConfigurations",
+		"MultiAZEnabled",
+		"NodeGroupConfiguration",
 		"NotificationTopicARN",
-		"NumCacheNodes",
+		"NumCacheClusters",
+		"NumNodeGroups",
 		"Port",
-		"PreferredAvailabilityZone",
-		"PreferredAvailabilityZones",
+		"PreferredCacheClusterAZs",
 		"PreferredMaintenanceWindow",
+		"PrimaryClusterID",
+		"ReplicasPerNodeGroup",
+		"ReplicationGroupDescription",
 		"ReplicationGroupID",
 		"SecurityGroupIDs",
 		"SnapshotARNs",
@@ -123,40 +130,31 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		"SnapshotRetentionLimit",
 		"SnapshotWindow",
 		"Tags",
+		"TransitEncryptionEnabled",
+		"UserGroupIDs",
 	}
 	assert.Equal(expSpecFieldCamel, attrCamelNames(specFields))
 
 	expStatusFieldCamel := []string{
-		"AtRestEncryptionEnabled",
+		"AllowedScaleDownModifications",
+		"AllowedScaleUpModifications",
 		"AuthTokenEnabled",
 		"AuthTokenLastModifiedDate",
-		"CacheClusterCreateTime",
-		"CacheClusterStatus",
-		"CacheNodes",
-		"CacheParameterGroup",
-		"CacheSecurityGroups",
-		"ClientDownloadLandingPage",
+		"AutomaticFailover",
+		"ClusterEnabled",
 		"ConfigurationEndpoint",
-		"NotificationConfiguration",
+		"Description",
+		"Events",
+		"GlobalReplicationGroupInfo",
+		"MemberClusters",
+		"MemberClustersOutpostARNs",
+		"MultiAZ",
+		"NodeGroups",
 		"PendingModifiedValues",
-		"SecurityGroups",
-		"TransitEncryptionEnabled",
+		"SnapshottingClusterID",
+		"Status",
 	}
 	assert.Equal(expStatusFieldCamel, attrCamelNames(statusFields))
-}
-
-func TestElasticache_Ignored_Operations(t *testing.T) {
-	require := require.New(t)
-
-	g := testutil.NewGeneratorForService(t, "elasticache")
-
-	crds, err := g.GetCRDs()
-	require.Nil(err)
-
-	crd := getCRDByName("Snapshot", crds)
-	require.NotNil(crd)
-	require.NotNil(crd.Ops.Create)
-	require.Nil(crd.Ops.Delete)
 }
 
 func TestElasticache_Ignored_Resources(t *testing.T) {

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/api-2.json
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/api-2.json
@@ -24,7 +24,15 @@
       },
       "errors":[
         {"shape":"CacheClusterNotFoundFault"},
+        {"shape":"CacheParameterGroupNotFoundFault"},
+        {"shape":"CacheSecurityGroupNotFoundFault"},
+        {"shape":"CacheSubnetGroupNotFoundFault"},
+        {"shape":"InvalidReplicationGroupStateFault"},
+        {"shape":"ReplicationGroupNotFoundFault"},
+        {"shape":"ReservedCacheNodeNotFoundFault"},
         {"shape":"SnapshotNotFoundFault"},
+        {"shape":"UserNotFoundFault"},
+        {"shape":"UserGroupNotFoundFault"},
         {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidARNFault"}
       ]
@@ -113,6 +121,7 @@
         {"shape":"SnapshotNotFoundFault"},
         {"shape":"SnapshotQuotaExceededFault"},
         {"shape":"InvalidSnapshotStateFault"},
+        {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
@@ -160,6 +169,7 @@
         {"shape":"CacheParameterGroupQuotaExceededFault"},
         {"shape":"CacheParameterGroupAlreadyExistsFault"},
         {"shape":"InvalidCacheParameterGroupStateFault"},
+        {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
@@ -178,6 +188,7 @@
       "errors":[
         {"shape":"CacheSecurityGroupAlreadyExistsFault"},
         {"shape":"CacheSecurityGroupQuotaExceededFault"},
+        {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
@@ -197,7 +208,9 @@
         {"shape":"CacheSubnetGroupAlreadyExistsFault"},
         {"shape":"CacheSubnetGroupQuotaExceededFault"},
         {"shape":"CacheSubnetQuotaExceededFault"},
-        {"shape":"InvalidSubnet"}
+        {"shape":"TagQuotaPerResourceExceeded"},
+        {"shape":"InvalidSubnet"},
+        {"shape":"SubnetNotAllowedFault"}
       ]
     },
     "CreateGlobalReplicationGroup":{
@@ -234,6 +247,8 @@
         {"shape":"CacheClusterNotFoundFault"},
         {"shape":"InvalidCacheClusterStateFault"},
         {"shape":"ReplicationGroupAlreadyExistsFault"},
+        {"shape":"InvalidUserGroupStateFault"},
+        {"shape":"UserGroupNotFoundFault"},
         {"shape":"InsufficientCacheClusterCapacityFault"},
         {"shape":"CacheSecurityGroupNotFoundFault"},
         {"shape":"CacheSubnetGroupNotFoundFault"},
@@ -269,8 +284,50 @@
         {"shape":"InvalidReplicationGroupStateFault"},
         {"shape":"SnapshotQuotaExceededFault"},
         {"shape":"SnapshotFeatureNotSupportedFault"},
+        {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidParameterCombinationException"},
         {"shape":"InvalidParameterValueException"}
+      ]
+    },
+    "CreateUser":{
+      "name":"CreateUser",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateUserMessage"},
+      "output":{
+        "shape":"User",
+        "resultWrapper":"CreateUserResult"
+      },
+      "errors":[
+        {"shape":"UserAlreadyExistsFault"},
+        {"shape":"UserQuotaExceededFault"},
+        {"shape":"DuplicateUserNameFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"InvalidParameterCombinationException"},
+        {"shape":"TagQuotaPerResourceExceeded"}
+      ]
+    },
+    "CreateUserGroup":{
+      "name":"CreateUserGroup",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateUserGroupMessage"},
+      "output":{
+        "shape":"UserGroup",
+        "resultWrapper":"CreateUserGroupResult"
+      },
+      "errors":[
+        {"shape":"UserNotFoundFault"},
+        {"shape":"DuplicateUserNameFault"},
+        {"shape":"UserGroupAlreadyExistsFault"},
+        {"shape":"DefaultUserRequired"},
+        {"shape":"UserGroupQuotaExceededFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"TagQuotaPerResourceExceeded"}
       ]
     },
     "DecreaseNodeGroupsInGlobalReplicationGroup":{
@@ -432,6 +489,41 @@
         {"shape":"InvalidSnapshotStateFault"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
+      ]
+    },
+    "DeleteUser":{
+      "name":"DeleteUser",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteUserMessage"},
+      "output":{
+        "shape":"User",
+        "resultWrapper":"DeleteUserResult"
+      },
+      "errors":[
+        {"shape":"InvalidUserStateFault"},
+        {"shape":"UserNotFoundFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"DefaultUserAssociatedToUserGroupFault"}
+      ]
+    },
+    "DeleteUserGroup":{
+      "name":"DeleteUserGroup",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteUserGroupMessage"},
+      "output":{
+        "shape":"UserGroup",
+        "resultWrapper":"DeleteUserGroupResult"
+      },
+      "errors":[
+        {"shape":"UserGroupNotFoundFault"},
+        {"shape":"InvalidUserGroupStateFault"},
+        {"shape":"InvalidParameterValueException"}
       ]
     },
     "DescribeCacheClusters":{
@@ -680,6 +772,38 @@
         {"shape":"InvalidParameterCombinationException"}
       ]
     },
+    "DescribeUserGroups":{
+      "name":"DescribeUserGroups",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeUserGroupsMessage"},
+      "output":{
+        "shape":"DescribeUserGroupsResult",
+        "resultWrapper":"DescribeUserGroupsResult"
+      },
+      "errors":[
+        {"shape":"UserGroupNotFoundFault"},
+        {"shape":"InvalidParameterCombinationException"}
+      ]
+    },
+    "DescribeUsers":{
+      "name":"DescribeUsers",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeUsersMessage"},
+      "output":{
+        "shape":"DescribeUsersResult",
+        "resultWrapper":"DescribeUsersResult"
+      },
+      "errors":[
+        {"shape":"UserNotFoundFault"},
+        {"shape":"InvalidParameterCombinationException"}
+      ]
+    },
     "DisassociateGlobalReplicationGroup":{
       "name":"DisassociateGlobalReplicationGroup",
       "http":{
@@ -790,7 +914,15 @@
       },
       "errors":[
         {"shape":"CacheClusterNotFoundFault"},
+        {"shape":"CacheParameterGroupNotFoundFault"},
+        {"shape":"CacheSecurityGroupNotFoundFault"},
+        {"shape":"CacheSubnetGroupNotFoundFault"},
+        {"shape":"InvalidReplicationGroupStateFault"},
+        {"shape":"ReplicationGroupNotFoundFault"},
+        {"shape":"ReservedCacheNodeNotFoundFault"},
         {"shape":"SnapshotNotFoundFault"},
+        {"shape":"UserNotFoundFault"},
+        {"shape":"UserGroupNotFoundFault"},
         {"shape":"InvalidARNFault"}
       ]
     },
@@ -853,7 +985,8 @@
         {"shape":"CacheSubnetGroupNotFoundFault"},
         {"shape":"CacheSubnetQuotaExceededFault"},
         {"shape":"SubnetInUse"},
-        {"shape":"InvalidSubnet"}
+        {"shape":"InvalidSubnet"},
+        {"shape":"SubnetNotAllowedFault"}
       ]
     },
     "ModifyGlobalReplicationGroup":{
@@ -887,6 +1020,8 @@
       "errors":[
         {"shape":"ReplicationGroupNotFoundFault"},
         {"shape":"InvalidReplicationGroupStateFault"},
+        {"shape":"InvalidUserGroupStateFault"},
+        {"shape":"UserGroupNotFoundFault"},
         {"shape":"InvalidCacheClusterStateFault"},
         {"shape":"InvalidCacheSecurityGroupStateFault"},
         {"shape":"InsufficientCacheClusterCapacityFault"},
@@ -925,6 +1060,45 @@
         {"shape":"InvalidParameterCombinationException"}
       ]
     },
+    "ModifyUser":{
+      "name":"ModifyUser",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ModifyUserMessage"},
+      "output":{
+        "shape":"User",
+        "resultWrapper":"ModifyUserResult"
+      },
+      "errors":[
+        {"shape":"UserNotFoundFault"},
+        {"shape":"InvalidUserStateFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"InvalidParameterCombinationException"}
+      ]
+    },
+    "ModifyUserGroup":{
+      "name":"ModifyUserGroup",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ModifyUserGroupMessage"},
+      "output":{
+        "shape":"UserGroup",
+        "resultWrapper":"ModifyUserGroupResult"
+      },
+      "errors":[
+        {"shape":"UserGroupNotFoundFault"},
+        {"shape":"UserNotFoundFault"},
+        {"shape":"DuplicateUserNameFault"},
+        {"shape":"DefaultUserRequired"},
+        {"shape":"InvalidUserGroupStateFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"InvalidParameterCombinationException"}
+      ]
+    },
     "PurchaseReservedCacheNodesOffering":{
       "name":"PurchaseReservedCacheNodesOffering",
       "http":{
@@ -940,6 +1114,7 @@
         {"shape":"ReservedCacheNodesOfferingNotFoundFault"},
         {"shape":"ReservedCacheNodeAlreadyExistsFault"},
         {"shape":"ReservedCacheNodeQuotaExceededFault"},
+        {"shape":"TagQuotaPerResourceExceeded"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
@@ -990,7 +1165,15 @@
       },
       "errors":[
         {"shape":"CacheClusterNotFoundFault"},
+        {"shape":"CacheParameterGroupNotFoundFault"},
+        {"shape":"CacheSecurityGroupNotFoundFault"},
+        {"shape":"CacheSubnetGroupNotFoundFault"},
+        {"shape":"InvalidReplicationGroupStateFault"},
+        {"shape":"ReplicationGroupNotFoundFault"},
+        {"shape":"ReservedCacheNodeNotFoundFault"},
         {"shape":"SnapshotNotFoundFault"},
+        {"shape":"UserNotFoundFault"},
+        {"shape":"UserGroupNotFoundFault"},
         {"shape":"InvalidARNFault"},
         {"shape":"TagNotFoundFault"}
       ]
@@ -1094,6 +1277,10 @@
         "cross-az"
       ]
     },
+    "AccessString":{
+      "type":"string",
+      "pattern":".*\\S.*"
+    },
     "AddTagsToResourceMessage":{
       "type":"structure",
       "required":[
@@ -1129,7 +1316,22 @@
       "type":"string",
       "enum":[
         "SET",
-        "ROTATE"
+        "ROTATE",
+        "DELETE"
+      ]
+    },
+    "Authentication":{
+      "type":"structure",
+      "members":{
+        "Type":{"shape":"AuthenticationType"},
+        "PasswordCount":{"shape":"IntegerOptional"}
+      }
+    },
+    "AuthenticationType":{
+      "type":"string",
+      "enum":[
+        "password",
+        "no-password"
       ]
     },
     "AuthorizationAlreadyExistsFault":{
@@ -1229,6 +1431,7 @@
         "CacheClusterStatus":{"shape":"String"},
         "NumCacheNodes":{"shape":"IntegerOptional"},
         "PreferredAvailabilityZone":{"shape":"String"},
+        "PreferredOutpostArn":{"shape":"String"},
         "CacheClusterCreateTime":{"shape":"TStamp"},
         "PreferredMaintenanceWindow":{"shape":"String"},
         "PendingModifiedValues":{"shape":"PendingModifiedValues"},
@@ -1246,7 +1449,9 @@
         "AuthTokenLastModifiedDate":{"shape":"TStamp"},
         "TransitEncryptionEnabled":{"shape":"BooleanOptional"},
         "AtRestEncryptionEnabled":{"shape":"BooleanOptional"},
-        "ARN":{"shape":"String"}
+        "ARN":{"shape":"String"},
+        "ReplicationGroupLogDeliveryEnabled":{"shape":"Boolean"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationList"}
       },
       "wrapper":true
     },
@@ -1324,7 +1529,8 @@
         "Endpoint":{"shape":"Endpoint"},
         "ParameterGroupStatus":{"shape":"String"},
         "SourceCacheNodeId":{"shape":"String"},
-        "CustomerAvailabilityZone":{"shape":"String"}
+        "CustomerAvailabilityZone":{"shape":"String"},
+        "CustomerOutpostArn":{"shape":"String"}
       }
     },
     "CacheNodeIdsList":{
@@ -1642,6 +1848,12 @@
         "requires-reboot"
       ]
     },
+    "CloudWatchLogsDestinationDetails":{
+      "type":"structure",
+      "members":{
+        "LogGroup":{"shape":"String"}
+      }
+    },
     "ClusterIdList":{
       "type":"list",
       "member":{
@@ -1683,7 +1895,8 @@
       "members":{
         "NodeGroupId":{"shape":"AllowedNodeGroupId"},
         "NewReplicaCount":{"shape":"Integer"},
-        "PreferredAvailabilityZones":{"shape":"PreferredAvailabilityZoneList"}
+        "PreferredAvailabilityZones":{"shape":"PreferredAvailabilityZoneList"},
+        "PreferredOutpostArns":{"shape":"PreferredOutpostArnList"}
       }
     },
     "CopySnapshotMessage":{
@@ -1696,7 +1909,8 @@
         "SourceSnapshotName":{"shape":"String"},
         "TargetSnapshotName":{"shape":"String"},
         "TargetBucket":{"shape":"String"},
-        "KmsKeyId":{"shape":"String"}
+        "KmsKeyId":{"shape":"String"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CopySnapshotResult":{
@@ -1731,7 +1945,11 @@
         "AutoMinorVersionUpgrade":{"shape":"BooleanOptional"},
         "SnapshotRetentionLimit":{"shape":"IntegerOptional"},
         "SnapshotWindow":{"shape":"String"},
-        "AuthToken":{"shape":"String"}
+        "AuthToken":{"shape":"String"},
+        "OutpostMode":{"shape":"OutpostMode"},
+        "PreferredOutpostArn":{"shape":"String"},
+        "PreferredOutpostArns":{"shape":"PreferredOutpostArnList"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationRequestList"}
       }
     },
     "CreateCacheClusterResult":{
@@ -1750,7 +1968,8 @@
       "members":{
         "CacheParameterGroupName":{"shape":"String"},
         "CacheParameterGroupFamily":{"shape":"String"},
-        "Description":{"shape":"String"}
+        "Description":{"shape":"String"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CreateCacheParameterGroupResult":{
@@ -1767,7 +1986,8 @@
       ],
       "members":{
         "CacheSecurityGroupName":{"shape":"String"},
-        "Description":{"shape":"String"}
+        "Description":{"shape":"String"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CreateCacheSecurityGroupResult":{
@@ -1786,7 +2006,8 @@
       "members":{
         "CacheSubnetGroupName":{"shape":"String"},
         "CacheSubnetGroupDescription":{"shape":"String"},
-        "SubnetIds":{"shape":"SubnetIdentifierList"}
+        "SubnetIds":{"shape":"SubnetIdentifierList"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CreateCacheSubnetGroupResult":{
@@ -1850,7 +2071,9 @@
         "AuthToken":{"shape":"String"},
         "TransitEncryptionEnabled":{"shape":"BooleanOptional"},
         "AtRestEncryptionEnabled":{"shape":"BooleanOptional"},
-        "KmsKeyId":{"shape":"String"}
+        "KmsKeyId":{"shape":"String"},
+        "UserGroupIds":{"shape":"UserGroupIdListInput"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationRequestList"}
       }
     },
     "CreateReplicationGroupResult":{
@@ -1866,13 +2089,45 @@
         "ReplicationGroupId":{"shape":"String"},
         "CacheClusterId":{"shape":"String"},
         "SnapshotName":{"shape":"String"},
-        "KmsKeyId":{"shape":"String"}
+        "KmsKeyId":{"shape":"String"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CreateSnapshotResult":{
       "type":"structure",
       "members":{
         "Snapshot":{"shape":"Snapshot"}
+      }
+    },
+    "CreateUserGroupMessage":{
+      "type":"structure",
+      "required":[
+        "UserGroupId",
+        "Engine"
+      ],
+      "members":{
+        "UserGroupId":{"shape":"String"},
+        "Engine":{"shape":"EngineType"},
+        "UserIds":{"shape":"UserIdListInput"},
+        "Tags":{"shape":"TagList"}
+      }
+    },
+    "CreateUserMessage":{
+      "type":"structure",
+      "required":[
+        "UserId",
+        "UserName",
+        "Engine",
+        "AccessString"
+      ],
+      "members":{
+        "UserId":{"shape":"UserId"},
+        "UserName":{"shape":"UserName"},
+        "Engine":{"shape":"EngineType"},
+        "Passwords":{"shape":"PasswordListInput"},
+        "AccessString":{"shape":"AccessString"},
+        "NoPasswordRequired":{"shape":"BooleanOptional"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CustomerNodeEndpoint":{
@@ -1926,6 +2181,28 @@
       "members":{
         "ReplicationGroup":{"shape":"ReplicationGroup"}
       }
+    },
+    "DefaultUserAssociatedToUserGroupFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"DefaultUserAssociatedToUserGroup",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "DefaultUserRequired":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"DefaultUserRequired",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
     },
     "DeleteCacheClusterMessage":{
       "type":"structure",
@@ -2005,6 +2282,20 @@
       "type":"structure",
       "members":{
         "Snapshot":{"shape":"Snapshot"}
+      }
+    },
+    "DeleteUserGroupMessage":{
+      "type":"structure",
+      "required":["UserGroupId"],
+      "members":{
+        "UserGroupId":{"shape":"String"}
+      }
+    },
+    "DeleteUserMessage":{
+      "type":"structure",
+      "required":["UserId"],
+      "members":{
+        "UserId":{"shape":"UserId"}
       }
     },
     "DescribeCacheClustersMessage":{
@@ -2181,6 +2472,52 @@
         "Marker":{"shape":"String"}
       }
     },
+    "DescribeUserGroupsMessage":{
+      "type":"structure",
+      "members":{
+        "UserGroupId":{"shape":"String"},
+        "MaxRecords":{"shape":"IntegerOptional"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DescribeUserGroupsResult":{
+      "type":"structure",
+      "members":{
+        "UserGroups":{"shape":"UserGroupList"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DescribeUsersMessage":{
+      "type":"structure",
+      "members":{
+        "Engine":{"shape":"EngineType"},
+        "UserId":{"shape":"UserId"},
+        "Filters":{"shape":"FilterList"},
+        "MaxRecords":{"shape":"IntegerOptional"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DescribeUsersResult":{
+      "type":"structure",
+      "members":{
+        "Users":{"shape":"UserList"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DestinationDetails":{
+      "type":"structure",
+      "members":{
+        "CloudWatchLogsDetails":{"shape":"CloudWatchLogsDestinationDetails"},
+        "KinesisFirehoseDetails":{"shape":"KinesisFirehoseDestinationDetails"}
+      }
+    },
+    "DestinationType":{
+      "type":"string",
+      "enum":[
+        "cloudwatch-logs",
+        "kinesis-firehose"
+      ]
+    },
     "DisassociateGlobalReplicationGroupMessage":{
       "type":"structure",
       "required":[
@@ -2201,6 +2538,17 @@
       }
     },
     "Double":{"type":"double"},
+    "DuplicateUserNameFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"DuplicateUserName",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
     "EC2SecurityGroup":{
       "type":"structure",
       "members":{
@@ -2232,6 +2580,10 @@
         "CacheNodeTypeSpecificParameters":{"shape":"CacheNodeTypeSpecificParametersList"}
       },
       "wrapper":true
+    },
+    "EngineType":{
+      "type":"string",
+      "pattern":"[a-zA-Z]*"
     },
     "Event":{
       "type":"structure",
@@ -2274,6 +2626,34 @@
       "members":{
         "GlobalReplicationGroup":{"shape":"GlobalReplicationGroup"}
       }
+    },
+    "Filter":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "Values"
+      ],
+      "members":{
+        "Name":{"shape":"FilterName"},
+        "Values":{"shape":"FilterValueList"}
+      }
+    },
+    "FilterList":{
+      "type":"list",
+      "member":{"shape":"Filter"}
+    },
+    "FilterName":{
+      "type":"string",
+      "pattern":".*\\S.*"
+    },
+    "FilterValue":{
+      "type":"string",
+      "pattern":".*\\S.*"
+    },
+    "FilterValueList":{
+      "type":"list",
+      "member":{"shape":"FilterValue"},
+      "min":1
     },
     "GlobalNodeGroup":{
       "type":"structure",
@@ -2546,6 +2926,28 @@
       },
       "exception":true
     },
+    "InvalidUserGroupStateFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"InvalidUserGroupState",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "InvalidUserStateFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"InvalidUserState",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
     "InvalidVPCNetworkStateFault":{
       "type":"structure",
       "members":{
@@ -2561,6 +2963,12 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "KinesisFirehoseDestinationDetails":{
+      "type":"structure",
+      "members":{
+        "DeliveryStream":{"shape":"String"}
+      }
+    },
     "ListAllowedNodeTypeModificationsMessage":{
       "type":"structure",
       "members":{
@@ -2574,6 +2982,62 @@
       "members":{
         "ResourceName":{"shape":"String"}
       }
+    },
+    "LogDeliveryConfiguration":{
+      "type":"structure",
+      "members":{
+        "LogType":{"shape":"LogType"},
+        "DestinationType":{"shape":"DestinationType"},
+        "DestinationDetails":{"shape":"DestinationDetails"},
+        "LogFormat":{"shape":"LogFormat"},
+        "Status":{"shape":"LogDeliveryConfigurationStatus"},
+        "Message":{"shape":"String"}
+      }
+    },
+    "LogDeliveryConfigurationList":{
+      "type":"list",
+      "member":{
+        "shape":"LogDeliveryConfiguration",
+        "locationName":"LogDeliveryConfiguration"
+      }
+    },
+    "LogDeliveryConfigurationRequest":{
+      "type":"structure",
+      "members":{
+        "LogType":{"shape":"LogType"},
+        "DestinationType":{"shape":"DestinationType"},
+        "DestinationDetails":{"shape":"DestinationDetails"},
+        "LogFormat":{"shape":"LogFormat"},
+        "Enabled":{"shape":"BooleanOptional"}
+      }
+    },
+    "LogDeliveryConfigurationRequestList":{
+      "type":"list",
+      "member":{
+        "shape":"LogDeliveryConfigurationRequest",
+        "locationName":"LogDeliveryConfigurationRequest"
+      }
+    },
+    "LogDeliveryConfigurationStatus":{
+      "type":"string",
+      "enum":[
+        "active",
+        "enabling",
+        "modifying",
+        "disabling",
+        "error"
+      ]
+    },
+    "LogFormat":{
+      "type":"string",
+      "enum":[
+        "text",
+        "json"
+      ]
+    },
+    "LogType":{
+      "type":"string",
+      "enum":["slow-log"]
     },
     "ModifyCacheClusterMessage":{
       "type":"structure",
@@ -2597,7 +3061,8 @@
         "SnapshotWindow":{"shape":"String"},
         "CacheNodeType":{"shape":"String"},
         "AuthToken":{"shape":"String"},
-        "AuthTokenUpdateStrategy":{"shape":"AuthTokenUpdateStrategyType"}
+        "AuthTokenUpdateStrategy":{"shape":"AuthTokenUpdateStrategyType"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationRequestList"}
       }
     },
     "ModifyCacheClusterResult":{
@@ -2643,6 +3108,7 @@
         "ApplyImmediately":{"shape":"Boolean"},
         "CacheNodeType":{"shape":"String"},
         "EngineVersion":{"shape":"String"},
+        "CacheParameterGroupName":{"shape":"String"},
         "GlobalReplicationGroupDescription":{"shape":"String"},
         "AutomaticFailoverEnabled":{"shape":"BooleanOptional"}
       }
@@ -2680,7 +3146,11 @@
         "SnapshotWindow":{"shape":"String"},
         "CacheNodeType":{"shape":"String"},
         "AuthToken":{"shape":"String"},
-        "AuthTokenUpdateStrategy":{"shape":"AuthTokenUpdateStrategyType"}
+        "AuthTokenUpdateStrategy":{"shape":"AuthTokenUpdateStrategyType"},
+        "UserGroupIdsToAdd":{"shape":"UserGroupIdList"},
+        "UserGroupIdsToRemove":{"shape":"UserGroupIdList"},
+        "RemoveUserGroups":{"shape":"BooleanOptional"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationRequestList"}
       }
     },
     "ModifyReplicationGroupResult":{
@@ -2709,6 +3179,26 @@
       "type":"structure",
       "members":{
         "ReplicationGroup":{"shape":"ReplicationGroup"}
+      }
+    },
+    "ModifyUserGroupMessage":{
+      "type":"structure",
+      "required":["UserGroupId"],
+      "members":{
+        "UserGroupId":{"shape":"String"},
+        "UserIdsToAdd":{"shape":"UserIdListInput"},
+        "UserIdsToRemove":{"shape":"UserIdListInput"}
+      }
+    },
+    "ModifyUserMessage":{
+      "type":"structure",
+      "required":["UserId"],
+      "members":{
+        "UserId":{"shape":"UserId"},
+        "AccessString":{"shape":"AccessString"},
+        "AppendAccessString":{"shape":"AccessString"},
+        "Passwords":{"shape":"PasswordListInput"},
+        "NoPasswordRequired":{"shape":"BooleanOptional"}
       }
     },
     "MultiAZStatus":{
@@ -2747,7 +3237,9 @@
         "Slots":{"shape":"String"},
         "ReplicaCount":{"shape":"IntegerOptional"},
         "PrimaryAvailabilityZone":{"shape":"String"},
-        "ReplicaAvailabilityZones":{"shape":"AvailabilityZonesList"}
+        "ReplicaAvailabilityZones":{"shape":"AvailabilityZonesList"},
+        "PrimaryOutpostArn":{"shape":"String"},
+        "ReplicaOutpostArns":{"shape":"OutpostArnsList"}
       }
     },
     "NodeGroupConfigurationList":{
@@ -2771,6 +3263,7 @@
         "CacheNodeId":{"shape":"String"},
         "ReadEndpoint":{"shape":"Endpoint"},
         "PreferredAvailabilityZone":{"shape":"String"},
+        "PreferredOutpostArn":{"shape":"String"},
         "CurrentRole":{"shape":"String"}
       }
     },
@@ -2923,6 +3416,20 @@
         "TopicStatus":{"shape":"String"}
       }
     },
+    "OutpostArnsList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"OutpostArn"
+      }
+    },
+    "OutpostMode":{
+      "type":"string",
+      "enum":[
+        "single-outpost",
+        "cross-outpost"
+      ]
+    },
     "Parameter":{
       "type":"structure",
       "members":{
@@ -2958,12 +3465,31 @@
         "locationName":"Parameter"
       }
     },
+    "PasswordListInput":{
+      "type":"list",
+      "member":{"shape":"String"},
+      "min":1
+    },
     "PendingAutomaticFailoverStatus":{
       "type":"string",
       "enum":[
         "enabled",
         "disabled"
       ]
+    },
+    "PendingLogDeliveryConfiguration":{
+      "type":"structure",
+      "members":{
+        "LogType":{"shape":"LogType"},
+        "DestinationType":{"shape":"DestinationType"},
+        "DestinationDetails":{"shape":"DestinationDetails"},
+        "LogFormat":{"shape":"LogFormat"}
+      }
+    },
+    "PendingLogDeliveryConfigurationList":{
+      "type":"list",
+      "member":{"shape":"PendingLogDeliveryConfiguration"},
+      "locationName":"PendingLogDeliveryConfiguration"
     },
     "PendingModifiedValues":{
       "type":"structure",
@@ -2972,7 +3498,8 @@
         "CacheNodeIdsToRemove":{"shape":"CacheNodeIdsList"},
         "EngineVersion":{"shape":"String"},
         "CacheNodeType":{"shape":"String"},
-        "AuthTokenStatus":{"shape":"AuthTokenUpdateStatus"}
+        "AuthTokenStatus":{"shape":"AuthTokenUpdateStatus"},
+        "LogDeliveryConfigurations":{"shape":"PendingLogDeliveryConfigurationList"}
       }
     },
     "PreferredAvailabilityZoneList":{
@@ -2980,6 +3507,13 @@
       "member":{
         "shape":"String",
         "locationName":"PreferredAvailabilityZone"
+      }
+    },
+    "PreferredOutpostArnList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"PreferredOutpostArn"
       }
     },
     "ProcessedUpdateAction":{
@@ -3004,7 +3538,8 @@
       "members":{
         "ReservedCacheNodesOfferingId":{"shape":"String"},
         "ReservedCacheNodeId":{"shape":"String"},
-        "CacheNodeCount":{"shape":"IntegerOptional"}
+        "CacheNodeCount":{"shape":"IntegerOptional"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "PurchaseReservedCacheNodesOfferingResult":{
@@ -3126,8 +3661,11 @@
         "AuthTokenLastModifiedDate":{"shape":"TStamp"},
         "TransitEncryptionEnabled":{"shape":"BooleanOptional"},
         "AtRestEncryptionEnabled":{"shape":"BooleanOptional"},
+        "MemberClustersOutpostArns":{"shape":"ReplicationGroupOutpostArnList"},
         "KmsKeyId":{"shape":"String"},
-        "ARN":{"shape":"String"}
+        "ARN":{"shape":"String"},
+        "UserGroupIds":{"shape":"UserGroupIdList"},
+        "LogDeliveryConfigurations":{"shape":"LogDeliveryConfigurationList"}
       },
       "wrapper":true
     },
@@ -3194,13 +3732,22 @@
       },
       "exception":true
     },
+    "ReplicationGroupOutpostArnList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"ReplicationGroupOutpostArn"
+      }
+    },
     "ReplicationGroupPendingModifiedValues":{
       "type":"structure",
       "members":{
         "PrimaryClusterId":{"shape":"String"},
         "AutomaticFailoverStatus":{"shape":"PendingAutomaticFailoverStatus"},
         "Resharding":{"shape":"ReshardingStatus"},
-        "AuthTokenStatus":{"shape":"AuthTokenUpdateStatus"}
+        "AuthTokenStatus":{"shape":"AuthTokenUpdateStatus"},
+        "UserGroups":{"shape":"UserGroupsUpdateStatus"},
+        "LogDeliveryConfigurations":{"shape":"PendingLogDeliveryConfigurationList"}
       }
     },
     "ReservedCacheNode":{
@@ -3481,6 +4028,7 @@
         "EngineVersion":{"shape":"String"},
         "NumCacheNodes":{"shape":"IntegerOptional"},
         "PreferredAvailabilityZone":{"shape":"String"},
+        "PreferredOutpostArn":{"shape":"String"},
         "CacheClusterCreateTime":{"shape":"TStamp"},
         "PreferredMaintenanceWindow":{"shape":"String"},
         "TopicArn":{"shape":"String"},
@@ -3564,7 +4112,9 @@
         "cache-parameter-group",
         "cache-security-group",
         "cache-subnet-group",
-        "replication-group"
+        "replication-group",
+        "user",
+        "user-group"
       ]
     },
     "StartMigrationMessage":{
@@ -3589,7 +4139,8 @@
       "type":"structure",
       "members":{
         "SubnetIdentifier":{"shape":"String"},
-        "SubnetAvailabilityZone":{"shape":"AvailabilityZone"}
+        "SubnetAvailabilityZone":{"shape":"AvailabilityZone"},
+        "SubnetOutpost":{"shape":"SubnetOutpost"}
       }
     },
     "SubnetIdentifierList":{
@@ -3615,6 +4166,23 @@
       "member":{
         "shape":"Subnet",
         "locationName":"Subnet"
+      }
+    },
+    "SubnetNotAllowedFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"SubnetNotAllowedFault",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "SubnetOutpost":{
+      "type":"structure",
+      "members":{
+        "SubnetOutpostArn":{"shape":"String"}
       }
     },
     "TStamp":{"type":"timestamp"},
@@ -3695,6 +4263,10 @@
         "EndTime":{"shape":"TStamp"}
       }
     },
+    "UGReplicationGroupIdList":{
+      "type":"list",
+      "member":{"shape":"String"}
+    },
     "UnprocessedUpdateAction":{
       "type":"structure",
       "members":{
@@ -3773,6 +4345,151 @@
         "Marker":{"shape":"String"},
         "UpdateActions":{"shape":"UpdateActionList"}
       }
+    },
+    "User":{
+      "type":"structure",
+      "members":{
+        "UserId":{"shape":"String"},
+        "UserName":{"shape":"String"},
+        "Status":{"shape":"String"},
+        "Engine":{"shape":"EngineType"},
+        "AccessString":{"shape":"String"},
+        "UserGroupIds":{"shape":"UserGroupIdList"},
+        "Authentication":{"shape":"Authentication"},
+        "ARN":{"shape":"String"}
+      }
+    },
+    "UserAlreadyExistsFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserAlreadyExists",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UserGroup":{
+      "type":"structure",
+      "members":{
+        "UserGroupId":{"shape":"String"},
+        "Status":{"shape":"String"},
+        "Engine":{"shape":"EngineType"},
+        "UserIds":{"shape":"UserIdList"},
+        "PendingChanges":{"shape":"UserGroupPendingChanges"},
+        "ReplicationGroups":{"shape":"UGReplicationGroupIdList"},
+        "ARN":{"shape":"String"}
+      }
+    },
+    "UserGroupAlreadyExistsFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserGroupAlreadyExists",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UserGroupId":{
+      "type":"string",
+      "min":1,
+      "pattern":"[a-zA-Z][a-zA-Z0-9\\-]*"
+    },
+    "UserGroupIdList":{
+      "type":"list",
+      "member":{"shape":"UserGroupId"}
+    },
+    "UserGroupIdListInput":{
+      "type":"list",
+      "member":{"shape":"UserGroupId"},
+      "min":1
+    },
+    "UserGroupList":{
+      "type":"list",
+      "member":{"shape":"UserGroup"}
+    },
+    "UserGroupNotFoundFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserGroupNotFound",
+        "httpStatusCode":404,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UserGroupPendingChanges":{
+      "type":"structure",
+      "members":{
+        "UserIdsToRemove":{"shape":"UserIdList"},
+        "UserIdsToAdd":{"shape":"UserIdList"}
+      }
+    },
+    "UserGroupQuotaExceededFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserGroupQuotaExceeded",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UserGroupsUpdateStatus":{
+      "type":"structure",
+      "members":{
+        "UserGroupIdsToAdd":{"shape":"UserGroupIdList"},
+        "UserGroupIdsToRemove":{"shape":"UserGroupIdList"}
+      }
+    },
+    "UserId":{
+      "type":"string",
+      "min":1,
+      "pattern":"[a-zA-Z][a-zA-Z0-9\\-]*"
+    },
+    "UserIdList":{
+      "type":"list",
+      "member":{"shape":"UserId"}
+    },
+    "UserIdListInput":{
+      "type":"list",
+      "member":{"shape":"UserId"},
+      "min":1
+    },
+    "UserList":{
+      "type":"list",
+      "member":{"shape":"User"}
+    },
+    "UserName":{
+      "type":"string",
+      "min":1
+    },
+    "UserNotFoundFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserNotFound",
+        "httpStatusCode":404,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UserQuotaExceededFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"UserQuotaExceeded",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
     }
   }
 }

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/docs-2.json
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/docs-2.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "service": "<fullname>Amazon ElastiCache</fullname> <p>Amazon ElastiCache is a web service that makes it easier to set up, operate, and scale a distributed cache in the cloud.</p> <p>With ElastiCache, customers get all of the benefits of a high-performance, in-memory cache with less of the administrative burden involved in launching and managing a distributed cache. The service makes setup, scaling, and cluster failure handling much simpler than in a self-managed cache deployment.</p> <p>In addition, through integration with Amazon CloudWatch, customers get enhanced visibility into the key performance statistics associated with their cache and can receive alarms if a part of their cache runs hot.</p>",
   "operations": {
-    "AddTagsToResource": "<p>Adds up to 50 cost allocation tags to the named resource. A cost allocation tag is a key-value pair where the key and value are case-sensitive. You can use cost allocation tags to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
+    "AddTagsToResource": "<p>A tag is a key-value pair where the key and value are case-sensitive. You can use tags to categorize and track all your ElastiCache resources, with the exception of global replication group. When you add or remove tags on replication groups, those actions will be replicated to all nodes in the replication group. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/IAM.ResourceLevelPermissions.html\">Resource-level permissions</a>.</p> <p> For example, you can use cost-allocation tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
     "AuthorizeCacheSecurityGroupIngress": "<p>Allows network ingress to a cache security group. Applications using ElastiCache must be running on Amazon EC2, and Amazon EC2 security groups are used as the authorization mechanism.</p> <note> <p>You cannot authorize ingress from an Amazon EC2 security group in one region to an ElastiCache cluster in another region.</p> </note>",
     "BatchApplyUpdateAction": "<p>Apply the service update. For more information on service updates and applying them, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/applying-updates.html\">Applying Service Updates</a>.</p>",
     "BatchStopUpdateAction": "<p>Stop the service update. For more information on service updates and stopping them, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/stopping-self-service-updates.html\">Stopping Service Updates</a>.</p>",
@@ -12,18 +12,22 @@
     "CreateCacheParameterGroup": "<p>Creates a new Amazon ElastiCache cache parameter group. An ElastiCache cache parameter group is a collection of parameters and their values that are applied to all of the nodes in any cluster or replication group using the CacheParameterGroup.</p> <p>A newly created CacheParameterGroup is an exact duplicate of the default parameter group for the CacheParameterGroupFamily. To customize the newly created CacheParameterGroup you can change the values of specific parameters. For more information, see:</p> <ul> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheParameterGroup.html\">ModifyCacheParameterGroup</a> in the ElastiCache API Reference.</p> </li> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.html\">Parameters and Parameter Groups</a> in the ElastiCache User Guide.</p> </li> </ul>",
     "CreateCacheSecurityGroup": "<p>Creates a new cache security group. Use a cache security group to control access to one or more clusters.</p> <p>Cache security groups are only used when you are creating a cluster outside of an Amazon Virtual Private Cloud (Amazon VPC). If you are creating a cluster inside of a VPC, use a cache subnet group instead. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html\">CreateCacheSubnetGroup</a>.</p>",
     "CreateCacheSubnetGroup": "<p>Creates a new cache subnet group.</p> <p>Use this parameter only when you are creating a cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
-    "CreateGlobalReplicationGroup": "<p>Global Datastore for Redis offers fully managed, fast, reliable and secure cross-region replication. Using Global Datastore for Redis, you can create cross-region read replica clusters for ElastiCache for Redis to enable low-latency reads and disaster recovery across regions. For more information, see <a href=\"/AmazonElastiCache/latest/red-ug/Redis-Global-Clusters.html\">Replication Across Regions Using Global Datastore</a>. </p> <ul> <li> <p>The <b>GlobalReplicationGroupIdSuffix</b> is the name of the Global Datastore.</p> </li> <li> <p>The <b>PrimaryReplicationGroupId</b> represents the name of the primary cluster that accepts writes and will replicate updates to the secondary cluster.</p> </li> </ul>",
-    "CreateReplicationGroup": "<p>Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.</p> <p>This API can be used to create a standalone regional replication group or a secondary replication group associated with a Global Datastore.</p> <p>A Redis (cluster mode disabled) replication group is a collection of clusters, where one of the clusters is a read/write primary and the others are read-only replicas. Writes to the primary are asynchronously propagated to the replicas.</p> <p>A Redis (cluster mode enabled) replication group is a collection of 1 to 90 node groups (shards). Each node group (shard) has one read/write primary node and up to 5 read-only replica nodes. Writes to the primary are asynchronously propagated to the replicas. Redis (cluster mode enabled) replication groups partition the data across node groups (shards).</p> <p>When a Redis (cluster mode disabled) replication group has been successfully created, you can add one or more read replicas to it, up to a total of 5 read replicas. If you need to increase or decrease the number of node groups (console: shards), you can avail yourself of ElastiCache for Redis' scaling. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.html\">Scaling ElastiCache for Redis Clusters</a> in the <i>ElastiCache User Guide</i>.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "CreateGlobalReplicationGroup": "<p>Global Datastore for Redis offers fully managed, fast, reliable and secure cross-region replication. Using Global Datastore for Redis, you can create cross-region read replica clusters for ElastiCache for Redis to enable low-latency reads and disaster recovery across regions. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Redis-Global-Datastore.html\">Replication Across Regions Using Global Datastore</a>. </p> <ul> <li> <p>The <b>GlobalReplicationGroupIdSuffix</b> is the name of the Global datastore.</p> </li> <li> <p>The <b>PrimaryReplicationGroupId</b> represents the name of the primary cluster that accepts writes and will replicate updates to the secondary cluster.</p> </li> </ul>",
+    "CreateReplicationGroup": "<p>Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.</p> <p>This API can be used to create a standalone regional replication group or a secondary replication group associated with a Global datastore.</p> <p>A Redis (cluster mode disabled) replication group is a collection of clusters, where one of the clusters is a read/write primary and the others are read-only replicas. Writes to the primary are asynchronously propagated to the replicas.</p> <p>A Redis cluster-mode enabled cluster is comprised of from 1 to 90 shards (API/CLI: node groups). Each shard has a primary node and up to 5 read-only replica nodes. The configuration can range from 90 shards and 0 replicas to 15 shards and 5 replicas, which is the maximum number or replicas allowed. </p> <p>The node or shard limit can be increased to a maximum of 500 per cluster if the Redis engine version is 5.0.6 or higher. For example, you can choose to configure a 500 node cluster that ranges between 83 shards (one primary and 5 replicas per shard) and 500 shards (single primary and no replicas). Make sure there are enough available IP addresses to accommodate the increase. Common pitfalls include the subnets in the subnet group have too small a CIDR range or the subnets are shared and heavily used by other clusters. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.Creating.html\">Creating a Subnet Group</a>. For versions below 5.0.6, the limit is 250 per cluster.</p> <p>To request a limit increase, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html\">AWS Service Limits</a> and choose the limit type <b>Nodes per cluster per instance type</b>. </p> <p>When a Redis (cluster mode disabled) replication group has been successfully created, you can add one or more read replicas to it, up to a total of 5 read replicas. If you need to increase or decrease the number of node groups (console: shards), you can avail yourself of ElastiCache for Redis' scaling. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.html\">Scaling ElastiCache for Redis Clusters</a> in the <i>ElastiCache User Guide</i>.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "CreateSnapshot": "<p>Creates a copy of an entire cluster or replication group at a specific moment in time.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
-    "DecreaseNodeGroupsInGlobalReplicationGroup": "<p>Decreases the number of node groups in a Global Datastore</p>",
+    "CreateUser": "<p>For Redis engine version 6.x onwards: Creates a Redis user. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html\">Using Role Based Access Control (RBAC)</a>.</p>",
+    "CreateUserGroup": "<p>For Redis engine version 6.x onwards: Creates a Redis user group. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html\">Using Role Based Access Control (RBAC)</a> </p>",
+    "DecreaseNodeGroupsInGlobalReplicationGroup": "<p>Decreases the number of node groups in a Global datastore</p>",
     "DecreaseReplicaCount": "<p>Dynamically decreases the number of replicas in a Redis (cluster mode disabled) replication group or the number of replica nodes in one or more node groups (shards) of a Redis (cluster mode enabled) replication group. This operation is performed with no cluster down time.</p>",
-    "DeleteCacheCluster": "<p>Deletes a previously provisioned cluster. <code>DeleteCacheCluster</code> deletes all associated cache nodes, node endpoints and the cluster itself. When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the cluster; you cannot cancel or revert this operation.</p> <p>This operation is not valid for:</p> <ul> <li> <p>Redis (cluster mode enabled) clusters</p> </li> <li> <p>A cluster that is the last read replica of a replication group</p> </li> <li> <p>A node group (shard) that has Multi-AZ mode enabled</p> </li> <li> <p>A cluster from a Redis (cluster mode enabled) replication group</p> </li> <li> <p>A cluster that is not in the <code>available</code> state</p> </li> </ul>",
-    "DeleteCacheParameterGroup": "<p>Deletes the specified cache parameter group. You cannot delete a cache parameter group if it is associated with any cache clusters.</p>",
+    "DeleteCacheCluster": "<p>Deletes a previously provisioned cluster. <code>DeleteCacheCluster</code> deletes all associated cache nodes, node endpoints and the cluster itself. When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the cluster; you cannot cancel or revert this operation.</p> <p>This operation is not valid for:</p> <ul> <li> <p>Redis (cluster mode enabled) clusters</p> </li> <li> <p>Redis (cluster mode disabled) clusters</p> </li> <li> <p>A cluster that is the last read replica of a replication group</p> </li> <li> <p>A cluster that is the primary node of a replication group</p> </li> <li> <p>A node group (shard) that has Multi-AZ mode enabled</p> </li> <li> <p>A cluster from a Redis (cluster mode enabled) replication group</p> </li> <li> <p>A cluster that is not in the <code>available</code> state</p> </li> </ul>",
+    "DeleteCacheParameterGroup": "<p>Deletes the specified cache parameter group. You cannot delete a cache parameter group if it is associated with any cache clusters. You cannot delete the default cache parameter groups in your account.</p>",
     "DeleteCacheSecurityGroup": "<p>Deletes a cache security group.</p> <note> <p>You cannot delete a cache security group if it is associated with any clusters.</p> </note>",
-    "DeleteCacheSubnetGroup": "<p>Deletes a cache subnet group.</p> <note> <p>You cannot delete a cache subnet group if it is associated with any clusters.</p> </note>",
-    "DeleteGlobalReplicationGroup": "<p>Deleting a Global Datastore is a two-step process: </p> <ul> <li> <p>First, you must <a>DisassociateGlobalReplicationGroup</a> to remove the secondary clusters in the Global Datastore.</p> </li> <li> <p>Once the Global Datastore contains only the primary cluster, you can use DeleteGlobalReplicationGroup API to delete the Global Datastore while retainining the primary cluster using Retain…= true.</p> </li> </ul> <p>Since the Global Datastore has only a primary cluster, you can delete the Global Datastore while retaining the primary by setting <code>RetainPrimaryCluster=true</code>.</p> <p>When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this operation.</p>",
+    "DeleteCacheSubnetGroup": "<p>Deletes a cache subnet group.</p> <note> <p>You cannot delete a default cache subnet group or one that is associated with any clusters.</p> </note>",
+    "DeleteGlobalReplicationGroup": "<p>Deleting a Global datastore is a two-step process: </p> <ul> <li> <p>First, you must <a>DisassociateGlobalReplicationGroup</a> to remove the secondary clusters in the Global datastore.</p> </li> <li> <p>Once the Global datastore contains only the primary cluster, you can use the <code>DeleteGlobalReplicationGroup</code> API to delete the Global datastore while retainining the primary cluster using <code>RetainPrimaryReplicationGroup=true</code>.</p> </li> </ul> <p>Since the Global Datastore has only a primary cluster, you can delete the Global Datastore while retaining the primary by setting <code>RetainPrimaryReplicationGroup=true</code>. The primary cluster is never deleted when deleting a Global Datastore. It can only be deleted when it no longer is associated with any Global Datastore.</p> <p>When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this operation.</p>",
     "DeleteReplicationGroup": "<p>Deletes an existing replication group. By default, this operation deletes the entire replication group, including the primary/primaries and all of the read replicas. If the replication group has only one primary, you can optionally delete only the read replicas, while retaining the primary by setting <code>RetainPrimaryCluster=true</code>.</p> <p>When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "DeleteSnapshot": "<p>Deletes an existing snapshot. When you receive a successful response from this operation, ElastiCache immediately begins deleting the snapshot; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "DeleteUser": "<p>For Redis engine version 6.x onwards: Deletes a user. The user will be removed from all user groups and in turn removed from all replication groups. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html\">Using Role Based Access Control (RBAC)</a>. </p>",
+    "DeleteUserGroup": "<p>For Redis engine version 6.x onwards: Deletes a user group. The user group must first be disassociated from the replication group before it can be deleted. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html\">Using Role Based Access Control (RBAC)</a>. </p>",
     "DescribeCacheClusters": "<p>Returns information about all provisioned clusters if no cluster identifier is specified, or about a specific cache cluster if a cluster identifier is supplied.</p> <p>By default, abbreviated information about the clusters is returned. You can use the optional <i>ShowCacheNodeInfo</i> flag to retrieve detailed information about the cache nodes associated with the clusters. These details include the DNS address and port for the cache node endpoint.</p> <p>If the cluster is in the <i>creating</i> state, only cluster-level information is displayed until all of the nodes are successfully provisioned.</p> <p>If the cluster is in the <i>deleting</i> state, only cluster-level information is displayed.</p> <p>If cache nodes are currently being added to the cluster, node endpoint information and creation time for the additional nodes are not displayed until they are completely provisioned. When the cluster state is <i>available</i>, the cluster is ready for use.</p> <p>If cache nodes are currently being removed from the cluster, no endpoint information for the removed nodes is displayed.</p>",
     "DescribeCacheEngineVersions": "<p>Returns a list of the available cache engines and their versions.</p>",
     "DescribeCacheParameterGroups": "<p>Returns a list of cache parameter group descriptions. If a cache parameter group name is specified, the list contains only the descriptions for that group.</p>",
@@ -32,33 +36,37 @@
     "DescribeCacheSubnetGroups": "<p>Returns a list of cache subnet group descriptions. If a subnet group name is specified, the list contains only the description of that group. This is applicable only when you have ElastiCache in VPC setup. All ElastiCache clusters now launch in VPC by default. </p>",
     "DescribeEngineDefaultParameters": "<p>Returns the default engine and system parameter information for the specified cache engine.</p>",
     "DescribeEvents": "<p>Returns events related to clusters, cache security groups, and cache parameter groups. You can obtain events specific to a particular cluster, cache security group, or cache parameter group by providing the name as a parameter.</p> <p>By default, only the events occurring within the last hour are returned; however, you can retrieve up to 14 days' worth of events if necessary.</p>",
-    "DescribeGlobalReplicationGroups": "<p>Returns information about a particular global replication group. If no identifier is specified, returns information about all Global Datastores. </p>",
+    "DescribeGlobalReplicationGroups": "<p>Returns information about a particular global replication group. If no identifier is specified, returns information about all Global datastores. </p>",
     "DescribeReplicationGroups": "<p>Returns information about a particular replication group. If no identifier is specified, <code>DescribeReplicationGroups</code> returns information about all replication groups.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "DescribeReservedCacheNodes": "<p>Returns information about reserved cache nodes for this account, or about a specified reserved cache node.</p>",
     "DescribeReservedCacheNodesOfferings": "<p>Lists available reserved cache node offerings.</p>",
     "DescribeServiceUpdates": "<p>Returns details of the service updates</p>",
     "DescribeSnapshots": "<p>Returns information about cluster or replication group snapshots. By default, <code>DescribeSnapshots</code> lists all of your snapshots; it can optionally describe a single snapshot, or just the snapshots associated with a particular cache cluster.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "DescribeUpdateActions": "<p>Returns details of the update actions </p>",
-    "DisassociateGlobalReplicationGroup": "<p>Remove a secondary cluster from the Global Datastore using the Global Datastore name. The secondary cluster will no longer receive updates from the primary cluster, but will remain as a standalone cluster in that AWS region.</p>",
+    "DescribeUserGroups": "<p>Returns a list of user groups.</p>",
+    "DescribeUsers": "<p>Returns a list of users.</p>",
+    "DisassociateGlobalReplicationGroup": "<p>Remove a secondary cluster from the Global datastore using the Global datastore name. The secondary cluster will no longer receive updates from the primary cluster, but will remain as a standalone cluster in that AWS region.</p>",
     "FailoverGlobalReplicationGroup": "<p>Used to failover the primary region to a selected secondary region. The selected secondary region will become primary, and all other clusters will become secondary.</p>",
-    "IncreaseNodeGroupsInGlobalReplicationGroup": "<p>Increase the number of node groups in the Global Datastore</p>",
-    "IncreaseReplicaCount": "<p>Dynamically increases the number of replics in a Redis (cluster mode disabled) replication group or the number of replica nodes in one or more node groups (shards) of a Redis (cluster mode enabled) replication group. This operation is performed with no cluster down time.</p>",
+    "IncreaseNodeGroupsInGlobalReplicationGroup": "<p>Increase the number of node groups in the Global datastore</p>",
+    "IncreaseReplicaCount": "<p>Dynamically increases the number of replicas in a Redis (cluster mode disabled) replication group or the number of replica nodes in one or more node groups (shards) of a Redis (cluster mode enabled) replication group. This operation is performed with no cluster down time.</p>",
     "ListAllowedNodeTypeModifications": "<p>Lists all available node types that you can scale your Redis cluster's or replication group's current node type.</p> <p>When you use the <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code> operations to scale your cluster or replication group, the value of the <code>CacheNodeType</code> parameter must be one of the node types returned by this operation.</p>",
-    "ListTagsForResource": "<p>Lists all cost allocation tags currently on the named resource. A <code>cost allocation tag</code> is a key-value pair where the key is case-sensitive and the value is optional. You can use cost allocation tags to categorize and track your AWS costs.</p> <p>If the cluster is not in the <i>available</i> state, <code>ListTagsForResource</code> returns an error.</p> <p>You can have a maximum of 50 cost allocation tags on an ElastiCache resource. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Tagging.html\">Monitoring Costs with Tags</a>.</p>",
+    "ListTagsForResource": "<p>Lists all tags currently on a named resource.</p> <p> A tag is a key-value pair where the key and value are case-sensitive. You can use tags to categorize and track all your ElastiCache resources, with the exception of global replication group. When you add or remove tags on replication groups, those actions will be replicated to all nodes in the replication group. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/IAM.ResourceLevelPermissions.html\">Resource-level permissions</a>.</p> <p>If the cluster is not in the <i>available</i> state, <code>ListTagsForResource</code> returns an error.</p>",
     "ModifyCacheCluster": "<p>Modifies the settings for a cluster. You can use this operation to change one or more cluster configuration parameters by specifying the parameters and the new values.</p>",
     "ModifyCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group. You can modify up to 20 parameters in a single request by submitting a list parameter name and value pairs.</p>",
     "ModifyCacheSubnetGroup": "<p>Modifies an existing cache subnet group.</p>",
-    "ModifyGlobalReplicationGroup": "<p>Modifies the settings for a Global Datastore.</p>",
+    "ModifyGlobalReplicationGroup": "<p>Modifies the settings for a Global datastore.</p>",
     "ModifyReplicationGroup": "<p>Modifies the settings for a replication group.</p> <ul> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/scaling-redis-cluster-mode-enabled.html\">Scaling for Amazon ElastiCache for Redis (cluster mode enabled)</a> in the ElastiCache User Guide</p> </li> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyReplicationGroupShardConfiguration.html\">ModifyReplicationGroupShardConfiguration</a> in the ElastiCache API Reference</p> </li> </ul> <note> <p>This operation is valid for Redis only.</p> </note>",
-    "ModifyReplicationGroupShardConfiguration": "<p>Modifies a replication group's shards (node groups) by allowing you to add shards, remove shards, or rebalance the keyspaces among exisiting shards.</p>",
-    "PurchaseReservedCacheNodesOffering": "<p>Allows you to purchase a reserved cache node offering.</p>",
+    "ModifyReplicationGroupShardConfiguration": "<p>Modifies a replication group's shards (node groups) by allowing you to add shards, remove shards, or rebalance the keyspaces among existing shards.</p>",
+    "ModifyUser": "<p>Changes user password(s) and/or access string.</p>",
+    "ModifyUserGroup": "<p>Changes the list of users that belong to the user group.</p>",
+    "PurchaseReservedCacheNodesOffering": "<p>Allows you to purchase a reserved cache node offering. Reserved nodes are not eligible for cancellation and are non-refundable. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/reserved-nodes.html\">Managing Costs with Reserved Nodes</a> for Redis or <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/reserved-nodes.html\">Managing Costs with Reserved Nodes</a> for Memcached.</p>",
     "RebalanceSlotsInGlobalReplicationGroup": "<p>Redistribute slots to ensure uniform distribution across existing shards in the cluster.</p>",
     "RebootCacheCluster": "<p>Reboots some, or all, of the cache nodes within a provisioned cluster. This operation applies any modified cache parameter groups to the cluster. The reboot operation takes place as soon as possible, and results in a momentary outage to the cluster. During the reboot, the cluster status is set to REBOOTING.</p> <p>The reboot causes the contents of the cache (for each cache node being rebooted) to be lost.</p> <p>When the reboot is complete, a cluster event is created.</p> <p>Rebooting a cluster is currently supported on Memcached and Redis (cluster mode disabled) clusters. Rebooting is not supported on Redis (cluster mode enabled) clusters.</p> <p>If you make changes to parameters that require a Redis (cluster mode enabled) cluster reboot for the changes to be applied, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Rebooting.html\">Rebooting a Cluster</a> for an alternate process.</p>",
-    "RemoveTagsFromResource": "<p>Removes the tags identified by the <code>TagKeys</code> list from the named resource.</p>",
+    "RemoveTagsFromResource": "<p>Removes the tags identified by the <code>TagKeys</code> list from the named resource. A tag is a key-value pair where the key and value are case-sensitive. You can use tags to categorize and track all your ElastiCache resources, with the exception of global replication group. When you add or remove tags on replication groups, those actions will be replicated to all nodes in the replication group. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/IAM.ResourceLevelPermissions.html\">Resource-level permissions</a>.</p>",
     "ResetCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group to the engine or system default value. You can reset specific parameters by submitting a list of parameter names. To reset the entire cache parameter group, specify the <code>ResetAllParameters</code> and <code>CacheParameterGroupName</code> parameters.</p>",
     "RevokeCacheSecurityGroupIngress": "<p>Revokes ingress from a cache security group. Use this operation to disallow access from an Amazon EC2 security group that had been previously authorized.</p>",
     "StartMigration": "<p>Start the migration of data.</p>",
-    "TestFailover": "<p>Represents the input of a <code>TestFailover</code> operation which test automatic failover on a specified node group (called shard in the console) in a replication group (called cluster in the console).</p> <p class=\"title\"> <b>Note the following</b> </p> <ul> <li> <p>A customer can use this operation to test automatic failover on up to 5 shards (called node groups in the ElastiCache API and AWS CLI) in any rolling 24-hour period.</p> </li> <li> <p>If calling this operation on shards in different clusters (called replication groups in the API and CLI), the calls can be made concurrently.</p> <p> </p> </li> <li> <p>If calling this operation multiple times on different shards in the same Redis (cluster mode enabled) replication group, the first node replacement must complete before a subsequent call can be made.</p> </li> <li> <p>To determine whether the node replacement is complete you can check Events using the Amazon ElastiCache console, the AWS CLI, or the ElastiCache API. Look for the following automatic failover related events, listed here in order of occurrance:</p> <ol> <li> <p>Replication group message: <code>Test Failover API called for node group &lt;node-group-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Failover from master node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Replication group message: <code>Failover from master node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Cache cluster message: <code>Recovering cache nodes &lt;node-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Finished recovery for cache nodes &lt;node-id&gt;</code> </p> </li> </ol> <p>For more information see:</p> <ul> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ECEvents.Viewing.html\">Viewing ElastiCache Events</a> in the <i>ElastiCache User Guide</i> </p> </li> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeEvents.html\">DescribeEvents</a> in the ElastiCache API Reference</p> </li> </ul> </li> </ul> <p>Also see, <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html#auto-failover-test\">Testing Multi-AZ </a> in the <i>ElastiCache User Guide</i>.</p>"
+    "TestFailover": "<p>Represents the input of a <code>TestFailover</code> operation which test automatic failover on a specified node group (called shard in the console) in a replication group (called cluster in the console).</p> <p class=\"title\"> <b>Note the following</b> </p> <ul> <li> <p>A customer can use this operation to test automatic failover on up to 5 shards (called node groups in the ElastiCache API and AWS CLI) in any rolling 24-hour period.</p> </li> <li> <p>If calling this operation on shards in different clusters (called replication groups in the API and CLI), the calls can be made concurrently.</p> <p> </p> </li> <li> <p>If calling this operation multiple times on different shards in the same Redis (cluster mode enabled) replication group, the first node replacement must complete before a subsequent call can be made.</p> </li> <li> <p>To determine whether the node replacement is complete you can check Events using the Amazon ElastiCache console, the AWS CLI, or the ElastiCache API. Look for the following automatic failover related events, listed here in order of occurrance:</p> <ol> <li> <p>Replication group message: <code>Test Failover API called for node group &lt;node-group-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Failover from primary node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Replication group message: <code>Failover from primary node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Cache cluster message: <code>Recovering cache nodes &lt;node-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Finished recovery for cache nodes &lt;node-id&gt;</code> </p> </li> </ol> <p>For more information see:</p> <ul> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ECEvents.Viewing.html\">Viewing ElastiCache Events</a> in the <i>ElastiCache User Guide</i> </p> </li> <li> <p> <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeEvents.html\">DescribeEvents</a> in the ElastiCache API Reference</p> </li> </ul> </li> </ul> <p>Also see, <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html#auto-failover-test\">Testing Multi-AZ </a> in the <i>ElastiCache User Guide</i>.</p>"
   },
   "shapes": {
     "APICallRateForCustomerExceededFault": {
@@ -71,6 +79,14 @@
       "refs": {
         "CreateCacheClusterMessage$AZMode": "<p>Specifies whether the nodes in this Memcached cluster are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region.</p> <p>This parameter is only supported for Memcached clusters.</p> <p>If the <code>AZMode</code> and <code>PreferredAvailabilityZones</code> are not specified, ElastiCache assumes <code>single-az</code> mode.</p>",
         "ModifyCacheClusterMessage$AZMode": "<p>Specifies whether the new nodes in this Memcached cluster are all created in a single Availability Zone or created across multiple Availability Zones.</p> <p>Valid values: <code>single-az</code> | <code>cross-az</code>.</p> <p>This option is only supported for Memcached clusters.</p> <note> <p>You cannot specify <code>single-az</code> if the Memcached cluster already has cache nodes in different Availability Zones. If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone.</p> <p>Only newly created nodes are located in different Availability Zones. </p> </note>"
+      }
+    },
+    "AccessString": {
+      "base": null,
+      "refs": {
+        "CreateUserMessage$AccessString": "<p>Access permissions string used for this user.</p>",
+        "ModifyUserMessage$AccessString": "<p>Access permissions string used for this user.</p>",
+        "ModifyUserMessage$AppendAccessString": "<p>Adds additional user permissions to the access string.</p>"
       }
     },
     "AddTagsToResourceMessage": {
@@ -104,8 +120,20 @@
     "AuthTokenUpdateStrategyType": {
       "base": null,
       "refs": {
-        "ModifyCacheClusterMessage$AuthTokenUpdateStrategy": "<p>Specifies the strategy to use to update the AUTH token. This parameter must be specified with the <code>auth-token</code> parameter. Possible values:</p> <ul> <li> <p>Rotate</p> </li> <li> <p>Set</p> </li> </ul> <p> For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html\">Authenticating Users with Redis AUTH</a> </p>",
-        "ModifyReplicationGroupMessage$AuthTokenUpdateStrategy": "<p>Specifies the strategy to use to update the AUTH token. This parameter must be specified with the <code>auth-token</code> parameter. Possible values:</p> <ul> <li> <p>Rotate</p> </li> <li> <p>Set</p> </li> </ul> <p> For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html\">Authenticating Users with Redis AUTH</a> </p>"
+        "ModifyCacheClusterMessage$AuthTokenUpdateStrategy": "<p>Specifies the strategy to use to update the AUTH token. This parameter must be specified with the <code>auth-token</code> parameter. Possible values:</p> <ul> <li> <p>Rotate</p> </li> <li> <p>Set</p> </li> </ul> <p> For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html\">Authenticating Users with Redis AUTH</a> </p>",
+        "ModifyReplicationGroupMessage$AuthTokenUpdateStrategy": "<p>Specifies the strategy to use to update the AUTH token. This parameter must be specified with the <code>auth-token</code> parameter. Possible values:</p> <ul> <li> <p>Rotate</p> </li> <li> <p>Set</p> </li> </ul> <p> For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html\">Authenticating Users with Redis AUTH</a> </p>"
+      }
+    },
+    "Authentication": {
+      "base": "<p>Indicates whether the user requires a password to authenticate.</p>",
+      "refs": {
+        "User$Authentication": "<p>Denotes whether the user requires a password to authenticate.</p>"
+      }
+    },
+    "AuthenticationType": {
+      "base": null,
+      "refs": {
+        "Authentication$Type": "<p>Indicates whether the user requires a password to authenticate.</p>"
       }
     },
     "AuthorizationAlreadyExistsFault": {
@@ -171,8 +199,9 @@
       "base": null,
       "refs": {
         "CacheCluster$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
+        "CacheCluster$ReplicationGroupLogDeliveryEnabled": "<p>A boolean value indicating whether log delivery is enabled for the replication group.</p>",
         "CacheNodeTypeSpecificParameter$IsModifiable": "<p>Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed.</p>",
-        "CacheParameterGroup$IsGlobal": "<p>Indicates whether the parameter group is associated with a Global Datastore</p>",
+        "CacheParameterGroup$IsGlobal": "<p>Indicates whether the parameter group is associated with a Global datastore</p>",
         "CompleteMigrationMessage$Force": "<p>Forces the migration to stop without ensuring that data is in sync. It is recommended to use this option only to abort the migration and not recommended when application wants to continue migration to ElastiCache.</p>",
         "DecreaseNodeGroupsInGlobalReplicationGroupMessage$ApplyImmediately": "<p>Indicates that the shard reconfiguration process begins immediately. At present, the only permitted value for this parameter is true. </p>",
         "DecreaseReplicaCountMessage$ApplyImmediately": "<p>If <code>True</code>, the number of replica nodes is decreased immediately. <code>ApplyImmediately=False</code> is not currently supported.</p>",
@@ -202,21 +231,25 @@
         "CreateReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
         "CreateReplicationGroupMessage$TransitEncryptionEnabled": "<p>A flag that enables in-transit encryption when set to <code>true</code>.</p> <p>You cannot modify the value of <code>TransitEncryptionEnabled</code> after the cluster is created. To enable in-transit encryption on a cluster you must set <code>TransitEncryptionEnabled</code> to <code>true</code> when you create a cluster.</p> <p>This parameter is valid only if the <code>Engine</code> parameter is <code>redis</code>, the <code>EngineVersion</code> parameter is <code>3.2.6</code>, <code>4.x</code> or later, and the cluster is being created in an Amazon VPC.</p> <p>If you enable in-transit encryption, you must also specify a value for <code>CacheSubnetGroup</code>.</p> <p> <b>Required:</b> Only available when creating a replication group in an Amazon VPC using redis version <code>3.2.6</code>, <code>4.x</code> or later.</p> <p>Default: <code>false</code> </p> <important> <p>For HIPAA compliance, you must specify <code>TransitEncryptionEnabled</code> as <code>true</code>, an <code>AuthToken</code>, and a <code>CacheSubnetGroup</code>.</p> </important>",
         "CreateReplicationGroupMessage$AtRestEncryptionEnabled": "<p>A flag that enables encryption at rest when set to <code>true</code>.</p> <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the replication group is created. To enable encryption at rest on a replication group you must set <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create the replication group. </p> <p> <b>Required:</b> Only available when creating a replication group in an Amazon VPC using redis version <code>3.2.6</code>, <code>4.x</code> or later.</p> <p>Default: <code>false</code> </p>",
+        "CreateUserMessage$NoPasswordRequired": "<p>Indicates a password is not required for this user.</p>",
         "DeleteReplicationGroupMessage$RetainPrimaryCluster": "<p>If set to <code>true</code>, all of the read replicas are deleted, but the primary node is retained.</p>",
         "DescribeCacheClustersMessage$ShowCacheNodeInfo": "<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to retrieve information about the individual cache nodes.</p>",
         "DescribeCacheClustersMessage$ShowCacheClustersNotInReplicationGroups": "<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to show only nodes (API/CLI: clusters) that are not members of a replication group. In practice, this mean Memcached and single node Redis clusters.</p>",
-        "DescribeGlobalReplicationGroupsMessage$ShowMemberInfo": "<p>Returns the list of members that comprise the Global Datastore.</p>",
+        "DescribeGlobalReplicationGroupsMessage$ShowMemberInfo": "<p>Returns the list of members that comprise the Global datastore.</p>",
         "DescribeSnapshotsMessage$ShowNodeGroupConfig": "<p>A Boolean value which if true, the node group (shard) configuration is included in the snapshot description.</p>",
         "DescribeUpdateActionsMessage$ShowNodeLevelUpdateStatus": "<p>Dictates whether to include node level update status in the response </p>",
-        "GlobalReplicationGroup$ClusterEnabled": "<p>A flag that indicates whether the Global Datastore is cluster enabled.</p>",
+        "GlobalReplicationGroup$ClusterEnabled": "<p>A flag that indicates whether the Global datastore is cluster enabled.</p>",
         "GlobalReplicationGroup$AuthTokenEnabled": "<p>A flag that enables using an <code>AuthToken</code> (password) when issuing Redis commands.</p> <p>Default: <code>false</code> </p>",
-        "GlobalReplicationGroup$TransitEncryptionEnabled": "<p>A flag that enables in-transit encryption when set to true. You cannot modify the value of <code>TransitEncryptionEnabled</code> after the cluster is created. To enable in-transit encryption on a cluster you must set <code>TransitEncryptionEnabled</code> to true when you create a cluster. </p>",
+        "GlobalReplicationGroup$TransitEncryptionEnabled": "<p>A flag that enables in-transit encryption when set to true. You cannot modify the value of <code>TransitEncryptionEnabled</code> after the cluster is created. To enable in-transit encryption on a cluster you must set <code>TransitEncryptionEnabled</code> to true when you create a cluster. </p> <p> <b>Required:</b> Only available when creating a replication group in an Amazon VPC using redis version <code>3.2.6</code>, <code>4.x</code> or later.</p>",
         "GlobalReplicationGroup$AtRestEncryptionEnabled": "<p>A flag that enables encryption at rest when set to <code>true</code>.</p> <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the replication group is created. To enable encryption at rest on a replication group you must set <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create the replication group. </p> <p> <b>Required:</b> Only available when creating a replication group in an Amazon VPC using redis version <code>3.2.6</code>, <code>4.x</code> or later.</p>",
+        "LogDeliveryConfigurationRequest$Enabled": "<p>Specify if log delivery is enabled. Default <code>true</code>.</p>",
         "ModifyCacheClusterMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
         "ModifyGlobalReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Determines whether a read replica is automatically promoted to read/write primary if the existing primary encounters a failure. </p>",
         "ModifyReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Determines whether a read replica is automatically promoted to read/write primary if the existing primary encounters a failure.</p> <p>Valid values: <code>true</code> | <code>false</code> </p>",
-        "ModifyReplicationGroupMessage$MultiAZEnabled": "<p>A flag indicating if you have Multi-AZ enabled to enhance fault tolerance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html\">Minimizing Downtime: Multi-AZ</a>.</p>",
+        "ModifyReplicationGroupMessage$MultiAZEnabled": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
         "ModifyReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
+        "ModifyReplicationGroupMessage$RemoveUserGroups": "<p>Removes the user groups that can access this replication group.</p>",
+        "ModifyUserMessage$NoPasswordRequired": "<p>Indicates no password is required for the user.</p>",
         "ReplicationGroup$ClusterEnabled": "<p>A flag indicating whether or not this replication group is cluster enabled; i.e., whether its data can be partitioned across multiple shards (API/CLI: node groups).</p> <p>Valid values: <code>true</code> | <code>false</code> </p>",
         "ReplicationGroup$AuthTokenEnabled": "<p>A flag that enables using an <code>AuthToken</code> (password) when issuing Redis commands.</p> <p>Default: <code>false</code> </p>",
         "ReplicationGroup$TransitEncryptionEnabled": "<p>A flag that enables in-transit encryption when set to <code>true</code>.</p> <p>You cannot modify the value of <code>TransitEncryptionEnabled</code> after the cluster is created. To enable in-transit encryption on a cluster you must set <code>TransitEncryptionEnabled</code> to <code>true</code> when you create a cluster.</p> <p> <b>Required:</b> Only available when creating a replication group in an Amazon VPC using redis version <code>3.2.6</code>, <code>4.x</code> or later.</p> <p>Default: <code>false</code> </p>",
@@ -281,7 +314,7 @@
       }
     },
     "CacheNode": {
-      "base": "<p>Represents an individual cache node within a cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+      "base": "<p>Represents an individual cache node within a cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
       "refs": {
         "CacheNodeList$member": null
       }
@@ -494,6 +527,12 @@
         "Parameter$ChangeType": "<p>Indicates whether a change to the parameter is applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>"
       }
     },
+    "CloudWatchLogsDestinationDetails": {
+      "base": "<p>The configuration details of the CloudWatch Logs destination.</p>",
+      "refs": {
+        "DestinationDetails$CloudWatchLogsDetails": "<p>The configuration details of the CloudWatch Logs destination.</p>"
+      }
+    },
     "ClusterIdList": {
       "base": null,
       "refs": {
@@ -601,6 +640,16 @@
       "refs": {
       }
     },
+    "CreateUserGroupMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateUserMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
     "CustomerNodeEndpoint": {
       "base": "<p>The endpoint from which data should be migrated.</p>",
       "refs": {
@@ -630,6 +679,16 @@
     },
     "DecreaseReplicaCountResult": {
       "base": null,
+      "refs": {
+      }
+    },
+    "DefaultUserAssociatedToUserGroupFault": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DefaultUserRequired": {
+      "base": "<p>You must add default user to a user group.</p>",
       "refs": {
       }
     },
@@ -684,6 +743,16 @@
       }
     },
     "DeleteSnapshotResult": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteUserGroupMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteUserMessage": {
       "base": null,
       "refs": {
       }
@@ -778,6 +847,42 @@
       "refs": {
       }
     },
+    "DescribeUserGroupsMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeUserGroupsResult": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeUsersMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeUsersResult": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DestinationDetails": {
+      "base": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose destination.</p>",
+      "refs": {
+        "LogDeliveryConfiguration$DestinationDetails": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose destination.</p>",
+        "LogDeliveryConfigurationRequest$DestinationDetails": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose destination.</p>",
+        "PendingLogDeliveryConfiguration$DestinationDetails": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose destination.</p>"
+      }
+    },
+    "DestinationType": {
+      "base": null,
+      "refs": {
+        "LogDeliveryConfiguration$DestinationType": "<p>Returns the destination type, either <code>cloudwatch-logs</code> or <code>kinesis-firehose</code>.</p>",
+        "LogDeliveryConfigurationRequest$DestinationType": "<p>Specify either <code>cloudwatch-logs</code> or <code>kinesis-firehose</code> as the destination type.</p>",
+        "PendingLogDeliveryConfiguration$DestinationType": "<p>Returns the destination type, either CloudWatch Logs or Kinesis Data Firehose.</p>"
+      }
+    },
     "DisassociateGlobalReplicationGroupMessage": {
       "base": null,
       "refs": {
@@ -799,6 +904,11 @@
         "SlotMigration$ProgressPercentage": "<p>The percentage of the slot migration that is complete.</p>"
       }
     },
+    "DuplicateUserNameFault": {
+      "base": "<p>A user with this username already exists.</p>",
+      "refs": {
+      }
+    },
     "EC2SecurityGroup": {
       "base": "<p>Provides ownership and status information for an Amazon EC2 security group.</p>",
       "refs": {
@@ -814,7 +924,7 @@
     "Endpoint": {
       "base": "<p>Represents the information required for client programs to connect to a cache node.</p>",
       "refs": {
-        "CacheCluster$ConfigurationEndpoint": "<p>Represents a Memcached cluster endpoint which, if Automatic Discovery is enabled on the cluster, can be used by an application to connect to any node in the cluster. The configuration endpoint will always have <code>.cfg</code> in it.</p> <p>Example: <code>mem-3.9dvc4r<u>.cfg</u>.usw2.cache.amazonaws.com:11211</code> </p>",
+        "CacheCluster$ConfigurationEndpoint": "<p>Represents a Memcached cluster endpoint which can be used by an application to connect to any node in the cluster. The configuration endpoint will always have <code>.cfg</code> in it.</p> <p>Example: <code>mem-3.9dvc4r<u>.cfg</u>.usw2.cache.amazonaws.com:11211</code> </p>",
         "CacheNode$Endpoint": "<p>The hostname for connecting to this cache node.</p>",
         "NodeGroup$PrimaryEndpoint": "<p>The endpoint of the primary node in this node group (shard).</p>",
         "NodeGroup$ReaderEndpoint": "<p>The endpoint of the replica nodes in this node group (shard).</p>",
@@ -826,6 +936,16 @@
       "base": "<p>Represents the output of a <code>DescribeEngineDefaultParameters</code> operation.</p>",
       "refs": {
         "DescribeEngineDefaultParametersResult$EngineDefaults": null
+      }
+    },
+    "EngineType": {
+      "base": null,
+      "refs": {
+        "CreateUserGroupMessage$Engine": "<p>The current supported value is Redis. </p>",
+        "CreateUserMessage$Engine": "<p>The current supported value is Redis. </p>",
+        "DescribeUsersMessage$Engine": "<p>The Redis engine. </p>",
+        "User$Engine": "<p>The current supported value is Redis.</p>",
+        "UserGroup$Engine": "<p>The current supported value is Redis. </p>"
       }
     },
     "Event": {
@@ -855,6 +975,36 @@
       "refs": {
       }
     },
+    "Filter": {
+      "base": "<p>Used to streamline results of a search based on the property being filtered.</p>",
+      "refs": {
+        "FilterList$member": null
+      }
+    },
+    "FilterList": {
+      "base": null,
+      "refs": {
+        "DescribeUsersMessage$Filters": "<p>Filter to determine the list of User IDs to return.</p>"
+      }
+    },
+    "FilterName": {
+      "base": null,
+      "refs": {
+        "Filter$Name": "<p>The property being filtered. For example, UserId.</p>"
+      }
+    },
+    "FilterValue": {
+      "base": null,
+      "refs": {
+        "FilterValueList$member": null
+      }
+    },
+    "FilterValueList": {
+      "base": null,
+      "refs": {
+        "Filter$Values": "<p>The property values to filter on. For example, \"user-123\".</p>"
+      }
+    },
     "GlobalNodeGroup": {
       "base": "<p>Indicates the slot configuration and global identifier for a slice group.</p>",
       "refs": {
@@ -864,8 +1014,8 @@
     "GlobalNodeGroupIdList": {
       "base": null,
       "refs": {
-        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalNodeGroupsToRemove": "<p>If the value of NodeGroupCount is less than the current number of node groups (shards), then either NodeGroupsToRemove or NodeGroupsToRetain is required. NodeGroupsToRemove is a list of NodeGroupIds to remove from the cluster. ElastiCache for Redis will attempt to remove all node groups listed by NodeGroupsToRemove from the cluster. </p>",
-        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalNodeGroupsToRetain": "<p>If the value of NodeGroupCount is less than the current number of node groups (shards), then either NodeGroupsToRemove or NodeGroupsToRetain is required. NodeGroupsToRemove is a list of NodeGroupIds to remove from the cluster. ElastiCache for Redis will attempt to remove all node groups listed by NodeGroupsToRemove from the cluster. </p>"
+        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalNodeGroupsToRemove": "<p>If the value of NodeGroupCount is less than the current number of node groups (shards), then either NodeGroupsToRemove or NodeGroupsToRetain is required. GlobalNodeGroupsToRemove is a list of NodeGroupIds to remove from the cluster. ElastiCache for Redis will attempt to remove all node groups listed by GlobalNodeGroupsToRemove from the cluster. </p>",
+        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalNodeGroupsToRetain": "<p>If the value of NodeGroupCount is less than the current number of node groups (shards), then either NodeGroupsToRemove or NodeGroupsToRetain is required. GlobalNodeGroupsToRetain is a list of NodeGroupIds to retain from the cluster. ElastiCache for Redis will attempt to retain all node groups listed by GlobalNodeGroupsToRetain from the cluster. </p>"
       }
     },
     "GlobalNodeGroupList": {
@@ -875,7 +1025,7 @@
       }
     },
     "GlobalReplicationGroup": {
-      "base": "<p>Consists of a primary cluster that accepts writes and an associated secondary cluster that resides in a different AWS region. The secondary cluster accepts only reads. The primary cluster automatically replicates updates to the secondary cluster.</p> <ul> <li> <p>The <b>GlobalReplicationGroupIdSuffix</b> represents the name of the Global Datastore, which is what you use to associate a secondary cluster.</p> </li> </ul>",
+      "base": "<p>Consists of a primary cluster that accepts writes and an associated secondary cluster that resides in a different AWS region. The secondary cluster accepts only reads. The primary cluster automatically replicates updates to the secondary cluster.</p> <ul> <li> <p>The <b>GlobalReplicationGroupIdSuffix</b> represents the name of the Global datastore, which is what you use to associate a secondary cluster.</p> </li> </ul>",
       "refs": {
         "CreateGlobalReplicationGroupResult$GlobalReplicationGroup": null,
         "DecreaseNodeGroupsInGlobalReplicationGroupResult$GlobalReplicationGroup": null,
@@ -889,14 +1039,14 @@
       }
     },
     "GlobalReplicationGroupAlreadyExistsFault": {
-      "base": "<p>The Global Datastore name already exists.</p>",
+      "base": "<p>The Global datastore name already exists.</p>",
       "refs": {
       }
     },
     "GlobalReplicationGroupInfo": {
-      "base": "<p>The name of the Global Datastore and role of this replication group in the Global Datastore.</p>",
+      "base": "<p>The name of the Global datastore and role of this replication group in the Global datastore.</p>",
       "refs": {
-        "ReplicationGroup$GlobalReplicationGroupInfo": "<p>The name of the Global Datastore and role of this replication group in the Global Datastore.</p>"
+        "ReplicationGroup$GlobalReplicationGroupInfo": "<p>The name of the Global datastore and role of this replication group in the Global datastore.</p>"
       }
     },
     "GlobalReplicationGroupList": {
@@ -906,7 +1056,7 @@
       }
     },
     "GlobalReplicationGroupMember": {
-      "base": "<p>A member of a Global Datastore. It contains the Replication Group Id, the AWS region and the role of the replication group. </p>",
+      "base": "<p>A member of a Global datastore. It contains the Replication Group Id, the AWS region and the role of the replication group. </p>",
       "refs": {
         "GlobalReplicationGroupMemberList$member": null
       }
@@ -914,11 +1064,11 @@
     "GlobalReplicationGroupMemberList": {
       "base": null,
       "refs": {
-        "GlobalReplicationGroup$Members": "<p>The replication groups that comprise the Global Datastore.</p>"
+        "GlobalReplicationGroup$Members": "<p>The replication groups that comprise the Global datastore.</p>"
       }
     },
     "GlobalReplicationGroupNotFoundFault": {
-      "base": "<p>The Global Datastore does not exist</p>",
+      "base": "<p>The Global datastore does not exist</p>",
       "refs": {
       }
     },
@@ -963,9 +1113,10 @@
     "IntegerOptional": {
       "base": null,
       "refs": {
-        "CacheCluster$NumCacheNodes": "<p>The number of cache nodes in the cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
+        "Authentication$PasswordCount": "<p>The number of passwords belonging to the user. The maximum is two.</p>",
+        "CacheCluster$NumCacheNodes": "<p>The number of cache nodes in the cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 40.</p>",
         "CacheCluster$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p> </important>",
-        "CreateCacheClusterMessage$NumCacheNodes": "<p>The initial number of cache nodes that the cluster has.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <p>If you need more than 20 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
+        "CreateCacheClusterMessage$NumCacheNodes": "<p>The initial number of cache nodes that the cluster has.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 40.</p> <p>If you need more than 40 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
         "CreateCacheClusterMessage$Port": "<p>The port number on which each of the cache nodes accepts connections.</p>",
         "CreateCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
         "CreateReplicationGroupMessage$NumCacheClusters": "<p>The number of clusters this replication group initially has.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>ReplicasPerNodeGroup</code> instead.</p> <p>If <code>AutomaticFailoverEnabled</code> is <code>true</code>, the value of this parameter must be at least 2. If <code>AutomaticFailoverEnabled</code> is <code>false</code> you can omit this parameter (it will default to 1), or you can explicitly set it to a value between 2 and 6.</p> <p>The maximum permitted value for <code>NumCacheClusters</code> is 6 (1 primary plus 5 replicas).</p>",
@@ -991,15 +1142,17 @@
         "DescribeServiceUpdatesMessage$MaxRecords": "<p>The maximum number of records to include in the response</p>",
         "DescribeSnapshotsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 50</p> <p>Constraints: minimum 20; maximum 50.</p>",
         "DescribeUpdateActionsMessage$MaxRecords": "<p>The maximum number of records to include in the response</p>",
+        "DescribeUserGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified MaxRecords value, a marker is included in the response so that the remaining results can be retrieved. </p>",
+        "DescribeUsersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified MaxRecords value, a marker is included in the response so that the remaining results can be retrieved. </p>",
         "IncreaseReplicaCountMessage$NewReplicaCount": "<p>The number of read replica nodes you want at the completion of this operation. For Redis (cluster mode disabled) replication groups, this is the number of replica nodes in the replication group. For Redis (cluster mode enabled) replication groups, this is the number of replica nodes in each of the replication group's node groups.</p>",
-        "ModifyCacheClusterMessage$NumCacheNodes": "<p>The number of cache nodes that the cluster should have. If the value for <code>NumCacheNodes</code> is greater than the sum of the number of current cache nodes and the number of cache nodes pending creation (which may be zero), more nodes are added. If the value is less than the number of existing cache nodes, nodes are removed. If the value is equal to the number of current cache nodes, any pending add or remove requests are canceled.</p> <p>If you are removing cache nodes, you must use the <code>CacheNodeIdsToRemove</code> parameter to provide the IDs of the specific cache nodes to remove.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <note> <p>Adding or removing Memcached cache nodes can be applied immediately or as a pending operation (see <code>ApplyImmediately</code>).</p> <p>A pending operation to modify the number of cache nodes in a cluster during its maintenance window, whether by adding or removing nodes in accordance with the scale out architecture, is not queued. The customer's latest request to add or remove nodes to the cluster overrides any previous pending operations to modify the number of cache nodes in the cluster. For example, a request to remove 2 nodes would override a previous pending operation to remove 3 nodes. Similarly, a request to add 2 nodes would override a previous pending operation to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned in different Availability Zones with flexible cache node placement, a request to add nodes does not automatically override a previous pending operation to add nodes. The customer can modify the previous pending operation to add more nodes or explicitly cancel the pending request and retry the new request. To cancel pending operations to modify the number of cache nodes in a cluster, use the <code>ModifyCacheCluster</code> request and set <code>NumCacheNodes</code> equal to the number of cache nodes currently in the cluster.</p> </note>",
+        "ModifyCacheClusterMessage$NumCacheNodes": "<p>The number of cache nodes that the cluster should have. If the value for <code>NumCacheNodes</code> is greater than the sum of the number of current cache nodes and the number of cache nodes pending creation (which may be zero), more nodes are added. If the value is less than the number of existing cache nodes, nodes are removed. If the value is equal to the number of current cache nodes, any pending add or remove requests are canceled.</p> <p>If you are removing cache nodes, you must use the <code>CacheNodeIdsToRemove</code> parameter to provide the IDs of the specific cache nodes to remove.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 40.</p> <note> <p>Adding or removing Memcached cache nodes can be applied immediately or as a pending operation (see <code>ApplyImmediately</code>).</p> <p>A pending operation to modify the number of cache nodes in a cluster during its maintenance window, whether by adding or removing nodes in accordance with the scale out architecture, is not queued. The customer's latest request to add or remove nodes to the cluster overrides any previous pending operations to modify the number of cache nodes in the cluster. For example, a request to remove 2 nodes would override a previous pending operation to remove 3 nodes. Similarly, a request to add 2 nodes would override a previous pending operation to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned in different Availability Zones with flexible cache node placement, a request to add nodes does not automatically override a previous pending operation to add nodes. The customer can modify the previous pending operation to add more nodes or explicitly cancel the pending request and retry the new request. To cancel pending operations to modify the number of cache nodes in a cluster, use the <code>ModifyCacheCluster</code> request and set <code>NumCacheNodes</code> equal to the number of cache nodes currently in the cluster.</p> </note>",
         "ModifyCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <note> <p>If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </note>",
         "ModifyReplicationGroupMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic node group (shard) snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>",
         "NodeGroupConfiguration$ReplicaCount": "<p>The number of read replica nodes in this node group (shard).</p>",
-        "PendingModifiedValues$NumCacheNodes": "<p>The new number of cache nodes for the cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
+        "PendingModifiedValues$NumCacheNodes": "<p>The new number of cache nodes for the cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 40.</p>",
         "PurchaseReservedCacheNodesOfferingMessage$CacheNodeCount": "<p>The number of cache node instances to reserve.</p> <p>Default: <code>1</code> </p>",
         "ReplicationGroup$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </important>",
-        "Snapshot$NumCacheNodes": "<p>The number of cache nodes in the source cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
+        "Snapshot$NumCacheNodes": "<p>The number of cache nodes in the source cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 40.</p>",
         "Snapshot$Port": "<p>The port number used by each cache nodes in the source cluster.</p>",
         "Snapshot$SnapshotRetentionLimit": "<p>For an automatic snapshot, the number of days for which ElastiCache retains the snapshot before deleting it.</p> <p>For manual snapshots, this field reflects the <code>SnapshotRetentionLimit</code> for the source cluster when the snapshot was created. This field is otherwise ignored: Manual snapshots do not expire, and can only be deleted using the <code>DeleteSnapshot</code> operation. </p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>",
         "Snapshot$NumNodeGroups": "<p>The number of node groups (shards) in this snapshot. When restoring from a snapshot, the number of node groups (shards) in the snapshot and in the restored replication group must be the same.</p>"
@@ -1026,7 +1179,7 @@
       }
     },
     "InvalidGlobalReplicationGroupStateFault": {
-      "base": "<p>The Global Datastore is not available or in primary-only state.</p>",
+      "base": "<p>The Global datastore is not available or in primary-only state.</p>",
       "refs": {
       }
     },
@@ -1060,6 +1213,16 @@
       "refs": {
       }
     },
+    "InvalidUserGroupStateFault": {
+      "base": "<p>The user group is not in an active state.</p>",
+      "refs": {
+      }
+    },
+    "InvalidUserStateFault": {
+      "base": "<p>The user is not in active state.</p>",
+      "refs": {
+      }
+    },
     "InvalidVPCNetworkStateFault": {
       "base": "<p>The VPC network is in an invalid state.</p>",
       "refs": {
@@ -1071,6 +1234,12 @@
         "RemoveTagsFromResourceMessage$TagKeys": "<p>A list of <code>TagKeys</code> identifying the tags you want removed from the named resource.</p>"
       }
     },
+    "KinesisFirehoseDestinationDetails": {
+      "base": "<p>The configuration details of the Kinesis Data Firehose destination.</p>",
+      "refs": {
+        "DestinationDetails$KinesisFirehoseDetails": "<p>The configuration details of the Kinesis Data Firehose destination.</p>"
+      }
+    },
     "ListAllowedNodeTypeModificationsMessage": {
       "base": "<p>The input parameters for the <code>ListAllowedNodeTypeModifications</code> operation.</p>",
       "refs": {
@@ -1079,6 +1248,56 @@
     "ListTagsForResourceMessage": {
       "base": "<p>The input parameters for the <code>ListTagsForResource</code> operation.</p>",
       "refs": {
+      }
+    },
+    "LogDeliveryConfiguration": {
+      "base": "<p>Returns the destination, format and type of the logs. </p>",
+      "refs": {
+        "LogDeliveryConfigurationList$member": null
+      }
+    },
+    "LogDeliveryConfigurationList": {
+      "base": null,
+      "refs": {
+        "CacheCluster$LogDeliveryConfigurations": "<p>Returns the destination, format and type of the logs.</p>",
+        "ReplicationGroup$LogDeliveryConfigurations": "<p>Returns the destination, format and type of the logs. </p>"
+      }
+    },
+    "LogDeliveryConfigurationRequest": {
+      "base": "<p>Specifies the destination, format and type of the logs. </p>",
+      "refs": {
+        "LogDeliveryConfigurationRequestList$member": null
+      }
+    },
+    "LogDeliveryConfigurationRequestList": {
+      "base": null,
+      "refs": {
+        "CreateCacheClusterMessage$LogDeliveryConfigurations": "<p>Specifies the destination, format and type of the logs. </p>",
+        "CreateReplicationGroupMessage$LogDeliveryConfigurations": "<p>Specifies the destination, format and type of the logs.</p>",
+        "ModifyCacheClusterMessage$LogDeliveryConfigurations": "<p>Specifies the destination, format and type of the logs.</p>",
+        "ModifyReplicationGroupMessage$LogDeliveryConfigurations": "<p>Specifies the destination, format and type of the logs.</p>"
+      }
+    },
+    "LogDeliveryConfigurationStatus": {
+      "base": null,
+      "refs": {
+        "LogDeliveryConfiguration$Status": "<p>Returns the log delivery configuration status. Values are one of <code>enabling</code> | <code>disabling</code> | <code>modifying</code> | <code>active</code> | <code>error</code> </p>"
+      }
+    },
+    "LogFormat": {
+      "base": null,
+      "refs": {
+        "LogDeliveryConfiguration$LogFormat": "<p>Returns the log format, either JSON or TEXT.</p>",
+        "LogDeliveryConfigurationRequest$LogFormat": "<p>Specifies either JSON or TEXT</p>",
+        "PendingLogDeliveryConfiguration$LogFormat": "<p>Returns the log format, either JSON or TEXT</p>"
+      }
+    },
+    "LogType": {
+      "base": null,
+      "refs": {
+        "LogDeliveryConfiguration$LogType": "<p>Refers to <a href=\"https://redis.io/commands/slowlog\">slow-log</a>.</p>",
+        "LogDeliveryConfigurationRequest$LogType": "<p>Refers to <a href=\"https://redis.io/commands/slowlog\">slow-log</a>.</p>",
+        "PendingLogDeliveryConfiguration$LogType": "<p>Refers to <a href=\"https://redis.io/commands/slowlog\">slow-log</a>.</p>"
       }
     },
     "ModifyCacheClusterMessage": {
@@ -1132,6 +1351,16 @@
       }
     },
     "ModifyReplicationGroupShardConfigurationResult": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ModifyUserGroupMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ModifyUserMessage": {
       "base": null,
       "refs": {
       }
@@ -1279,6 +1508,18 @@
         "CacheCluster$NotificationConfiguration": "<p>Describes a notification topic and its status. Notification topics are used for publishing ElastiCache events to subscribers using Amazon Simple Notification Service (SNS). </p>"
       }
     },
+    "OutpostArnsList": {
+      "base": null,
+      "refs": {
+        "NodeGroupConfiguration$ReplicaOutpostArns": "<p>The outpost ARN of the node replicas.</p>"
+      }
+    },
+    "OutpostMode": {
+      "base": null,
+      "refs": {
+        "CreateCacheClusterMessage$OutpostMode": "<p>Specifies whether the nodes in the cluster are created in a single outpost or across multiple outposts.</p>"
+      }
+    },
     "Parameter": {
       "base": "<p>Describes an individual setting that controls some aspect of ElastiCache behavior.</p>",
       "refs": {
@@ -1305,10 +1546,30 @@
         "EngineDefaults$Parameters": "<p>Contains a list of engine default parameters.</p>"
       }
     },
+    "PasswordListInput": {
+      "base": null,
+      "refs": {
+        "CreateUserMessage$Passwords": "<p>Passwords used for this user. You can create up to two passwords for each user.</p>",
+        "ModifyUserMessage$Passwords": "<p>The passwords belonging to the user. You are allowed up to two.</p>"
+      }
+    },
     "PendingAutomaticFailoverStatus": {
       "base": null,
       "refs": {
         "ReplicationGroupPendingModifiedValues$AutomaticFailoverStatus": "<p>Indicates the status of automatic failover for this Redis replication group.</p>"
+      }
+    },
+    "PendingLogDeliveryConfiguration": {
+      "base": "<p>The log delivery configurations being modified </p>",
+      "refs": {
+        "PendingLogDeliveryConfigurationList$member": null
+      }
+    },
+    "PendingLogDeliveryConfigurationList": {
+      "base": null,
+      "refs": {
+        "PendingModifiedValues$LogDeliveryConfigurations": "<p>The log delivery configurations being modified </p>",
+        "ReplicationGroupPendingModifiedValues$LogDeliveryConfigurations": "<p>The log delivery configurations being modified </p>"
       }
     },
     "PendingModifiedValues": {
@@ -1322,7 +1583,14 @@
       "refs": {
         "ConfigureShard$PreferredAvailabilityZones": "<p>A list of <code>PreferredAvailabilityZone</code> strings that specify which availability zones the replication group's nodes are to be in. The nummber of <code>PreferredAvailabilityZone</code> values must equal the value of <code>NewReplicaCount</code> plus 1 to account for the primary node. If this member of <code>ReplicaConfiguration</code> is omitted, ElastiCache for Redis selects the availability zone for each of the replicas.</p>",
         "CreateCacheClusterMessage$PreferredAvailabilityZones": "<p>A list of the Availability Zones in which cache nodes are created. The order of the zones in the list is not important.</p> <p>This option is only supported on Memcached.</p> <note> <p>If you are creating your cluster in an Amazon VPC (recommended) you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheNodes</code>.</p> </note> <p>If you want all the nodes in the same Availability Zone, use <code>PreferredAvailabilityZone</code> instead, or repeat the Availability Zone multiple times in the list.</p> <p>Default: System chosen Availability Zones.</p>",
-        "ModifyCacheClusterMessage$NewAvailabilityZones": "<p>The list of Availability Zones where the new Memcached cache nodes are created.</p> <p>This parameter is only valid when <code>NumCacheNodes</code> in the request is greater than the sum of the number of active cache nodes and the number of cache nodes pending creation (which may be zero). The number of Availability Zones supplied in this list must match the cache nodes being added in this request.</p> <p>This option is only supported on Memcached clusters.</p> <p>Scenarios:</p> <ul> <li> <p> <b>Scenario 1:</b> You have 3 active nodes and wish to add 2 nodes. Specify <code>NumCacheNodes=5</code> (3 + 2) and optionally specify two Availability Zones for the two new nodes.</p> </li> <li> <p> <b>Scenario 2:</b> You have 3 active nodes and 2 nodes pending creation (from the scenario 1 call) and want to add 1 more node. Specify <code>NumCacheNodes=6</code> ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.</p> </li> <li> <p> <b>Scenario 3:</b> You want to cancel all pending operations. Specify <code>NumCacheNodes=3</code> to cancel all pending operations.</p> </li> </ul> <p>The Availability Zone placement of nodes pending creation cannot be modified. If you wish to cancel any nodes pending creation, add 0 nodes by setting <code>NumCacheNodes</code> to the number of current nodes.</p> <p>If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone. Only newly created nodes can be located in different Availability Zones. For guidance on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html\">Cache Node Considerations for Memcached</a>.</p> <p> <b>Impact of new add/remove requests upon pending requests</b> </p> <ul> <li> <p>Scenario-1</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-2</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-3</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending create.</p> </li> </ul> </li> <li> <p>Scenario-4</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create is added to the pending create.</p> <important> <p> <b>Important:</b> If the new create request is <b>Apply Immediately - Yes</b>, all creates are performed immediately. If the new create request is <b>Apply Immediately - No</b>, all creates are pending.</p> </important> </li> </ul> </li> </ul>"
+        "ModifyCacheClusterMessage$NewAvailabilityZones": "<note> <p>This option is only supported on Memcached clusters.</p> </note> <p>The list of Availability Zones where the new Memcached cache nodes are created.</p> <p>This parameter is only valid when <code>NumCacheNodes</code> in the request is greater than the sum of the number of active cache nodes and the number of cache nodes pending creation (which may be zero). The number of Availability Zones supplied in this list must match the cache nodes being added in this request.</p> <p>Scenarios:</p> <ul> <li> <p> <b>Scenario 1:</b> You have 3 active nodes and wish to add 2 nodes. Specify <code>NumCacheNodes=5</code> (3 + 2) and optionally specify two Availability Zones for the two new nodes.</p> </li> <li> <p> <b>Scenario 2:</b> You have 3 active nodes and 2 nodes pending creation (from the scenario 1 call) and want to add 1 more node. Specify <code>NumCacheNodes=6</code> ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.</p> </li> <li> <p> <b>Scenario 3:</b> You want to cancel all pending operations. Specify <code>NumCacheNodes=3</code> to cancel all pending operations.</p> </li> </ul> <p>The Availability Zone placement of nodes pending creation cannot be modified. If you wish to cancel any nodes pending creation, add 0 nodes by setting <code>NumCacheNodes</code> to the number of current nodes.</p> <p>If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone. Only newly created nodes can be located in different Availability Zones. For guidance on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html\">Cache Node Considerations for Memcached</a>.</p> <p> <b>Impact of new add/remove requests upon pending requests</b> </p> <ul> <li> <p>Scenario-1</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-2</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-3</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending create.</p> </li> </ul> </li> <li> <p>Scenario-4</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create is added to the pending create.</p> <important> <p> <b>Important:</b> If the new create request is <b>Apply Immediately - Yes</b>, all creates are performed immediately. If the new create request is <b>Apply Immediately - No</b>, all creates are pending.</p> </important> </li> </ul> </li> </ul>"
+      }
+    },
+    "PreferredOutpostArnList": {
+      "base": null,
+      "refs": {
+        "ConfigureShard$PreferredOutpostArns": "<p>The outpost ARNs in which the cache cluster is created.</p>",
+        "CreateCacheClusterMessage$PreferredOutpostArns": "<p>The outpost ARNs in which the cache cluster is created.</p>"
       }
     },
     "ProcessedUpdateAction": {
@@ -1389,7 +1657,7 @@
     "RegionalConfigurationList": {
       "base": null,
       "refs": {
-        "IncreaseNodeGroupsInGlobalReplicationGroupMessage$RegionalConfigurations": "<p>Describes the replication group IDs, the AWS regions where they are stored and the shard configuration for each that comprise the Global Datastore</p>"
+        "IncreaseNodeGroupsInGlobalReplicationGroupMessage$RegionalConfigurations": "<p>Describes the replication group IDs, the AWS regions where they are stored and the shard configuration for each that comprise the Global datastore</p>"
       }
     },
     "RemoveReplicasList": {
@@ -1462,6 +1730,12 @@
     "ReplicationGroupNotUnderMigrationFault": {
       "base": "<p>The designated replication group is not available for data migration.</p>",
       "refs": {
+      }
+    },
+    "ReplicationGroupOutpostArnList": {
+      "base": null,
+      "refs": {
+        "ReplicationGroup$MemberClustersOutpostArns": "<p>The outpost ARNs of the replication group's member clusters.</p>"
       }
     },
     "ReplicationGroupPendingModifiedValues": {
@@ -1720,11 +1994,12 @@
         "BatchStopUpdateActionMessage$ServiceUpdateName": "<p>The unique ID of the service update</p>",
         "CacheCluster$CacheClusterId": "<p>The user-supplied identifier of the cluster. This identifier is a unique key that identifies a cluster.</p>",
         "CacheCluster$ClientDownloadLandingPage": "<p>The URL of the web page where you can download the latest ElastiCache client library.</p>",
-        "CacheCluster$CacheNodeType": "<p>The name of the compute and memory capacity node type for the cluster.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "CacheCluster$CacheNodeType": "<p>The name of the compute and memory capacity node type for the cluster.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "CacheCluster$Engine": "<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) to be used for this cluster.</p>",
         "CacheCluster$EngineVersion": "<p>The version of the cache engine that is used in this cluster.</p>",
         "CacheCluster$CacheClusterStatus": "<p>The current state of this cluster, one of the following values: <code>available</code>, <code>creating</code>, <code>deleted</code>, <code>deleting</code>, <code>incompatible-network</code>, <code>modifying</code>, <code>rebooting cluster nodes</code>, <code>restore-failed</code>, or <code>snapshotting</code>.</p>",
         "CacheCluster$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the cluster is located or \"Multiple\" if the cache nodes are located in different Availability Zones.</p>",
+        "CacheCluster$PreferredOutpostArn": "<p>The outpost ARN in which the cache cluster is created.</p>",
         "CacheCluster$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
         "CacheCluster$CacheSubnetGroupName": "<p>The name of the cache subnet group associated with the cluster.</p>",
         "CacheCluster$ReplicationGroupId": "<p>The replication group to which this cluster belongs. If this field is empty, the cluster is not associated with any replication group.</p>",
@@ -1734,7 +2009,7 @@
         "CacheClusterMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "CacheEngineVersion$Engine": "<p>The name of the cache engine.</p>",
         "CacheEngineVersion$EngineVersion": "<p>The version number of the cache engine.</p>",
-        "CacheEngineVersion$CacheParameterGroupFamily": "<p>The name of the cache parameter group family associated with this cache engine.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p>",
+        "CacheEngineVersion$CacheParameterGroupFamily": "<p>The name of the cache parameter group family associated with this cache engine.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p>",
         "CacheEngineVersion$CacheEngineDescription": "<p>The description of the cache engine.</p>",
         "CacheEngineVersion$CacheEngineVersionDescription": "<p>The description of the cache engine version.</p>",
         "CacheEngineVersionMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
@@ -1743,6 +2018,7 @@
         "CacheNode$ParameterGroupStatus": "<p>The status of the parameter group applied to this cache node.</p>",
         "CacheNode$SourceCacheNodeId": "<p>The ID of the primary node to which this read replica node is synchronized. If this field is empty, this node is not associated with a primary cluster.</p>",
         "CacheNode$CustomerAvailabilityZone": "<p>The Availability Zone where this node was created and now resides.</p>",
+        "CacheNode$CustomerOutpostArn": "<p>The customer outpost ARN of the cache node.</p>",
         "CacheNodeIdsList$member": null,
         "CacheNodeTypeSpecificParameter$ParameterName": "<p>The name of the parameter.</p>",
         "CacheNodeTypeSpecificParameter$Description": "<p>A description of the parameter.</p>",
@@ -1754,7 +2030,7 @@
         "CacheNodeTypeSpecificValue$Value": "<p>The value for the cache node type.</p>",
         "CacheNodeUpdateStatus$CacheNodeId": "<p>The node ID of the cache cluster</p>",
         "CacheParameterGroup$CacheParameterGroupName": "<p>The name of the cache parameter group.</p>",
-        "CacheParameterGroup$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that this cache parameter group is compatible with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p>",
+        "CacheParameterGroup$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that this cache parameter group is compatible with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p>",
         "CacheParameterGroup$Description": "<p>The description for this cache parameter group.</p>",
         "CacheParameterGroup$ARN": "<p>The ARN (Amazon Resource Name) of the cache parameter group.</p>",
         "CacheParameterGroupDetails$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
@@ -1765,7 +2041,7 @@
         "CacheSecurityGroup$OwnerId": "<p>The AWS account ID of the cache security group owner.</p>",
         "CacheSecurityGroup$CacheSecurityGroupName": "<p>The name of the cache security group.</p>",
         "CacheSecurityGroup$Description": "<p>The description of the cache security group.</p>",
-        "CacheSecurityGroup$ARN": "<p>The ARN (Amazon Resource Name) of the cache security group.</p>",
+        "CacheSecurityGroup$ARN": "<p>The ARN of the cache security group,</p>",
         "CacheSecurityGroupMembership$CacheSecurityGroupName": "<p>The name of the cache security group.</p>",
         "CacheSecurityGroupMembership$Status": "<p>The membership status in the cache security group. The status changes when a cache security group is modified, or when the cache security groups assigned to a cluster are modified.</p>",
         "CacheSecurityGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
@@ -1775,43 +2051,45 @@
         "CacheSubnetGroup$VpcId": "<p>The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet group.</p>",
         "CacheSubnetGroup$ARN": "<p>The ARN (Amazon Resource Name) of the cache subnet group.</p>",
         "CacheSubnetGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
+        "CloudWatchLogsDestinationDetails$LogGroup": "<p>The name of the CloudWatch Logs log group.</p>",
         "ClusterIdList$member": null,
         "CompleteMigrationMessage$ReplicationGroupId": "<p>The ID of the replication group to which data is being migrated.</p>",
         "CopySnapshotMessage$SourceSnapshotName": "<p>The name of an existing snapshot from which to make a copy.</p>",
         "CopySnapshotMessage$TargetSnapshotName": "<p>A name for the snapshot copy. ElastiCache does not permit overwriting a snapshot, therefore this name must be unique within its context - ElastiCache or an Amazon S3 bucket if exporting.</p>",
-        "CopySnapshotMessage$TargetBucket": "<p>The Amazon S3 bucket to which the snapshot is exported. This parameter is used only when exporting a snapshot for external access.</p> <p>When using this parameter to export a snapshot, be sure Amazon ElastiCache has the needed permissions to this S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html#backups-exporting-grant-access\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the <i>Amazon ElastiCache User Guide</i>.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Snapshots.Exporting.html\">Exporting a Snapshot</a> in the <i>Amazon ElastiCache User Guide</i>.</p>",
+        "CopySnapshotMessage$TargetBucket": "<p>The Amazon S3 bucket to which the snapshot is exported. This parameter is used only when exporting a snapshot for external access.</p> <p>When using this parameter to export a snapshot, be sure Amazon ElastiCache has the needed permissions to this S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html#backups-exporting-grant-access\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the <i>Amazon ElastiCache User Guide</i>.</p> <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html\">Exporting a Snapshot</a> in the <i>Amazon ElastiCache User Guide</i>.</p>",
         "CopySnapshotMessage$KmsKeyId": "<p>The ID of the KMS key used to encrypt the target snapshot.</p>",
         "CreateCacheClusterMessage$CacheClusterId": "<p>The node group (shard) identifier. This parameter is stored as a lowercase string.</p> <p> <b>Constraints:</b> </p> <ul> <li> <p>A name must contain from 1 to 50 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
         "CreateCacheClusterMessage$ReplicationGroupId": "<p>The ID of the replication group to which this cluster should belong. If this parameter is specified, the cluster is added to the specified replication group as a read replica; otherwise, the cluster is a standalone primary that is not part of any replication group.</p> <p>If the specified replication group is Multi-AZ enabled and the Availability Zone is not specified, the cluster is created in Availability Zones that provide the best spread of read replicas across Availability Zones.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
         "CreateCacheClusterMessage$PreferredAvailabilityZone": "<p>The EC2 Availability Zone in which the cluster is created.</p> <p>All nodes belonging to this cluster are placed in the preferred Availability Zone. If you want to create your nodes across multiple Availability Zones, use <code>PreferredAvailabilityZones</code>.</p> <p>Default: System chosen Availability Zone.</p>",
-        "CreateCacheClusterMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "CreateCacheClusterMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "CreateCacheClusterMessage$Engine": "<p>The name of the cache engine to be used for this cluster.</p> <p>Valid values for this parameter are: <code>memcached</code> | <code>redis</code> </p>",
         "CreateCacheClusterMessage$EngineVersion": "<p>The version number of the cache engine to be used for this cluster. To view the supported cache engine versions, use the DescribeCacheEngineVersions operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cluster or replication group and create it anew with the earlier engine version. </p>",
         "CreateCacheClusterMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this cluster. If this argument is omitted, the default parameter group for the specified engine is used. You cannot use any parameter group which has <code>cluster-enabled='yes'</code> when creating a cluster.</p>",
         "CreateCacheClusterMessage$CacheSubnetGroupName": "<p>The name of the subnet group to be used for the cluster.</p> <p>Use this parameter only when you are creating a cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>",
         "CreateCacheClusterMessage$SnapshotName": "<p>The name of a Redis snapshot from which to restore data into the new node group (shard). The snapshot status changes to <code>restoring</code> while the new node group (shard) is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
-        "CreateCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
+        "CreateCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p>",
         "CreateCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cluster owner.</p> </note>",
         "CreateCacheClusterMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
         "CreateCacheClusterMessage$AuthToken": "<p> <b>Reserved parameter.</b> The password used to access a password protected server.</p> <p>Password constraints:</p> <ul> <li> <p>Must be only printable ASCII characters.</p> </li> <li> <p>Must be at least 16 characters and no more than 128 characters in length.</p> </li> <li> <p>The only permitted printable special characters are !, &amp;, #, $, ^, &lt;, &gt;, and -. Other printable special characters cannot be used in the AUTH token.</p> </li> </ul> <p>For more information, see <a href=\"http://redis.io/commands/AUTH\">AUTH password</a> at http://redis.io/commands/AUTH.</p>",
+        "CreateCacheClusterMessage$PreferredOutpostArn": "<p>The outpost ARN in which the cache cluster is created.</p>",
         "CreateCacheParameterGroupMessage$CacheParameterGroupName": "<p>A user-specified name for the cache parameter group.</p>",
-        "CreateCacheParameterGroupMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p>",
+        "CreateCacheParameterGroupMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p>",
         "CreateCacheParameterGroupMessage$Description": "<p>A user-specified description for the cache parameter group.</p>",
         "CreateCacheSecurityGroupMessage$CacheSecurityGroupName": "<p>A name for the cache security group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Cannot be the word \"Default\".</p> <p>Example: <code>mysecuritygroup</code> </p>",
         "CreateCacheSecurityGroupMessage$Description": "<p>A description for the cache security group.</p>",
         "CreateCacheSubnetGroupMessage$CacheSubnetGroupName": "<p>A name for the cache subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p> <p>Example: <code>mysubnetgroup</code> </p>",
         "CreateCacheSubnetGroupMessage$CacheSubnetGroupDescription": "<p>A description for the cache subnet group.</p>",
-        "CreateGlobalReplicationGroupMessage$GlobalReplicationGroupIdSuffix": "<p>The suffix name of a Global Datastore. The suffix guarantees uniqueness of the Global Datastore name across multiple regions.</p>",
-        "CreateGlobalReplicationGroupMessage$GlobalReplicationGroupDescription": "<p>Provides details of the Global Datastore</p>",
+        "CreateGlobalReplicationGroupMessage$GlobalReplicationGroupIdSuffix": "<p>The suffix name of a Global datastore. Amazon ElastiCache automatically applies a prefix to the Global datastore ID when it is created. Each AWS Region has its own prefix. For instance, a Global datastore ID created in the US-West-1 region will begin with \"dsdfu\" along with the suffix name you provide. The suffix, combined with the auto-generated prefix, guarantees uniqueness of the Global datastore name across multiple regions. </p> <p>For a full list of AWS Regions and their respective Global datastore iD prefixes, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Redis-Global-Datastores-CLI.html\">Using the AWS CLI with Global datastores </a>.</p>",
+        "CreateGlobalReplicationGroupMessage$GlobalReplicationGroupDescription": "<p>Provides details of the Global datastore</p>",
         "CreateGlobalReplicationGroupMessage$PrimaryReplicationGroupId": "<p>The name of the primary cluster that accepts writes and will replicate updates to the secondary cluster.</p>",
         "CreateReplicationGroupMessage$ReplicationGroupId": "<p>The replication group identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>A name must contain from 1 to 40 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
         "CreateReplicationGroupMessage$ReplicationGroupDescription": "<p>A user-created description for the replication group.</p>",
-        "CreateReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "CreateReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "CreateReplicationGroupMessage$PrimaryClusterId": "<p>The identifier of the cluster that serves as the primary for this replication group. This cluster must already exist and have a status of <code>available</code>.</p> <p>This parameter is not required if <code>NumCacheClusters</code>, <code>NumNodeGroups</code>, or <code>ReplicasPerNodeGroup</code> is specified.</p>",
-        "CreateReplicationGroupMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
-        "CreateReplicationGroupMessage$Engine": "<p>The name of the cache engine to be used for the clusters in this replication group.</p>",
+        "CreateReplicationGroupMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "CreateReplicationGroupMessage$Engine": "<p>The name of the cache engine to be used for the clusters in this replication group. Must be Redis.</p>",
         "CreateReplicationGroupMessage$EngineVersion": "<p>The version number of the cache engine to be used for the clusters in this replication group. To view the supported cache engine versions, use the <code>DescribeCacheEngineVersions</code> operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>) in the <i>ElastiCache User Guide</i>, but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cluster or replication group and create it anew with the earlier engine version. </p>",
-        "CreateReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.</p> <note> <p>If you are restoring to an engine version that is different than the original, you must specify the default version of that version. For example, <code>CacheParameterGroupName=default.redis4.0</code>.</p> </note> <p>If you are running Redis version 3.2.4 or later, only one node group (shard), and want to use a default parameter group, we recommend that you specify the parameter group by name. </p> <ul> <li> <p>To create a Redis (cluster mode disabled) replication group, use <code>CacheParameterGroupName=default.redis3.2</code>.</p> </li> <li> <p>To create a Redis (cluster mode enabled) replication group, use <code>CacheParameterGroupName=default.redis3.2.cluster.on</code>.</p> </li> </ul>",
+        "CreateReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.</p> <p>If you are running Redis version 3.2.4 or later, only one node group (shard), and want to use a default parameter group, we recommend that you specify the parameter group by name. </p> <ul> <li> <p>To create a Redis (cluster mode disabled) replication group, use <code>CacheParameterGroupName=default.redis3.2</code>.</p> </li> <li> <p>To create a Redis (cluster mode enabled) replication group, use <code>CacheParameterGroupName=default.redis3.2.cluster.on</code>.</p> </li> </ul>",
         "CreateReplicationGroupMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to be used for the replication group.</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>",
         "CreateReplicationGroupMessage$SnapshotName": "<p>The name of a snapshot from which to restore data into the new replication group. The snapshot status changes to <code>restoring</code> while the new replication group is being created.</p>",
         "CreateReplicationGroupMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
@@ -1823,23 +2101,25 @@
         "CreateSnapshotMessage$CacheClusterId": "<p>The identifier of an existing cluster. The snapshot is created from this cluster.</p>",
         "CreateSnapshotMessage$SnapshotName": "<p>A name for the snapshot being created.</p>",
         "CreateSnapshotMessage$KmsKeyId": "<p>The ID of the KMS key used to encrypt the snapshot.</p>",
+        "CreateUserGroupMessage$UserGroupId": "<p>The ID of the user group.</p>",
         "CustomerNodeEndpoint$Address": "<p>The address of the node endpoint</p>",
-        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "DecreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "DecreaseReplicaCountMessage$ReplicationGroupId": "<p>The id of the replication group from which you want to remove replica nodes.</p>",
         "DeleteCacheClusterMessage$CacheClusterId": "<p>The cluster identifier for the cluster to be deleted. This parameter is not case sensitive.</p>",
         "DeleteCacheClusterMessage$FinalSnapshotIdentifier": "<p>The user-supplied name of a final cluster snapshot. This is the unique name that identifies the snapshot. ElastiCache creates the snapshot, and then deletes the cluster immediately afterward.</p>",
         "DeleteCacheParameterGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to delete.</p> <note> <p>The specified cache security group must not be associated with any clusters.</p> </note>",
         "DeleteCacheSecurityGroupMessage$CacheSecurityGroupName": "<p>The name of the cache security group to delete.</p> <note> <p>You cannot delete the default security group.</p> </note>",
         "DeleteCacheSubnetGroupMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to delete.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p>",
-        "DeleteGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "DeleteGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "DeleteReplicationGroupMessage$ReplicationGroupId": "<p>The identifier for the cluster to be deleted. This parameter is not case sensitive.</p>",
         "DeleteReplicationGroupMessage$FinalSnapshotIdentifier": "<p>The name of a final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster, rather than one of the replicas; this is to ensure that it captures the freshest data. After the final snapshot is taken, the replication group is immediately deleted.</p>",
         "DeleteSnapshotMessage$SnapshotName": "<p>The name of the snapshot to be deleted.</p>",
+        "DeleteUserGroupMessage$UserGroupId": "<p>The ID of the user group.</p>",
         "DescribeCacheClustersMessage$CacheClusterId": "<p>The user-supplied cluster identifier. If this parameter is specified, only information about that specific cluster is returned. This parameter isn't case sensitive.</p>",
         "DescribeCacheClustersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheEngineVersionsMessage$Engine": "<p>The cache engine to return. Valid values: <code>memcached</code> | <code>redis</code> </p>",
         "DescribeCacheEngineVersionsMessage$EngineVersion": "<p>The cache engine version to return.</p> <p>Example: <code>1.4.14</code> </p>",
-        "DescribeCacheEngineVersionsMessage$CacheParameterGroupFamily": "<p>The name of a specific cache parameter group family to return details for.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "DescribeCacheEngineVersionsMessage$CacheParameterGroupFamily": "<p>The name of a specific cache parameter group family to return details for.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
         "DescribeCacheEngineVersionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheParameterGroupsMessage$CacheParameterGroupName": "<p>The name of a specific cache parameter group to return details for.</p>",
         "DescribeCacheParameterGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
@@ -1850,27 +2130,27 @@
         "DescribeCacheSecurityGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheSubnetGroupsMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to return details for.</p>",
         "DescribeCacheSubnetGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "DescribeEngineDefaultParametersMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p>",
+        "DescribeEngineDefaultParametersMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p>",
         "DescribeEngineDefaultParametersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeEventsMessage$SourceIdentifier": "<p>The identifier of the event source for which events are returned. If not specified, all sources are included in the response.</p>",
         "DescribeEventsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "DescribeGlobalReplicationGroupsMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "DescribeGlobalReplicationGroupsMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "DescribeGlobalReplicationGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeGlobalReplicationGroupsResult$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by MaxRecords. &gt;</p>",
         "DescribeReplicationGroupsMessage$ReplicationGroupId": "<p>The identifier for the replication group to be described. This parameter is not case sensitive.</p> <p>If you do not specify this parameter, information about all replication groups is returned.</p>",
         "DescribeReplicationGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeReservedCacheNodesMessage$ReservedCacheNodeId": "<p>The reserved cache node identifier filter value. Use this parameter to show only the reservation that matches the specified reservation ID.</p>",
         "DescribeReservedCacheNodesMessage$ReservedCacheNodesOfferingId": "<p>The offering identifier filter value. Use this parameter to show only purchased reservations matching the specified offering identifier.</p>",
-        "DescribeReservedCacheNodesMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "DescribeReservedCacheNodesMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "DescribeReservedCacheNodesMessage$Duration": "<p>The duration filter value, specified in years or seconds. Use this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
         "DescribeReservedCacheNodesMessage$ProductDescription": "<p>The product description filter value. Use this parameter to show only those reservations matching the specified product description.</p>",
-        "DescribeReservedCacheNodesMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>",
+        "DescribeReservedCacheNodesMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"|\"All Upfront\"|\"Partial Upfront\"| \"No Upfront\"</code> </p>",
         "DescribeReservedCacheNodesMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeReservedCacheNodesOfferingsMessage$ReservedCacheNodesOfferingId": "<p>The offering identifier filter value. Use this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
-        "DescribeReservedCacheNodesOfferingsMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "DescribeReservedCacheNodesOfferingsMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "DescribeReservedCacheNodesOfferingsMessage$Duration": "<p>Duration filter value, specified in years or seconds. Use this parameter to show only reservations for a given duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
         "DescribeReservedCacheNodesOfferingsMessage$ProductDescription": "<p>The product description filter value. Use this parameter to show only the available offerings matching the specified product description.</p>",
-        "DescribeReservedCacheNodesOfferingsMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>",
+        "DescribeReservedCacheNodesOfferingsMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\" |\"All Upfront\"|\"Partial Upfront\"| \"No Upfront\"</code> </p>",
         "DescribeReservedCacheNodesOfferingsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeServiceUpdatesMessage$ServiceUpdateName": "<p>The unique ID of the service update</p>",
         "DescribeServiceUpdatesMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
@@ -1883,43 +2163,50 @@
         "DescribeUpdateActionsMessage$ServiceUpdateName": "<p>The unique ID of the service update</p>",
         "DescribeUpdateActionsMessage$Engine": "<p>The Elasticache engine to which the update applies. Either Redis or Memcached </p>",
         "DescribeUpdateActionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "DisassociateGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
-        "DisassociateGlobalReplicationGroupMessage$ReplicationGroupId": "<p>The name of the secondary cluster you wish to remove from the Global Datastore</p>",
-        "DisassociateGlobalReplicationGroupMessage$ReplicationGroupRegion": "<p>The AWS region of secondary cluster you wish to remove from the Global Datastore</p>",
+        "DescribeUserGroupsMessage$UserGroupId": "<p>The ID of the user group.</p>",
+        "DescribeUserGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by MaxRecords. &gt;</p>",
+        "DescribeUserGroupsResult$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by MaxRecords. &gt;</p>",
+        "DescribeUsersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by MaxRecords. &gt;</p>",
+        "DescribeUsersResult$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by MaxRecords. &gt;</p>",
+        "DisassociateGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
+        "DisassociateGlobalReplicationGroupMessage$ReplicationGroupId": "<p>The name of the secondary cluster you wish to remove from the Global datastore</p>",
+        "DisassociateGlobalReplicationGroupMessage$ReplicationGroupRegion": "<p>The AWS region of secondary cluster you wish to remove from the Global datastore</p>",
         "EC2SecurityGroup$Status": "<p>The status of the Amazon EC2 security group.</p>",
         "EC2SecurityGroup$EC2SecurityGroupName": "<p>The name of the Amazon EC2 security group.</p>",
         "EC2SecurityGroup$EC2SecurityGroupOwnerId": "<p>The AWS account ID of the Amazon EC2 security group owner.</p>",
         "Endpoint$Address": "<p>The DNS hostname of the cache node.</p>",
-        "EngineDefaults$CacheParameterGroupFamily": "<p>Specifies the name of the cache parameter group family to which the engine default parameters apply.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | </p>",
+        "EngineDefaults$CacheParameterGroupFamily": "<p>Specifies the name of the cache parameter group family to which the engine default parameters apply.</p> <p>Valid values are: <code>memcached1.4</code> | <code>memcached1.5</code> | <code>memcached1.6</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> | <code>redis4.0</code> | <code>redis5.0</code> | <code>redis6.x</code> | </p>",
         "EngineDefaults$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "Event$SourceIdentifier": "<p>The identifier for the source of the event. For example, if the event occurred at the cluster level, the identifier would be the name of the cluster.</p>",
         "Event$Message": "<p>The text of the event.</p>",
         "EventsMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
-        "FailoverGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
-        "FailoverGlobalReplicationGroupMessage$PrimaryRegion": "<p>The AWS region of the primary cluster of the Global Datastore</p>",
+        "FailoverGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
+        "FailoverGlobalReplicationGroupMessage$PrimaryRegion": "<p>The AWS region of the primary cluster of the Global datastore</p>",
         "FailoverGlobalReplicationGroupMessage$PrimaryReplicationGroupId": "<p>The name of the primary replication group</p>",
         "GlobalNodeGroup$GlobalNodeGroupId": "<p>The name of the global node group</p>",
         "GlobalNodeGroup$Slots": "<p>The keyspace for this node group</p>",
         "GlobalNodeGroupIdList$member": null,
-        "GlobalReplicationGroup$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
-        "GlobalReplicationGroup$GlobalReplicationGroupDescription": "<p>The optional description of the Global Datastore</p>",
-        "GlobalReplicationGroup$Status": "<p>The status of the Global Datastore</p>",
-        "GlobalReplicationGroup$CacheNodeType": "<p>The cache node type of the Global Datastore</p>",
+        "GlobalReplicationGroup$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
+        "GlobalReplicationGroup$GlobalReplicationGroupDescription": "<p>The optional description of the Global datastore</p>",
+        "GlobalReplicationGroup$Status": "<p>The status of the Global datastore</p>",
+        "GlobalReplicationGroup$CacheNodeType": "<p>The cache node type of the Global datastore</p>",
         "GlobalReplicationGroup$Engine": "<p>The Elasticache engine. For Redis only.</p>",
-        "GlobalReplicationGroup$EngineVersion": "<p>The Elasticache Redis engine version. For preview, it is Redis version 5.0.5 only.</p>",
+        "GlobalReplicationGroup$EngineVersion": "<p>The Elasticache Redis engine version.</p>",
         "GlobalReplicationGroup$ARN": "<p>The ARN (Amazon Resource Name) of the global replication group.</p>",
-        "GlobalReplicationGroupInfo$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
-        "GlobalReplicationGroupInfo$GlobalReplicationGroupMemberRole": "<p>The role of the replication group in a Global Datastore. Can be primary or secondary.</p>",
-        "GlobalReplicationGroupMember$ReplicationGroupId": "<p>The replication group id of the Global Datastore member.</p>",
-        "GlobalReplicationGroupMember$ReplicationGroupRegion": "<p>The AWS region of the Global Datastore member.</p>",
+        "GlobalReplicationGroupInfo$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
+        "GlobalReplicationGroupInfo$GlobalReplicationGroupMemberRole": "<p>The role of the replication group in a Global datastore. Can be primary or secondary.</p>",
+        "GlobalReplicationGroupMember$ReplicationGroupId": "<p>The replication group id of the Global datastore member.</p>",
+        "GlobalReplicationGroupMember$ReplicationGroupRegion": "<p>The AWS region of the Global datastore member.</p>",
         "GlobalReplicationGroupMember$Role": "<p>Indicates the role of the replication group, primary or secondary.</p>",
         "GlobalReplicationGroupMember$Status": "<p>The status of the membership of the replication group.</p>",
-        "IncreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "IncreaseNodeGroupsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "IncreaseReplicaCountMessage$ReplicationGroupId": "<p>The id of the replication group to which you want to add replica nodes.</p>",
         "KeyList$member": null,
+        "KinesisFirehoseDestinationDetails$DeliveryStream": "<p>The name of the Kinesis Data Firehose delivery stream.</p>",
         "ListAllowedNodeTypeModificationsMessage$CacheClusterId": "<p>The name of the cluster you want to scale up to a larger node instanced type. ElastiCache uses the cluster id to identify the current node type of this cluster and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>",
         "ListAllowedNodeTypeModificationsMessage$ReplicationGroupId": "<p>The name of the replication group want to scale up to a larger node type. ElastiCache uses the replication group id to identify the current node type being used by this replication group, and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>",
         "ListTagsForResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource for which you want the list of tags, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
+        "LogDeliveryConfiguration$Message": "<p>Returns an error message for the log delivery configuration.</p>",
         "ModifyCacheClusterMessage$CacheClusterId": "<p>The cluster identifier. This value is stored as a lowercase string.</p>",
         "ModifyCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
         "ModifyCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be same as the cluster owner.</p> </note>",
@@ -1932,10 +2219,11 @@
         "ModifyCacheParameterGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to modify.</p>",
         "ModifyCacheSubnetGroupMessage$CacheSubnetGroupName": "<p>The name for the cache subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p> <p>Example: <code>mysubnetgroup</code> </p>",
         "ModifyCacheSubnetGroupMessage$CacheSubnetGroupDescription": "<p>A description of the cache subnet group.</p>",
-        "ModifyGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
-        "ModifyGlobalReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this Global Datastore to.</p>",
-        "ModifyGlobalReplicationGroupMessage$EngineVersion": "<p>The upgraded version of the cache engine to be run on the clusters in the Global Datastore. </p>",
-        "ModifyGlobalReplicationGroupMessage$GlobalReplicationGroupDescription": "<p>A description of the Global Datastore</p>",
+        "ModifyGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
+        "ModifyGlobalReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this Global datastore to.</p>",
+        "ModifyGlobalReplicationGroupMessage$EngineVersion": "<p>The upgraded version of the cache engine to be run on the clusters in the Global datastore. </p>",
+        "ModifyGlobalReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to use with the Global datastore. It must be compatible with the major engine version used by the Global datastore.</p>",
+        "ModifyGlobalReplicationGroupMessage$GlobalReplicationGroupDescription": "<p>A description of the Global datastore</p>",
         "ModifyReplicationGroupMessage$ReplicationGroupId": "<p>The identifier of the replication group to modify.</p>",
         "ModifyReplicationGroupMessage$ReplicationGroupDescription": "<p>A description for the replication group. Maximum length is 255 characters.</p>",
         "ModifyReplicationGroupMessage$PrimaryClusterId": "<p>For replication groups with a single primary, if this parameter is specified, ElastiCache promotes the specified cluster in the specified replication group to the primary role. The nodes of all other clusters in the replication group are read replicas.</p>",
@@ -1950,14 +2238,17 @@
         "ModifyReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this replication group to.</p>",
         "ModifyReplicationGroupMessage$AuthToken": "<p>Reserved parameter. The password used to access a password protected server. This parameter must be specified with the <code>auth-token-update-strategy </code> parameter. Password constraints:</p> <ul> <li> <p>Must be only printable ASCII characters</p> </li> <li> <p>Must be at least 16 characters and no more than 128 characters in length</p> </li> <li> <p>Cannot contain any of the following characters: '/', '\"', or '@', '%'</p> </li> </ul> <p> For more information, see AUTH password at <a href=\"http://redis.io/commands/AUTH\">AUTH</a>.</p>",
         "ModifyReplicationGroupShardConfigurationMessage$ReplicationGroupId": "<p>The name of the Redis (cluster mode enabled) cluster (replication group) on which the shards are to be configured.</p>",
+        "ModifyUserGroupMessage$UserGroupId": "<p>The ID of the user group.</p>",
         "NodeGroup$NodeGroupId": "<p>The identifier for the node group (shard). A Redis (cluster mode disabled) replication group contains only 1 node group; therefore, the node group ID is 0001. A Redis (cluster mode enabled) replication group contains 1 to 90 node groups numbered 0001 to 0090. Optionally, the user can provide the id for a node group. </p>",
         "NodeGroup$Status": "<p>The current state of this replication group - <code>creating</code>, <code>available</code>, <code>modifying</code>, <code>deleting</code>.</p>",
         "NodeGroup$Slots": "<p>The keyspace for this node group (shard).</p>",
         "NodeGroupConfiguration$Slots": "<p>A string that specifies the keyspace for a particular node group. Keyspaces range from 0 to 16,383. The string is in the format <code>startkey-endkey</code>.</p> <p>Example: <code>\"0-3999\"</code> </p>",
         "NodeGroupConfiguration$PrimaryAvailabilityZone": "<p>The Availability Zone where the primary node of this node group (shard) is launched.</p>",
+        "NodeGroupConfiguration$PrimaryOutpostArn": "<p>The outpost ARN of the primary node.</p>",
         "NodeGroupMember$CacheClusterId": "<p>The ID of the cluster to which the node belongs.</p>",
         "NodeGroupMember$CacheNodeId": "<p>The ID of the node within its cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
         "NodeGroupMember$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the node is located.</p>",
+        "NodeGroupMember$PreferredOutpostArn": "<p>The outpost ARN of the node group member.</p>",
         "NodeGroupMember$CurrentRole": "<p>The role that is currently assigned to the node - <code>primary</code> or <code>replica</code>. This member is only applicable for Redis (cluster mode disabled) replication groups.</p>",
         "NodeGroupMemberUpdateStatus$CacheClusterId": "<p>The cache cluster ID</p>",
         "NodeGroupMemberUpdateStatus$CacheNodeId": "<p>The node ID of the cache cluster</p>",
@@ -1969,6 +2260,7 @@
         "NodeTypeList$member": null,
         "NotificationConfiguration$TopicArn": "<p>The Amazon Resource Name (ARN) that identifies the topic.</p>",
         "NotificationConfiguration$TopicStatus": "<p>The current state of the topic.</p>",
+        "OutpostArnsList$member": null,
         "Parameter$ParameterName": "<p>The name of the parameter.</p>",
         "Parameter$ParameterValue": "<p>The value of the parameter.</p>",
         "Parameter$Description": "<p>A description of the parameter.</p>",
@@ -1978,15 +2270,17 @@
         "Parameter$MinimumEngineVersion": "<p>The earliest cache engine version to which the parameter can apply.</p>",
         "ParameterNameValue$ParameterName": "<p>The name of the parameter.</p>",
         "ParameterNameValue$ParameterValue": "<p>The value of the parameter.</p>",
+        "PasswordListInput$member": null,
         "PendingModifiedValues$EngineVersion": "<p>The new cache engine version that the cluster runs.</p>",
         "PendingModifiedValues$CacheNodeType": "<p>The cache node type that this cluster or replication group is scaled to.</p>",
         "PreferredAvailabilityZoneList$member": null,
+        "PreferredOutpostArnList$member": null,
         "ProcessedUpdateAction$ReplicationGroupId": "<p>The ID of the replication group</p>",
         "ProcessedUpdateAction$CacheClusterId": "<p>The ID of the cache cluster</p>",
         "ProcessedUpdateAction$ServiceUpdateName": "<p>The unique ID of the service update</p>",
         "PurchaseReservedCacheNodesOfferingMessage$ReservedCacheNodesOfferingId": "<p>The ID of the reserved cache node offering to purchase.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
         "PurchaseReservedCacheNodesOfferingMessage$ReservedCacheNodeId": "<p>A customer-specified identifier to track this reservation.</p> <note> <p>The Reserved Cache Node ID is an unique customer-specified identifier to track this reservation. If this parameter is not specified, ElastiCache automatically generates an identifier for the reservation.</p> </note> <p>Example: myreservationID</p>",
-        "RebalanceSlotsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global Datastore</p>",
+        "RebalanceSlotsInGlobalReplicationGroupMessage$GlobalReplicationGroupId": "<p>The name of the Global datastore</p>",
         "RebootCacheClusterMessage$CacheClusterId": "<p>The cluster identifier. This parameter is stored as a lowercase string.</p>",
         "RecurringCharge$RecurringChargeFrequency": "<p>The frequency of the recurring charge.</p>",
         "RegionalConfiguration$ReplicationGroupId": "<p>The name of the secondary cluster</p>",
@@ -2003,17 +2297,18 @@
         "ReplicationGroup$ARN": "<p>The ARN (Amazon Resource Name) of the replication group.</p>",
         "ReplicationGroupIdList$member": null,
         "ReplicationGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
+        "ReplicationGroupOutpostArnList$member": null,
         "ReplicationGroupPendingModifiedValues$PrimaryClusterId": "<p>The primary cluster ID that is applied immediately (if <code>--apply-immediately</code> was specified), or during the next maintenance window.</p>",
         "ReservedCacheNode$ReservedCacheNodeId": "<p>The unique identifier for the reservation.</p>",
         "ReservedCacheNode$ReservedCacheNodesOfferingId": "<p>The offering identifier.</p>",
-        "ReservedCacheNode$CacheNodeType": "<p>The cache node type for the reserved cache nodes.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "ReservedCacheNode$CacheNodeType": "<p>The cache node type for the reserved cache nodes.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "ReservedCacheNode$ProductDescription": "<p>The description of the reserved cache node.</p>",
         "ReservedCacheNode$OfferingType": "<p>The offering type of this reserved cache node.</p>",
         "ReservedCacheNode$State": "<p>The state of the reserved cache node.</p>",
         "ReservedCacheNode$ReservationARN": "<p>The Amazon Resource Name (ARN) of the reserved cache node.</p> <p>Example: <code>arn:aws:elasticache:us-east-1:123456789012:reserved-instance:ri-2017-03-27-08-33-25-582</code> </p>",
         "ReservedCacheNodeMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "ReservedCacheNodesOffering$ReservedCacheNodesOfferingId": "<p>A unique identifier for the reserved cache node offering.</p>",
-        "ReservedCacheNodesOffering$CacheNodeType": "<p>The cache node type for the reserved cache node.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "ReservedCacheNodesOffering$CacheNodeType": "<p>The cache node type for the reserved cache node.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "ReservedCacheNodesOffering$ProductDescription": "<p>The cache engine used by the offering.</p>",
         "ReservedCacheNodesOffering$OfferingType": "<p>The offering type.</p>",
         "ReservedCacheNodesOfferingMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
@@ -2036,10 +2331,11 @@
         "Snapshot$CacheClusterId": "<p>The user-supplied identifier of the source cluster.</p>",
         "Snapshot$SnapshotStatus": "<p>The status of the snapshot. Valid values: <code>creating</code> | <code>available</code> | <code>restoring</code> | <code>copying</code> | <code>deleting</code>.</p>",
         "Snapshot$SnapshotSource": "<p>Indicates whether the snapshot is from an automatic backup (<code>automated</code>) or was created manually (<code>manual</code>).</p>",
-        "Snapshot$CacheNodeType": "<p>The name of the compute and memory capacity node type for the source cluster.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
+        "Snapshot$CacheNodeType": "<p>The name of the compute and memory capacity node type for the source cluster.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>M6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.m6g.large</code>, <code>cache.m6g.xlarge</code>, <code>cache.m6g.2xlarge</code>, <code>cache.m6g.4xlarge</code>, <code>cache.m6g.8xlarge</code>, <code>cache.m6g.12xlarge</code>, <code>cache.m6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>M5 node types:</b> <code>cache.m5.large</code>, <code>cache.m5.xlarge</code>, <code>cache.m5.2xlarge</code>, <code>cache.m5.4xlarge</code>, <code>cache.m5.12xlarge</code>, <code>cache.m5.24xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> <p> <b>T3 node types:</b> <code>cache.t3.micro</code>, <code>cache.t3.small</code>, <code>cache.t3.medium</code> </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R6g node types</b> (available only for Redis engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward).</p> <p> <code>cache.r6g.large</code>, <code>cache.r6g.xlarge</code>, <code>cache.r6g.2xlarge</code>, <code>cache.r6g.4xlarge</code>, <code>cache.r6g.8xlarge</code>, <code>cache.r6g.12xlarge</code>, <code>cache.r6g.16xlarge</code> </p> <note> <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a> </p> </note> <p> <b>R5 node types:</b> <code>cache.r5.large</code>, <code>cache.r5.xlarge</code>, <code>cache.r5.2xlarge</code>, <code>cache.r5.4xlarge</code>, <code>cache.r5.12xlarge</code>, <code>cache.r5.24xlarge</code> </p> <p> <b>R4 node types:</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Additional node type info</b> </p> <ul> <li> <p>All current generation instance types are created in Amazon VPC by default.</p> </li> <li> <p>Redis append-only files (AOF) are not supported for T1 or T2 instances.</p> </li> <li> <p>Redis Multi-AZ with automatic failover is not supported on T1 instances.</p> </li> <li> <p>Redis configuration variables <code>appendonly</code> and <code>appendfsync</code> are not supported on Redis version 2.8.22 and later.</p> </li> </ul>",
         "Snapshot$Engine": "<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) used by the source cluster.</p>",
         "Snapshot$EngineVersion": "<p>The version of the cache engine version that is used by the source cluster.</p>",
         "Snapshot$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the source cluster is located.</p>",
+        "Snapshot$PreferredOutpostArn": "<p>The ARN (Amazon Resource Name) of the preferred outpost.</p>",
         "Snapshot$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
         "Snapshot$TopicArn": "<p>The Amazon Resource Name (ARN) for the topic used by the source cluster for publishing notifications.</p>",
         "Snapshot$CacheParameterGroupName": "<p>The cache parameter group that is associated with the source cluster.</p>",
@@ -2052,9 +2348,11 @@
         "StartMigrationMessage$ReplicationGroupId": "<p>The ID of the replication group to which data should be migrated.</p>",
         "Subnet$SubnetIdentifier": "<p>The unique identifier for the subnet.</p>",
         "SubnetIdentifierList$member": null,
+        "SubnetOutpost$SubnetOutpostArn": "<p>The outpost ARN of the subnet.</p>",
         "Tag$Key": "<p>The key for the tag. May not be null.</p>",
         "Tag$Value": "<p>The tag's value. May be null.</p>",
         "TestFailoverMessage$ReplicationGroupId": "<p>The name of the replication group (console: cluster) whose automatic failover is being tested by this operation.</p>",
+        "UGReplicationGroupIdList$member": null,
         "UnprocessedUpdateAction$ReplicationGroupId": "<p>The replication group ID</p>",
         "UnprocessedUpdateAction$CacheClusterId": "<p>The ID of the cache cluster</p>",
         "UnprocessedUpdateAction$ServiceUpdateName": "<p>The unique ID of the service update</p>",
@@ -2066,7 +2364,15 @@
         "UpdateAction$NodesUpdated": "<p>The progress of the service update on the replication group</p>",
         "UpdateAction$EstimatedUpdateTime": "<p>The estimated length of time for the update to complete</p>",
         "UpdateAction$Engine": "<p>The Elasticache engine to which the update applies. Either Redis or Memcached</p>",
-        "UpdateActionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"
+        "UpdateActionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "User$UserId": "<p>The ID of the user.</p>",
+        "User$UserName": "<p>The username of the user.</p>",
+        "User$Status": "<p>Indicates the user status. Can be \"active\", \"modifying\" or \"deleting\".</p>",
+        "User$AccessString": "<p>Access permissions string used for this user.</p>",
+        "User$ARN": "<p>The Amazon Resource Name (ARN) of the user.</p>",
+        "UserGroup$UserGroupId": "<p>The ID of the user group.</p>",
+        "UserGroup$Status": "<p>Indicates user group status. Can be \"creating\", \"active\", \"modifying\", \"deleting\".</p>",
+        "UserGroup$ARN": "<p>The Amazon Resource Name (ARN) of the user group.</p>"
       }
     },
     "Subnet": {
@@ -2091,6 +2397,17 @@
       "base": null,
       "refs": {
         "CacheSubnetGroup$Subnets": "<p>A list of subnets associated with the cache subnet group.</p>"
+      }
+    },
+    "SubnetNotAllowedFault": {
+      "base": "<p>At least one subnet ID does not match the other subnet IDs. This mismatch typically occurs when a user sets one subnet ID to a regional Availability Zone and a different one to an outpost. Or when a user sets the subnet ID to an Outpost when not subscribed on this service.</p>",
+      "refs": {
+      }
+    },
+    "SubnetOutpost": {
+      "base": "<p>The ID of the outpost subnet.</p>",
+      "refs": {
+        "Subnet$SubnetOutpost": "<p>The outpost ARN of the subnet.</p>"
       }
     },
     "TStamp": {
@@ -2129,7 +2446,7 @@
       }
     },
     "Tag": {
-      "base": "<p>A cost allocation Tag that can be added to an ElastiCache cluster or replication group. Tags are composed of a Key/Value pair. A tag with a null Value is permitted.</p>",
+      "base": "<p>A tag that can be added to an ElastiCache cluster or replication group. Tags are composed of a Key/Value pair. You can use tags to categorize and track all your ElastiCache resources, with the exception of global replication group. When you add or remove tags on replication groups, those actions will be replicated to all nodes in the replication group. A tag with a null Value is permitted.</p>",
       "refs": {
         "TagList$member": null
       }
@@ -2137,10 +2454,18 @@
     "TagList": {
       "base": null,
       "refs": {
-        "AddTagsToResourceMessage$Tags": "<p>A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value.</p>",
-        "CreateCacheClusterMessage$Tags": "<p>A list of cost allocation tags to be added to this resource.</p>",
-        "CreateReplicationGroupMessage$Tags": "<p>A list of cost allocation tags to be added to this resource. Tags are comma-separated key,value pairs (e.g. Key=<code>myKey</code>, Value=<code>myKeyValue</code>. You can include multiple tags as shown following: Key=<code>myKey</code>, Value=<code>myKeyValue</code> Key=<code>mySecondKey</code>, Value=<code>mySecondKeyValue</code>.</p>",
-        "TagListMessage$TagList": "<p>A list of cost allocation tags as key-value pairs.</p>"
+        "AddTagsToResourceMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CopySnapshotMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateCacheClusterMessage$Tags": "<p>A list of tags to be added to this resource.</p>",
+        "CreateCacheParameterGroupMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateCacheSecurityGroupMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateCacheSubnetGroupMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateReplicationGroupMessage$Tags": "<p>A list of tags to be added to this resource. Tags are comma-separated key,value pairs (e.g. Key=<code>myKey</code>, Value=<code>myKeyValue</code>. You can include multiple tags as shown following: Key=<code>myKey</code>, Value=<code>myKeyValue</code> Key=<code>mySecondKey</code>, Value=<code>mySecondKeyValue</code>. Tags on replication groups will be replicated to all nodes.</p>",
+        "CreateSnapshotMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateUserGroupMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "CreateUserMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "PurchaseReservedCacheNodesOfferingMessage$Tags": "<p>A list of tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value, although null is accepted.</p>",
+        "TagListMessage$TagList": "<p>A list of tags as key-value pairs.</p>"
       }
     },
     "TagListMessage": {
@@ -2177,6 +2502,12 @@
       "base": "<p>Filters update actions from the service updates that are in available status during the time range.</p>",
       "refs": {
         "DescribeUpdateActionsMessage$ServiceUpdateTimeRange": "<p>The range of time specified to search for service updates that are in available status</p>"
+      }
+    },
+    "UGReplicationGroupIdList": {
+      "base": null,
+      "refs": {
+        "UserGroup$ReplicationGroups": "<p>A list of replication groups that the user group can access.</p>"
       }
     },
     "UnprocessedUpdateAction": {
@@ -2224,6 +2555,129 @@
     },
     "UpdateActionsMessage": {
       "base": null,
+      "refs": {
+      }
+    },
+    "User": {
+      "base": null,
+      "refs": {
+        "UserList$member": null
+      }
+    },
+    "UserAlreadyExistsFault": {
+      "base": "<p>A user with this ID already exists.</p>",
+      "refs": {
+      }
+    },
+    "UserGroup": {
+      "base": null,
+      "refs": {
+        "UserGroupList$member": null
+      }
+    },
+    "UserGroupAlreadyExistsFault": {
+      "base": "<p>The user group with this ID already exists.</p>",
+      "refs": {
+      }
+    },
+    "UserGroupId": {
+      "base": null,
+      "refs": {
+        "UserGroupIdList$member": null,
+        "UserGroupIdListInput$member": null
+      }
+    },
+    "UserGroupIdList": {
+      "base": null,
+      "refs": {
+        "ModifyReplicationGroupMessage$UserGroupIdsToAdd": "<p>The user group you are associating with the replication group.</p>",
+        "ModifyReplicationGroupMessage$UserGroupIdsToRemove": "<p>The user group to remove, meaning the users in the group no longer can access the replication group.</p>",
+        "ReplicationGroup$UserGroupIds": "<p>The list of user group IDs that have access to the replication group.</p>",
+        "User$UserGroupIds": "<p>Returns a list of the user group IDs the user belongs to.</p>",
+        "UserGroupsUpdateStatus$UserGroupIdsToAdd": "<p>The list of user group IDs to add.</p>",
+        "UserGroupsUpdateStatus$UserGroupIdsToRemove": "<p>The list of user group IDs to remove.</p>"
+      }
+    },
+    "UserGroupIdListInput": {
+      "base": null,
+      "refs": {
+        "CreateReplicationGroupMessage$UserGroupIds": "<p>The user group to associate with the replication group.</p>"
+      }
+    },
+    "UserGroupList": {
+      "base": null,
+      "refs": {
+        "DescribeUserGroupsResult$UserGroups": "<p>Returns a list of user groups.</p>"
+      }
+    },
+    "UserGroupNotFoundFault": {
+      "base": "<p>The user group was not found or does not exist</p>",
+      "refs": {
+      }
+    },
+    "UserGroupPendingChanges": {
+      "base": "<p>Returns the updates being applied to the user group.</p>",
+      "refs": {
+        "UserGroup$PendingChanges": "<p>A list of updates being applied to the user groups.</p>"
+      }
+    },
+    "UserGroupQuotaExceededFault": {
+      "base": "<p>The number of users exceeds the user group limit.</p>",
+      "refs": {
+      }
+    },
+    "UserGroupsUpdateStatus": {
+      "base": "<p>The status of the user group update.</p>",
+      "refs": {
+        "ReplicationGroupPendingModifiedValues$UserGroups": "<p>The user groups being modified.</p>"
+      }
+    },
+    "UserId": {
+      "base": null,
+      "refs": {
+        "CreateUserMessage$UserId": "<p>The ID of the user.</p>",
+        "DeleteUserMessage$UserId": "<p>The ID of the user.</p>",
+        "DescribeUsersMessage$UserId": "<p>The ID of the user.</p>",
+        "ModifyUserMessage$UserId": "<p>The ID of the user.</p>",
+        "UserIdList$member": null,
+        "UserIdListInput$member": null
+      }
+    },
+    "UserIdList": {
+      "base": null,
+      "refs": {
+        "UserGroup$UserIds": "<p>The list of user IDs that belong to the user group.</p>",
+        "UserGroupPendingChanges$UserIdsToRemove": "<p>The list of user IDs to remove.</p>",
+        "UserGroupPendingChanges$UserIdsToAdd": "<p>The list of user IDs to add.</p>"
+      }
+    },
+    "UserIdListInput": {
+      "base": null,
+      "refs": {
+        "CreateUserGroupMessage$UserIds": "<p>The list of user IDs that belong to the user group.</p>",
+        "ModifyUserGroupMessage$UserIdsToAdd": "<p>The list of user IDs to add to the user group.</p>",
+        "ModifyUserGroupMessage$UserIdsToRemove": "<p>The list of user IDs to remove from the user group.</p>"
+      }
+    },
+    "UserList": {
+      "base": null,
+      "refs": {
+        "DescribeUsersResult$Users": "<p>A list of users.</p>"
+      }
+    },
+    "UserName": {
+      "base": null,
+      "refs": {
+        "CreateUserMessage$UserName": "<p>The username of the user.</p>"
+      }
+    },
+    "UserNotFoundFault": {
+      "base": "<p>The user does not exist or could not be found.</p>",
+      "refs": {
+      }
+    },
+    "UserQuotaExceededFault": {
+      "base": "<p>The quota of users has been exceeded.</p>",
       "refs": {
       }
     }

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -1,20 +1,79 @@
 resources:
   CacheSubnetGroup:
     exceptions:
-      codes:
-        404: CacheSubnetGroupNotFoundFault
+      errors:
+        404:
+          code: CacheSubnetGroupNotFoundFault
+      terminal_codes:
+        - CacheSubnetGroupQuotaExceeded
+        - CacheSubnetQuotaExceededFault
+        - SubnetInUse
+        - InvalidSubnet
+        - InvalidParameter
+        - InvalidParameterValue
+        - InvalidParameterCombination
     fields:
       Events:
         is_read_only: true
         from:
           operation: DescribeEvents
           path: Events
+  ReplicationGroup:
+    update_conditions_custom_method_name: CustomUpdateConditions
+    exceptions:
+      terminal_codes:
+        - InvalidParameter
+        - InvalidParameterValue
+        - InvalidParameterCombination
+        - InsufficientCacheClusterCapacity
+        - CacheSecurityGroupNotFound
+        - CacheSubnetGroupNotFoundFault
+        - ClusterQuotaForCustomerExceeded
+        - NodeQuotaForClusterExceeded
+        - NodeQuotaForCustomerExceeded
+        - InvalidVPCNetworkStateFault
+        - TagQuotaPerResourceExceeded
+        - NodeGroupsPerReplicationGroupQuotaExceeded
+        - InvalidCacheSecurityGroupState
+        - CacheParameterGroupNotFound
+        - InvalidKMSKeyFault
+    fields:
+      AllowedScaleUpModifications:
+        is_read_only: true
+        from:
+          operation: ListAllowedNodeTypeModifications
+          path: ScaleUpModifications
+      AllowedScaleDownModifications:
+        is_read_only: true
+        from:
+          operation: ListAllowedNodeTypeModifications
+          path: ScaleDownModifications
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
+      AuthToken:
+        is_secret: true
   Snapshot:
+    update_conditions_custom_method_name: CustomUpdateConditions
+    exceptions:
+      terminal_codes:
+        - InvalidParameter
+        - InvalidParameterValue
+        - InvalidParameterCombination
+        - SnapshotAlreadyExistsFault
+        - CacheClusterNotFound
+        - ReplicationGroupNotFoundFault
+        - SnapshotQuotaExceededFault
+        - SnapshotFeatureNotSupportedFault
     fields:
       SourceSnapshotName:
         from:
           operation: CopySnapshot
           path: SourceSnapshotName
+    update_operation:
+      custom_method_name: customUpdateSnapshot
   CacheParameterGroup:
     exceptions:
       terminal_codes:
@@ -41,34 +100,38 @@ resources:
           path: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
-  ReplicationGroup:
-    fields:
-      AllowedScaleUpModifications:
-        is_read_only: true
-        from:
-          operation: ListAllowedNodeTypeModifications
-          path: ScaleUpModifications
-      AllowedScaleDownModifications:
-        is_read_only: true
-        from:
-          operation: ListAllowedNodeTypeModifications
-          path: ScaleDownModifications
-      Events:
-        is_read_only: true
-        from:
-          operation: DescribeEvents
-          path: Events
-      AuthToken:
-        is_secret: true
 operations:
+  DescribeCacheSubnetGroups:
+    set_output_custom_method_name: CustomDescribeCacheSubnetGroupsSetOutput
+  DescribeReplicationGroups:
+    set_output_custom_method_name: CustomDescribeReplicationGroupsSetOutput
+  CreateReplicationGroup:
+    set_output_custom_method_name: CustomCreateReplicationGroupSetOutput
   ModifyReplicationGroup:
+    custom_implementation: CustomModifyReplicationGroup
+    set_output_custom_method_name: CustomModifyReplicationGroupSetOutput
     override_values:
       ApplyImmediately: true
-  ModifyCacheCluster:
-    override_values:
-      ApplyImmediately: true
+  CreateSnapshot:
+    custom_implementation: CustomCreateSnapshot
+    set_output_custom_method_name: CustomCreateSnapshotSetOutput
+  DescribeSnapshots:
+    set_output_custom_method_name: CustomDescribeSnapshotSetOutput
+  CreateCacheParameterGroup:
+    set_output_custom_method_name: CustomCreateCacheParameterGroupSetOutput
+  DescribeCacheParameterGroups:
+    set_output_custom_method_name: CustomDescribeCacheParameterGroupsSetOutput
 ignore:
-  operations:
-    - DeleteSnapshot
   resource_names:
     - GlobalReplicationGroup
+    - CacheCluster
+    - CacheSecurityGroup
+    - User
+    - UserGroup
+  field_paths:
+    - DescribeSnapshotsInput.CacheClusterId
+    - DescribeSnapshotsInput.ReplicationGroupId
+    - DescribeSnapshotsInput.SnapshotSource
+    - ModifyReplicationGroupInput.SecurityGroupIds
+    - ModifyReplicationGroupInput.EngineVersion
+    - CreateReplicationGroupInput.GlobalReplicationGroupId


### PR DESCRIPTION
ElastiCache would use new AWS SDK Go to include new features like LogDelivery which are currently not part of `elasticache-controller`. This PR updates the test data used in code generator for Elasticache tests.

Additionally I have updated `generator.yaml` to be inline with one being used in `elasticache-controller`. Updated unit tests which use `CacheCluster` resource to `ReplicationGroup`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
