### PR TITLE
Add a new config to override `kubebuilder:printcolumn` priority

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -124,6 +124,10 @@ type PrintFieldConfig struct {
 	// include the field in `kubectl get` response. This field is generally used
 	// to override very long and redundant columns names.
 	Name string `json:"name"`
+	// Priority differentiates between fields/columns shown in standard view or wide
+	// view (using the -o wide flag). Fields with priority 0 are shown in standard view.
+	// Fields with priority greater than 0 are only shown in wide view. Default is 0
+	Priority int `json:"priority"`
 }
 
 // FieldConfig contains instructions to the code generator about how

--- a/pkg/model/printer_column.go
+++ b/pkg/model/printer_column.go
@@ -24,6 +24,7 @@ type PrinterColumn struct {
 	CRD      *CRD
 	Name     string
 	Type     string
+	Priority int
 	JSONPath string
 }
 
@@ -140,6 +141,7 @@ func (r *CRD) addPrintableColumn(
 		CRD:      r,
 		Name:     name,
 		Type:     printColumnType,
+		Priority: field.FieldConfig.Print.Priority,
 		JSONPath: jsonPath,
 	}
 	r.additionalPrinterColumns = append(r.additionalPrinterColumns, column)

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -48,7 +48,7 @@ type {{ .CRD.Kind }}Status struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 {{- range $column := .CRD.AdditionalPrinterColumns }}
-// +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},JSONPath=`{{$column.JSONPath}}`
+// +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},priority={{$column.Priority}},JSONPath=`{{$column.JSONPath}}`
 {{- end }}
 {{- if .CRD.ShortNames }}
 // +kubebuilder:resource:shortName={{ Join .CRD.ShortNames ";" }}


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/821

Description of changes:
This patch introduces a new config field called "Standard" under 
`PrintFieldConfig` to indicates whether the column is of priority 0 or 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
