### PR TITLE
crossplane: remove unnecessary error handling in Update

### DIFF
--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -143,10 +143,7 @@ func (e *external) Update(ctx context.Context, mg cpresource.Managed) (managed.E
 		return managed.ExternalUpdate{}, errors.Wrap(err, "pre-update failed")
 	}
 	resp, err := e.client.{{ .CRD.Ops.Update.ExportedName }}WithContext(ctx, input)
-	if err != nil {
-		return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
-	}
-	return e.postUpdate(ctx, cr, resp, managed.ExternalUpdate{}, err)
+	return e.postUpdate(ctx, cr, resp, managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate))
 	{{- else }}
 	return e.update(ctx, mg)
 	{{ end }}


### PR DESCRIPTION
Description of changes: Remove unnecessary error handling in Update because it's already handled in return statement. Manually tested.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
