### PR TITLE
Remove unnecessary homedir module

### DIFF
--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +61,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	hd, err := homedir.Dir()
+	hd, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Printf("unable to determine $HOME: %s\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gertd/go-pluralize v0.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/iancoleman/strcase v0.1.3
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/operator-framework/api v0.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1


### PR DESCRIPTION
`os.UserHomeDir` is supported in go1.12+. We no longer need a third party module to load the home directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
