### PR TITLE
Extend ack-generate to generate slice with elements of type K8s Secret

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -817,9 +817,9 @@ func setSDKForContainer(
 //
 //     or:
 //
-//	   tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
-//	   if err != nil {
-//	       return nil, err
+//     tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
+//     if err != nil {
+//         return nil, err
 //     }
 //     if tmpSecret != "" {
 //         f3elem = tmpSecret

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -1109,6 +1109,49 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 	)
 }
 
+func TestSetSDK_Elasticache_User_Create_Override_Values(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+
+	crd := testutil.GetCRDByName(t, g, "User")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Spec.AccessString != nil {
+		res.SetAccessString(*r.ko.Spec.AccessString)
+	}
+	if r.ko.Spec.NoPasswordRequired != nil {
+		res.SetNoPasswordRequired(*r.ko.Spec.NoPasswordRequired)
+	}
+	if r.ko.Spec.Passwords != nil {
+		f3 := []*string{}
+		for _, f3iter := range r.ko.Spec.Passwords {
+			var f3elem string
+			if f3iter != nil {
+				tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
+				if err != nil {
+					return nil, err
+				}
+				if tmpSecret != "" {
+					f3elem = tmpSecret
+				}
+			}
+			f3 = append(f3, &f3elem)
+		}
+		res.SetPasswords(f3)
+	}
+	if r.ko.Spec.UserID != nil {
+		res.SetUserId(*r.ko.Spec.UserID)
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1),
+	)
+}
+
 func TestSetSDK_RDS_DBInstance_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -274,6 +274,13 @@ func TestElasticache_ValidateAuthTokenIsSecret(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.Equal("*ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoType)
-	assert.Equal("ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoTypeElem)
+	assert.Equal("SecretKeyReference", crd.SpecFields["AuthToken"].GoTypeElem)
 	assert.Equal("*ackv1alpha1.SecretKeyReference", crd.SpecFields["AuthToken"].GoTypeWithPkgName)
+
+	crd = getCRDByName("User", crds)
+	require.NotNil(crd)
+
+	assert.Equal("[]*ackv1alpha1.SecretKeyReference", crd.SpecFields["Passwords"].GoType)
+	assert.Equal("SecretKeyReference", crd.SpecFields["Passwords"].GoTypeElem)
+	assert.Equal("[]*ackv1alpha1.SecretKeyReference", crd.SpecFields["Passwords"].GoTypeWithPkgName)
 }

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -18,6 +18,10 @@ resources:
         from:
           operation: DescribeEvents
           path: Events
+  User:
+    fields:
+      Passwords:
+        is_secret: true
   ReplicationGroup:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
@@ -126,7 +130,6 @@ ignore:
     - GlobalReplicationGroup
     - CacheCluster
     - CacheSecurityGroup
-    - User
     - UserGroup
   field_paths:
     - DescribeSnapshotsInput.CacheClusterId

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -95,12 +95,8 @@ func NewField(
 		shape = shapeRef.Shape
 	}
 
-	if cfg != nil && cfg.IsSecret {
-		gt = "*ackv1alpha1.SecretKeyReference"
-		gte = "ackv1alpha1.SecretKeyReference"
-		gtwp = "*ackv1alpha1.SecretKeyReference"
-	} else if shape != nil {
-		gte, gt, gtwp = cleanGoType(crd.sdkAPI, crd.cfg, shape)
+	if shape != nil {
+		gte, gt, gtwp = cleanGoType(crd.sdkAPI, crd.cfg, shape, cfg)
 	} else {
 		gte = "string"
 		gt = "*string"


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/828

Description of changes:
With this code change, when a field of type slice
is configured as secret type inside Generator config,
then the generated CRD yaml allows specifying multiple k8s secret values
for that field in input yaml and generated sdk code supplies these values
to the resource API input field as slice type.

Added unit tests to test the scenario.

Details on resultant generated code:
Taking ElastiCache User API has `passwords` filed as example:
ElastiCache User API has `passwords` filed of type `[]*string` in the API input. [Reference API docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/elasticache/create-user.html)

When this field is configured as secret type inside Generator config:
```
resources:
  User:
    fields:
      Passwords:
        is_secret: true
```
and service controller code is generated with changes from this PR then,
the generated CRD yaml for password field is:
```
              passwords:
                description: Passwords used for this user. You can create up to two
                  passwords for each user.
                items:
                  description: SecretKeyReference combines a k8s corev1.SecretReference
                    with a specific key within the referred-to Secret
                  properties:
                    key:
                      description: Key is the key within the secret
                      type: string
                    name:
                      description: Name is unique within a namespace to reference
                        a secret resource.
                      type: string
                    namespace:
                      description: Namespace defines the space within which the secret
                        name must be unique.
                      type: string
                  required:
                  - key
                  type: object
                type: array
```
Observe that the password field is `array` type with K8s Secreret as element type

and User resource sdk.go file contain following code for password field while setting the inputs:
```
	if r.ko.Spec.Passwords != nil {
		f3 := []*string{}
		for _, f3iter := range r.ko.Spec.Passwords {
			var f3elem string
			if f3iter != nil {
				tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
				if err != nil {
					return nil, err
				}
				if tmpSecret != "" {
					f3elem = tmpSecret
				}
			}
			f3 = append(f3, &f3elem)
		}
		res.SetPasswords(f3)
	}
```
Observe that it supplies the secrets values as slice type to the input API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Testing:
1. ```make test``` passed for `code-generator` which contained already existing tests for secret fields code generation scenarios for MQ, ElastiCache ReplicationGroup.
2. ```make test``` passed for ElastiCache ACK controller generated code.
3. Generated ElastiCache controller code did not have any unrelated/unexpected changes.