### PR TITLE
Patch the correct observed state after a `rm.ReadOne` call

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -74,6 +74,9 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
 		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/807

For some controllers we noticed an incorrect reconciliation behaviour
when a custom hook code was returning a `RequeueNeededAfter` error.
More precisely `resourceManager.ReadOne` was not returning the correct
observed state when `sdkFind` returns with an error. Which was causing
 the reconciler to patch to wrong state (`desird` instead `observed`).

This patch fixes this issue by passing the correct observed state to `onError`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
