### PR TITLE
Enable crd variables and controller functions and hooks within hook templates

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -122,10 +122,16 @@ func Controller(
 		return nil, err
 	}
 
+	metaVars := g.MetaVars()
+
 	// Hook code can reference a template path, and we can look up the template
 	// in any of our base paths...
 	controllerFuncMap["Hook"] = func(r *ackmodel.CRD, hookID string) string {
-		code, err := ResourceHookCode(templateBasePaths, r, hookID)
+		crdVars := &templateCRDVars{
+			metaVars,
+			r,
+		}
+		code, err := ResourceHookCode(templateBasePaths, r, hookID, crdVars, controllerFuncMap)
 		if err != nil {
 			// It's a compile-time error, so just panic...
 			panic(err)
@@ -139,8 +145,6 @@ func Controller(
 		controllerCopyPaths,
 		controllerFuncMap,
 	)
-
-	metaVars := g.MetaVars()
 
 	// First add all the CRD pkg/resource templates
 	targets := []string{

--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -105,6 +105,8 @@ func ResourceHookCode(
 	templateBasePaths []string,
 	r *ackmodel.CRD,
 	hookID string,
+	vars interface{},
+	funcMap ttpl.FuncMap,
 ) (string, error) {
 	resourceName := r.Names.Original
 	if resourceName == "" || hookID == "" {
@@ -146,6 +148,7 @@ func ResourceHookCode(
 			return "", err
 		}
 		t := ttpl.New(tplPath)
+		t = t.Funcs(funcMap)
 		if t, err = t.Parse(string(tplContents)); err != nil {
 			err := fmt.Errorf(
 				"resource %s hook config for %s is invalid: error parsing %s: %s",
@@ -156,7 +159,7 @@ func ResourceHookCode(
 		var b bytes.Buffer
 		// TODO(jaypipes): Instead of nil for template vars here, maybe pass in
 		// a struct of variables?
-		if err := t.Execute(&b, nil); err != nil {
+		if err := t.Execute(&b, vars); err != nil {
 			err := fmt.Errorf(
 				"resource %s hook config for %s is invalid: error executing %s: %s",
 				resourceName, hookID, tplPath, err,

--- a/pkg/generate/ack/hook_test.go
+++ b/pkg/generate/ack/hook_test.go
@@ -38,7 +38,7 @@ func TestResourceHookCodeInline(t *testing.T) {
 
 	// The Broker's update operation has a special hook callback configured
 	expected := `if err := rm.requeueIfNotRunning(latest); err != nil { return nil, err }`
-	got, err := ack.ResourceHookCode(basePaths, crd, hookID)
+	got, err := ack.ResourceHookCode(basePaths, crd, hookID, nil, nil)
 	assert.Nil(err)
 	assert.Equal(expected, got)
 }
@@ -59,7 +59,7 @@ func TestResourceHookCodeTemplatePath(t *testing.T) {
 
 	// The Broker's delete operation has a special hook configured to point to a template.
 	expected := "// this is my template.\n"
-	got, err := ack.ResourceHookCode(basePaths, crd, hookID)
+	got, err := ack.ResourceHookCode(basePaths, crd, hookID, nil, nil)
 	assert.Nil(err)
 	assert.Equal(expected, got)
 }


### PR DESCRIPTION
Issue #, https://github.com/aws-controllers-k8s/community/issues/838

Description of changes:
This PR enables support for crd variables and controller functions and hooks within hook templates.
The hook templates insides the service controllers can be similar to the templates that are inside code-generator.

For example, following hook template refers `.CRD` variable, invokes controller function `GoCodeSetCreateOutput` and has its own extension hook `sdk_addon_set_output_post_populate`:
and it can be used as hook inside generator.yaml for a resource:

```
{{ $outputShape := .CRD.GetOutputShape .CRD.Ops.Create }}
// This method copies the data from given {{ $outputShape.ShapeName }} by populating it
// into copy of supplied resource and returns that.
func (rm *resourceManager) set{{ $outputShape.ShapeName }}Output (
    r *resource,
    obj *svcsdk.{{ $outputShape.ShapeName }},
) (*resource, error) {
	if obj == nil ||
		r == nil ||
		r.ko == nil {
		return nil, nil
	}
	resp := &svcsdk.{{ .CRD.Ops.Create.OutputRef.Shape.ShapeName }}{ {{ $outputShape.ShapeName }}:obj }
	// Merge in the information we read from the API call above to the copy of
    // the original Kubernetes object we passed to the function
    ko := r.ko.DeepCopy()
{{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko" 1 true }}
{{ $createCode }}
	rm.setStatusDefaults(ko)
{{- if $hookCode := Hook .CRD "sdk_addon_set_output_post_populate" }}
{{ $hookCode }}
{{- end }}
    return &resource{ko}, nil
}

```

Testing:
`make test` passed for `code-generator`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
