### PR TITLE
Add a new generator config to append an Age `printcolumn`

### DIFF
--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -255,6 +255,13 @@ type UpdateOperationConfig struct {
 // PrintConfig informs instruct the code generator on how to sort kubebuilder
 // printcolumn marker coments.
 type PrintConfig struct {
+	// AddAgeColumn a boolean informing the code generator whether to append a kubebuilder
+	// marker comment to show a resource Age (created since date) in `kubectl get` response.
+	// The Age value is parsed from '.metadata.creationTimestamp'.
+	//
+	// NOTE: this is the Kubernetes resource Age (creation time at the api-server/etcd)
+	// and not the AWS resource Age.
+	AddAgeColumn bool `json:"add_age_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
 }
@@ -427,4 +434,19 @@ func (c *Config) GetResourcePrintOrderByName(resourceName string) string {
 		return rConfig.Print.OrderBy
 	}
 	return ""
+}
+
+// GetResourcePrintAddAgeColumn returns the resource printer AddAgeColumn config
+func (c *Config) GetResourcePrintAddAgeColumn(resourceName string) bool {
+	if c == nil {
+		return false
+	}
+	rConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return false
+	}
+	if rConfig.Print != nil {
+		return rConfig.Print.AddAgeColumn
+	}
+	return false
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -426,6 +426,12 @@ func (r *CRD) GetResourcePrintOrderByName() string {
 	return orderBy
 }
 
+// PrintAgeColumn returns whether the code generator should append 'Age'
+// kubebuilder:printcolumn comment marker
+func (r *CRD) PrintAgeColumn() bool {
+	return r.cfg.GetResourcePrintAddAgeColumn(r.Names.Camel)
+}
+
 // CustomUpdateMethodName returns the name of the custom resourceManager method
 // for updating the resource state, if any has been specified in the generator
 // config

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -50,6 +50,9 @@ type {{ .CRD.Kind }}Status struct {
 {{- range $column := .CRD.AdditionalPrinterColumns }}
 // +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},JSONPath=`{{$column.JSONPath}}`
 {{- end }}
+{{- if .CRD.PrintAgeColumn }}
+// +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
+{{- end }}
 {{- if .CRD.ShortNames }}
 // +kubebuilder:resource:shortName={{ Join .CRD.ShortNames ";" }}
 {{- end }}


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/822

Since All kubernetes resources have a `.metadata.creationTimestamp` field,
we need a way to instruct the code generator to generate kubebuilder
marker comments that will append the AGE field the `kubectl get`
response.

This patch extends `Resource.PrintConfig` to allow configuring the
`ack-generate` to generate such marker comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
