### PR TITLE
crossplane: Mark spec as required, status.atProvider as optional

### DIFF
--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -51,7 +51,7 @@ type {{ .CRD.Kind }}Observation struct {
 // {{ .CRD.Kind }}Status defines the observed state of {{ .CRD.Kind }}.
 type {{ .CRD.Kind }}Status struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider {{ .CRD.Kind }}Observation `json:"atProvider"`
+	AtProvider {{ .CRD.Kind }}Observation `json:"atProvider,omitempty"`
 }
 
 
@@ -66,7 +66,7 @@ type {{ .CRD.Kind }}Status struct {
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec   {{ .CRD.Kind }}Spec   `json:"spec,omitempty"`
+	Spec   {{ .CRD.Kind }}Spec   `json:"spec"`
 	Status {{ .CRD.Kind }}Status `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
This is required to fix https://github.com/crossplane/provider-aws/issues/697

In the vast majority of resources a spec is required, so I'd like to mark it as such. I believe that in the edge cases where the spec really contains only optional fields it's possible to write `spec: {}`.

We prefer not to mark status fields as required, since resources will always exist at some point without their status and we consider 'requiredness' to be more of a human-facing constraint than a software-facing constraint that our managed resource controllers should be subject to.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
