### PR TITLE
Add a new config to override kubebuilder `printcolumn:name`

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -135,6 +135,10 @@ type FieldConfig struct {
 	// AdditionalPrinterColumns list to be included in the `kubectl get`
 	// response.
 	IsPrintable bool `json:"is_printable"`
+	// PrintName instructs the code generator to override the column name used
+	// to include the field in `kubectl get` response. If `IsPrintable` is false
+	// this field is ignored.
+	PrintName string `json:"print_name"`
 	// Required indicates whether this field is a required member or not.
 	// This field is used to configure '+kubebuilder:validation:Required' on API object's members.
 	IsRequired *bool `json:"is_required,omitempty"`

--- a/pkg/model/printer_column.go
+++ b/pkg/model/printer_column.go
@@ -82,21 +82,22 @@ func (r *CRD) addPrintableColumn(
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
 	// This maps Go type to OpenAPI type.
 	acceptableColumnMaps := map[string]string{
-		"string":  "string",
-		"boolean": "boolean",
-		"int":     "integer",
-		"int8":    "integer",
-		"int16":   "integer",
-		"int32":   "integer",
-		"int64":   "integer",
-		"uint":    "integer",
-		"uint8":   "integer",
-		"uint16":  "integer",
-		"uint32":  "integer",
-		"uint64":  "integer",
-		"uintptr": "integer",
-		"float32": "number",
-		"float64": "number",
+		"string":      "string",
+		"boolean":     "boolean",
+		"int":         "integer",
+		"int8":        "integer",
+		"int16":       "integer",
+		"int32":       "integer",
+		"int64":       "integer",
+		"uint":        "integer",
+		"uint8":       "integer",
+		"uint16":      "integer",
+		"uint32":      "integer",
+		"uint64":      "integer",
+		"uintptr":     "integer",
+		"float32":     "number",
+		"float64":     "number",
+		"metav1.Time": "date",
 	}
 	printColumnType, exists := acceptableColumnMaps[fieldColumnType]
 
@@ -108,9 +109,14 @@ func (r *CRD) addPrintableColumn(
 		panic(msg)
 	}
 
+	name := field.Names.Camel
+	if field.FieldConfig.PrintName != "" {
+		name = field.FieldConfig.PrintName
+	}
+
 	column := &PrinterColumn{
 		CRD:      r,
-		Name:     field.Names.Camel,
+		Name:     name,
 		Type:     printColumnType,
 		JSONPath: jsonPath,
 	}


### PR DESCRIPTION
Issue N/A

In some CRDs like `GlobalTable` adding a `is_printable: true` to the `GlobalTableStatus` causes `kubectl get` to print very large/redundant column names.

Description of changes:
- This patch adds a new config to allow overriding kubebuilder `printcolumn:name`
- Adds `metav1.Time` to the `acceptableColumnMap`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
