### PR TITLE
Add base CRD documentation

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -110,10 +110,11 @@ func (r *CRD) TypeRenames() map[string]string {
 // Documentation returns the base documentation string for the API formatted as
 // a Go code comment block
 func (r *CRD) Documentation() string {
-	docString := fmt.Sprintf("// %sSpec defines the desired state of %s", r.Names.Original, r.Names.Original)
+	docString := fmt.Sprintf("// %sSpec defines the desired state of %s.", r.Names.Original, r.Names.Original)
 	shape, ok := r.sdkAPI.API.Shapes[r.Names.Original]
 	if ok {
-		docString += "\n" + shape.Documentation
+		// Separate with a double newline to force a newline in the CRD base
+		docString += "\n//\n" + shape.Documentation
 	}
 	return docString
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -110,11 +110,12 @@ func (r *CRD) TypeRenames() map[string]string {
 // Documentation returns the base documentation string for the API formatted as
 // a Go code comment block
 func (r *CRD) Documentation() string {
+	docString := fmt.Sprintf("// %sSpec defines the desired state of %s", r.Names.Original, r.Names.Original)
 	shape, ok := r.sdkAPI.API.Shapes[r.Names.Original]
 	if ok {
-		return shape.Documentation
+		docString += "\n" + shape.Documentation
 	}
-	return fmt.Sprintf("// %sSpec defines the desired state of %s", r.Names.Original, r.Names.Original)
+	return docString
 }
 
 // HasShapeAsMember returns true if the supplied Shape name appears in *any*

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -104,6 +105,16 @@ func (r *CRD) SDKAPIPackageName() string {
 // type definition names conflict with generated names)
 func (r *CRD) TypeRenames() map[string]string {
 	return r.sdkAPI.GetTypeRenames(r.cfg)
+}
+
+// Documentation returns the base documentation string for the API formatted as
+// a Go code comment block
+func (r *CRD) Documentation() string {
+	shape, ok := r.sdkAPI.API.Shapes[r.Names.Original]
+	if ok {
+		return shape.Documentation
+	}
+	return fmt.Sprintf("// %sSpec defines the desired state of %s", r.Names.Original, r.Names.Original)
 }
 
 // HasShapeAsMember returns true if the supplied Shape name appears in *any*

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
+{{ .CRD.Documentation }}
 type {{ .CRD.Kind }}Spec struct {
 	{{- range $fieldName, $field := .CRD.SpecFields }}
 	{{- if $field.ShapeRef }}


### PR DESCRIPTION
Description of changes:
Replaces the comment block for CRDs with the documentation of the resource shape from the AWS SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
