### PR TITLE
Explicitly mentioning 'metrics' for the ACK controller service.

### DIFF
--- a/templates/helm/templates/metrics-service.yaml
+++ b/templates/helm/templates/metrics-service.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.service.create }}
+{{- if .Values.metrics.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}
@@ -21,7 +21,7 @@ spec:
 {{- range $key, $value := .Values.deployment.labels }}
     {{ $key }}: {{ $value | quote }}
 {{- end }}
-  type: {{ .Values.service.type }}
+  type: {{ .Values.metrics.service.type }}
   ports:
   - name: metricsport
     port: 8080

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -16,9 +16,14 @@ deployment:
   labels: {}
   containerPort: 8080
 
-service:
-  create: false
-  type: "ClusterIP"
+metrics:
+  service:
+    # Set to true to automatically create a Kubernetes Service resource for the
+    # Prometheus metrics server endpoint in controller
+    create: false
+    # Which Type to use for the Kubernetes Service?
+    # See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: "ClusterIP"
 
 resources:
   requests:


### PR DESCRIPTION
Description of changes:

Explicitly mentioning 'metrics' for the ACK controller service.

Sample dry-run putput:

```
# Source: ack-apigatewayv2-controller/templates/metrics-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: somename-ack-apigatewayv2-controller-metrics
  namespace: default
  labels:
    app.kubernetes.io/name: ack-apigatewayv2-controller
    app.kubernetes.io/instance: somename
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "v0.0.2"
    k8s-app: ack-apigatewayv2-controller
    helm.sh/chart: ack-apigatewayv2-controller-v0.0.2
    control-plane: controller
spec:
  selector:
    app.kubernetes.io/name: ack-apigatewayv2-controller
    app.kubernetes.io/instance: somename
    app.kubernetes.io/managed-by: Helm
    k8s-app: ack-apigatewayv2-controller
  type: ClusterIP
  ports:
  - name: metricsport
    port: 8080
    targetPort: 8080
    protocol: TCP

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
