### PR TITLE
Add a new generator config to change `PrinterColumn` sort function

### DIFF
--- a/pkg/generate/codedeploy_test.go
+++ b/pkg/generate/codedeploy_test.go
@@ -113,12 +113,12 @@ func TestCodeDeploy_Deployment(t *testing.T) {
 
 	// We marked the fields, "ApplicationName", "DeploymentGroupName",
 	// "DeploymentConfigName and "Description" as printer columns in the
-	// generator.yaml. Let's make sure that they are always returned in sorted
-	// order.
+	// generator.yaml and trimmed the "Name" suffix. Let's make sure that
+	// they are always returned in sorted order.
 	expPrinterColNames := []string{
-		"ApplicationName",
-		"DeploymentConfigName",
-		"DeploymentGroupName",
+		"Application",
+		"DeploymentConfig",
+		"DeploymentGroup",
 		"Description",
 	}
 	gotPrinterCols := crd.AdditionalPrinterColumns()

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -116,6 +116,16 @@ type CompareFieldConfig struct {
 	NilEqualsZeroValue bool `json:"nil_equals_zero_value"`
 }
 
+// PrintFieldConfig instructs the code generator how to handle kubebuilder:printcolumn
+// comment marker generation. If this struct is not nil, the field will be added to the
+// columns of `kubectl get` response.
+type PrintFieldConfig struct {
+	// Name instructs the code generator to override the column name used to
+	// include the field in `kubectl get` response. This field is generally used
+	// to override very long and redundant columns names.
+	Name string `json:"name"`
+}
+
 // FieldConfig contains instructions to the code generator about how
 // to interpret the value of an Attribute and how to map it to a CRD's Spec or
 // Status field
@@ -131,14 +141,6 @@ type FieldConfig struct {
 	// IsReadOnly indicates the field's value can not be set by a Kubernetes
 	// user; in other words, the field should go in the CR's Status struct
 	IsReadOnly bool `json:"is_read_only"`
-	// IsPrintable determines whether the field should be included in the
-	// AdditionalPrinterColumns list to be included in the `kubectl get`
-	// response.
-	IsPrintable bool `json:"is_printable"`
-	// PrintName instructs the code generator to override the column name used
-	// to include the field in `kubectl get` response. If `IsPrintable` is false
-	// this field is ignored.
-	PrintName string `json:"print_name"`
 	// Required indicates whether this field is a required member or not.
 	// This field is used to configure '+kubebuilder:validation:Required' on API object's members.
 	IsRequired *bool `json:"is_required,omitempty"`
@@ -168,4 +170,8 @@ type FieldConfig struct {
 	// Compare instructs the code generator how to produce code that compares
 	// the value of the field in two resources
 	Compare *CompareFieldConfig `json:"compare,omitempty"`
+	// Print instructs the code generator how to generate comment markers that
+	// influence hows field are printed in `kubectl get` response. If this field
+	// is not nil, it will be added to the columns of `kubectl get`.
+	Print *PrintFieldConfig `json:"print,omitempty"`
 }

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -76,6 +76,9 @@ type ResourceConfig struct {
 	// If set to false, the user will be given an error if they attempt to adopt a resource
 	// with this type.
 	IsAdoptable *bool `json:"is_adoptable,omitempty"`
+	// Print contains instructions for the code generator to generate kubebuilder printcolumns
+	// marker comments.
+	Print *PrintConfig `json:"print,omitempty"`
 }
 
 // HooksConfig instructs the code generator how to inject custom callback hooks
@@ -249,6 +252,13 @@ type UpdateOperationConfig struct {
 	CustomMethodName string `json:"custom_method_name"`
 }
 
+// PrintConfig informs instruct the code generator on how to sort kubebuilder
+// printcolumn marker coments.
+type PrintConfig struct {
+	// OrderBy is the field used to sort the list of PrinterColumn options.
+	OrderBy string `json:"order_by"`
+}
+
 // ResourceConfig returns the ResourceConfig for a given named resource
 func (c *Config) ResourceConfig(name string) (*ResourceConfig, bool) {
 	rc, ok := c.Resources[name]
@@ -402,4 +412,19 @@ func (c *Config) ResourceIsAdoptable(resourceName string) bool {
 		return true
 	}
 	return *rConfig.IsAdoptable
+}
+
+// GetResourcePrintOrderByName returns the Printer Column order-by field name
+func (c *Config) GetResourcePrintOrderByName(resourceName string) string {
+	if c == nil {
+		return ""
+	}
+	rConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return ""
+	}
+	if rConfig.Print != nil {
+		return rConfig.Print.OrderBy
+	}
+	return ""
 }

--- a/pkg/generate/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
@@ -7,10 +7,13 @@ resources:
     # below, we're testing printer columns end up sorted properly in the CRD
     fields:
       DeploymentGroupName:
-        is_printable: true
+        print:
+          name: DeploymentGroup
       ApplicationName:
-        is_printable: true
+        print:
+          name: Application
       DeploymentConfigName:
-        is_printable: true
+        print:
+          name: DeploymentConfig
       Description:
-        is_printable: true
+        print: {}

--- a/pkg/generate/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
@@ -1,5 +1,7 @@
 resources:
   Deployment:
+    print:
+      order_by: jsonpath
     exceptions:
       errors:
         404:

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -176,7 +176,7 @@ func (r *CRD) AddSpecField(
 	fConfigs := r.cfg.ResourceFields(r.Names.Original)
 	fConfig := fConfigs[memberNames.Original]
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
-	if fConfig != nil && fConfig.IsPrintable {
+	if fConfig != nil && fConfig.Print != nil {
 		r.addSpecPrintableColumn(f)
 	}
 	r.SpecFields[memberNames.Original] = f
@@ -193,7 +193,7 @@ func (r *CRD) AddStatusField(
 	fConfigs := r.cfg.ResourceFields(r.Names.Original)
 	fConfig := fConfigs[memberNames.Original]
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
-	if fConfig != nil && fConfig.IsPrintable {
+	if fConfig != nil && fConfig.Print != nil {
 		r.addStatusPrintableColumn(f)
 	}
 	r.StatusFields[memberNames.Original] = f

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -417,6 +417,15 @@ func (r *CRD) IsAdoptable() bool {
 	return r.cfg.ResourceIsAdoptable(r.Names.Original)
 }
 
+// GetResourcePrintOrderByName returns the Printer Column order-by field name
+func (r *CRD) GetResourcePrintOrderByName() string {
+	orderBy := r.cfg.GetResourcePrintOrderByName(r.Names.Camel)
+	if orderBy == "" {
+		return "name"
+	}
+	return orderBy
+}
+
 // CustomUpdateMethodName returns the name of the custom resourceManager method
 // for updating the resource state, if any has been specified in the generator
 // config

--- a/pkg/model/printer_column.go
+++ b/pkg/model/printer_column.go
@@ -110,8 +110,8 @@ func (r *CRD) addPrintableColumn(
 	}
 
 	name := field.Names.Camel
-	if field.FieldConfig.PrintName != "" {
-		name = field.FieldConfig.PrintName
+	if field.FieldConfig.Print.Name != "" {
+		name = field.FieldConfig.Print.Name
 	}
 
 	column := &PrinterColumn{


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/823

This patch introduce a new generator configuration under resource
configuration, mainly to tune the `kubebuilder:printcolumn` marker
comments generation.

More precisely we add `PrintConfig` struct that contains one field
called `OrderBy` used to intruct the code generator how to sort the
`kubebuilder:printcolumn` marker comments.

e.g configuration:
```yaml
resources:
  Deployment:
    print:
      order_by: JSONPath
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
