### PR TITLE
Add CRD method to get OutputShape

### DIFF
--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2636,7 +2636,7 @@ func TestGetWrapperOutputShape(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			outputShape, err := code.GetWrapperOutputShape(tt.args.outputShape, tt.args.fieldPath)
+			outputShape, err := crd.GetWrapperOutputShape(tt.args.outputShape, tt.args.fieldPath)
 			if (err != nil) != tt.wantErr {
 				assert.Fail(fmt.Sprintf("GetWrapperOutputShape() error = %v, wantErr %v", err, tt.wantErr))
 			} else if !tt.wantErr {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR also adds a method `GetOutputShape` to crd which provides output shape

For example, `CreateReplicationGroupOutput`, `ModifyReplicationGroupOutput` wrap `ReplicationGroup` object.
This method is useful in creating reusable code which populates the fields from wrapped object to `ko`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
