### PR TITLE
fix: use deterministic sort for identifier field

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -400,7 +400,7 @@ func (r *CRD) SpecIdentifierField() *string {
 		r.Names.Original + "Name",
 		r.Names.Original + "Id",
 	}
-	for memberName := range r.SpecFields {
+	for _, memberName := range r.SpecFieldNames() {
 		if util.InStrings(memberName, lookup) {
 			return &r.SpecFields[memberName].Names.Camel
 		}


### PR DESCRIPTION
@kumargauravsharma noticed that when generating the User resource
package in the elasticache-controller, sometimes he saw the Identifier
field be User.Spec.UserID. Other times it was User.Spec.UserName. Turns
out in the `pkg/model.CRD:SpecIdentifierField()` method, we were looping
over the `CRD.SpecFields` map keys (which are not ordered) instead of a
sorted list of spec field names, which is returned by the
`CRD.SpecFieldNames()` method.

By submitting this pull request, I confirm that my contribution is made under the
terms of the Apache 2.0 license.
