### PR TITLE
Add a cobra `PostRunE` to save generation metadata 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 VERSION ?= "v0.0.0"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-GO_LDFLAGS=-ldflags "-X main.version=$(VERSION) \
-			-X main.buildHash=$(GITCOMMIT) \
-			-X main.buildDate=$(BUILDDATE)"
+IMPORT_PATH=github.com/aws-controllers-k8s/code-generator
+GO_LDFLAGS=-ldflags "-X $(IMPORT_PATH)/pkg/version.Version=$(VERSION) \
+			-X $(IMPORT_PATH)/pkg/version.BuildHash=$(GITCOMMIT) \
+			-X $(IMPORT_PATH)/pkg/version.BuildDate=$(BUILDDATE)"
 
 # We need to use the codegen tag when building and testing because the
 # aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...

--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -42,9 +42,10 @@ var (
 
 // apiCmd is the command that generates service API types
 var apisCmd = &cobra.Command{
-	Use:   "apis <service>",
-	Short: "Generate Kubernetes API type definitions for an AWS service API",
-	RunE:  generateAPIs,
+	Use:      "apis <service>",
+	Short:    "Generate Kubernetes API type definitions for an AWS service API",
+	RunE:     generateAPIs,
+	PostRunE: saveGeneratedMetadata,
 }
 
 func init() {
@@ -52,6 +53,19 @@ func init() {
 		&optGenVersion, "version", "v1alpha1", "the resource API Version to use when generating API infrastructure and type definitions",
 	)
 	rootCmd.AddCommand(apisCmd)
+}
+
+// saveGeneratedMetadata saves the parameters used to generate APIs and checksum
+// of the generated code.
+func saveGeneratedMetadata(cmd *cobra.Command, args []string) error {
+	err := ackgenerate.CreateGenerationMetadata(
+		optGenVersion,
+		filepath.Join(optOutputPath, "apis"),
+		ackgenerate.UpdateReasonAPIGeneration,
+		optAWSSDKGoVersion,
+		optGeneratorConfigPath,
+	)
+	return err
 }
 
 // generateAPIs generates the Go files for each resource in the AWS service

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -30,9 +30,6 @@ A tool to generate AWS service controller code`
 )
 
 var (
-	version                string
-	buildHash              string
-	buildDate              string
 	defaultCacheDir        string
 	optCacheDir            string
 	optRefreshCache        bool
@@ -125,11 +122,7 @@ func init() {
 // Execute adds all child commands to the root command and sets flags
 // appropriately. This is called by main.main(). It only needs to happen once
 // to the rootCmd.
-func Execute(v string, bh string, bd string) {
-	version = v
-	buildHash = bh
-	buildDate = bd
-
+func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/ack-generate/main.go
+++ b/cmd/ack-generate/main.go
@@ -17,15 +17,6 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/cmd/ack-generate/command"
 )
 
-var (
-	// version of application at compile time (-X 'main.version=$(VERSION)').
-	version = "(Unknown Version)"
-	// buildHash GIT hash of application at compile time (-X 'main.buildHash=$(GITCOMMIT)').
-	buildHash = "No Git-hash Provided."
-	// buildDate of application at compile time (-X 'main.buildDate=$(BUILDDATE)').
-	buildDate = "No Build Date Provided."
-)
-
 func main() {
-	command.Execute(version, buildHash, buildDate)
+	command.Execute()
 }

--- a/pkg/generate/ack/output.go
+++ b/pkg/generate/ack/output.go
@@ -1,0 +1,195 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ack
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/version"
+)
+
+const (
+	outputFileName = "ack-generate-metadata.yaml"
+)
+
+// UpdateReason is the reason a package got modified.
+type UpdateReason string
+
+const (
+	// UpdateReasonAPIGeneration should be used when an API package
+	// is modified by the APIs generator (ack-generate apis).
+	UpdateReasonAPIGeneration UpdateReason = "API generation"
+
+	// UpdateReasonConversionFunctionsGeneration Should be used when
+	// an API package is modified by conversion functions generator.
+	// TODO(hilalymh) ack-generate conversion-functions
+	UpdateReasonConversionFunctionsGeneration UpdateReason = "Conversion functions generation"
+)
+
+// GenerationMetadata represents the parameters used to generate/update the
+// API version directory.
+//
+// This type is public because soon it will be used by conversion generators
+// to load APIs generation metadata.
+// TODO(hilalymh) Add functions to load/edit metadata files.
+type GenerationMetadata struct {
+	// The APIs version e.g v1alpha2
+	APIVersion string `json:"api_version"`
+	// The checksum of all the combined files generated within the APIs directory
+	APIDirectoryChecksum string `json:"api_directory_checksum"`
+	// Last modification reason
+	LastModification lastModificationInfo `json:"last_modification"`
+	// AWS SDK Go version used generate the APIs
+	AWSSDKGoVersion string `json:"aws_sdk_go_version"`
+	// Informatiom about the ack-generate binary used to generate the APIs
+	ACKGenerateInfo ackGenerateInfo `json:"ack_generate_info"`
+	// Information about the generator config file used to generate the APIs
+	GeneratorConfigInfo generatorConfigInfo `json:"generator_config_info"`
+}
+
+// ack-generate binary information
+type ackGenerateInfo struct {
+	Version   string `json:"version"`
+	GoVersion string `json:"go_version"`
+	BuildDate string `json:"build_date"`
+	BuildHash string `json:"build_hash"`
+}
+
+// generator.yaml information
+type generatorConfigInfo struct {
+	OriginalFileName string `json:"original_file_name"`
+	FileChecksum     string `json:"file_checksum"`
+}
+
+// last modification information
+type lastModificationInfo struct {
+	// UTC Timestamp
+	Timestamp string `json:"timestamp"`
+	// Modification reason
+	Reason UpdateReason `json:"reason"`
+}
+
+// CreateGenerationMetadata gathers information about the generated code and save
+// a yaml version in the API version directory
+func CreateGenerationMetadata(
+	apiVersion string,
+	apisPath string,
+	modificationReason UpdateReason,
+	awsSDKGo string,
+	generatorFileName string,
+) error {
+	filesDirectory := filepath.Join(apisPath, apiVersion)
+	hash, err := hashDirectoryContent(filesDirectory)
+	if err != nil {
+		return err
+	}
+
+	generatorFileHash, err := hashFile(generatorFileName)
+	if err != nil {
+		return err
+	}
+
+	generationMetadata := &GenerationMetadata{
+		APIVersion:           apiVersion,
+		APIDirectoryChecksum: hash,
+		LastModification: lastModificationInfo{
+			Timestamp: time.Now().UTC().String(),
+			Reason:    modificationReason,
+		},
+		AWSSDKGoVersion: awsSDKGo,
+		ACKGenerateInfo: ackGenerateInfo{
+			Version:   version.Version,
+			BuildDate: version.BuildDate,
+			BuildHash: version.BuildHash,
+			GoVersion: version.GoVersion,
+		},
+		GeneratorConfigInfo: generatorConfigInfo{
+			OriginalFileName: filepath.Base(generatorFileName),
+			FileChecksum:     generatorFileHash,
+		},
+	}
+
+	data, err := yaml.Marshal(generationMetadata)
+	if err != nil {
+		return err
+	}
+
+	outputFileName := filepath.Join(filesDirectory, outputFileName)
+	err = ioutil.WriteFile(
+		outputFileName,
+		data,
+		os.ModePerm,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// hashDirectoryContent returns the sha1 checksum of a given directory. It will walk
+// the file tree of a directory and combine and the file contents before hashing it.
+func hashDirectoryContent(directory string) (string, error) {
+	h := sha1.New()
+	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			// ignore yaml files (output.yaml and generator.yaml)
+			fileExtension := filepath.Ext(info.Name())
+			if fileExtension == ".yaml" {
+				return nil
+			}
+
+			fileReader, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, err = io.Copy(h, fileReader)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	hash := hex.EncodeToString(h.Sum(nil))
+	return hash, nil
+}
+
+// hashFile returns the sha1 hash of a given file
+func hashFile(filename string) (string, error) {
+	h := sha1.New()
+	fileReader, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	_, err = io.Copy(h, fileReader)
+	if err != nil {
+		return "", err
+	}
+	hash := hex.EncodeToString(h.Sum(nil))
+	return hash, nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,31 +11,24 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package command
+package version
 
 import (
 	"fmt"
-
-	"github.com/spf13/cobra"
-
-	"github.com/aws-controllers-k8s/code-generator/pkg/version"
+	"runtime"
 )
 
-const debugHeader = `Date: %s
-Build: %s
-Version: %s
-Git Hash: %s
-`
-
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display the version of " + appName,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf(debugHeader, version.BuildDate, version.GoVersion, version.Version, version.BuildHash)
-	},
-}
+var (
+	// BuildDate of application at compile time (-X 'main.buildDate=$(BUILDDATE)').
+	BuildDate string = "No Build Date Provided."
+	// Version of application at compile time (-X 'main.version=$(VERSION)').
+	Version string = "(Unknown Version)"
+	// BuildHash is the GIT hash of application at compile time (-X 'main.buildHash=$(GITCOMMIT)').
+	BuildHash string = "No Git-hash Provided."
+	// GoVersion is the Go compiler version used to compile this binary
+	GoVersion string
+)
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
+	GoVersion = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/809

Description of changes:

This patch adds a cobra `PostRunE` function that writes generator
parameters, output metadata and generated files checksum, to a
file within the API versions directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
