### PR TITLE
Add a new operation config to override the `SetOutput` wrapper field

### DIFF
--- a/pkg/generate/config/operation.go
+++ b/pkg/generate/config/operation.go
@@ -28,6 +28,9 @@ type OperationConfig struct {
 	// `resourceManager` struct that will set fields on a `resource` struct
 	// depending on the output of the operation.
 	SetOutputCustomMethodName string `json:"set_output_custom_method_name,omitempty"`
+	// OutputWrapperFieldPath provides the JSON-Path like to the struct field containing
+	// information that will be merged into a `resource` object.
+	OutputWrapperFieldPath string `json:"output_wrapper_field_path,omitempty"`
 	// Override for resource name in case of heuristic failure
 	// An example of this is correcting stutter when the resource logic doesn't properly determine the resource name
 	ResourceName string `json:"resource_name"`

--- a/pkg/generate/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
@@ -4,3 +4,12 @@ resources:
       errors:
         404:
           code: ResourceNotFoundException
+operations:
+  DescribeBackup:
+    # DescribeBackupOutput is an unsual shape because it contains information for
+    # the backup it self (BackupDetails), the table details when the backup was
+    # created (SourceTableDetails) and the table features (SourceTableFeatureDetails).
+    # If not specified the code generator will try to determine the wrapper field by
+    # selecting for the output shape that only have a single member, which is incorrect
+    # in this case.
+    output_wrapper_field_path: BackupDescription.BackupDetails

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -352,6 +352,28 @@ func (r *CRD) SetOutputCustomMethodName(
 	return &resGenConfig.SetOutputCustomMethodName
 }
 
+// GetOutputWrapperFieldPath returns the JSON-Path of the output wrapper field
+// as *string for a given operation, if specified in generator config.
+func (r *CRD) GetOutputWrapperFieldPath(
+	op *awssdkmodel.Operation,
+) *string {
+	if op == nil {
+		return nil
+	}
+	if r.cfg == nil {
+		return nil
+	}
+	opConfig, found := r.cfg.Operations[op.Name]
+	if !found {
+		return nil
+	}
+
+	if opConfig.OutputWrapperFieldPath == "" {
+		return nil
+	}
+	return &opConfig.OutputWrapperFieldPath
+}
+
 // GetCustomImplementation returns custom implementation method name for the
 // supplied operation as specified in generator config
 func (r *CRD) GetCustomImplementation(


### PR DESCRIPTION
Issue N/A

In some AWS APIs `Describe` operations output contains the
wanted information in a wrapper field like `TableDescription` and
`GlobalTableDescription` ... However in some other APIs for the same
operation type, the wanted information is wrapped in different nested
object, like `BackupDescription.BackupDetails` for example.

Description of changes:
This patch adds a new operation configuration that instructs the
code-generator to use a specific field path, in order to find the
struct that contains the information we want to set the output from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
