### PR TITLE
Add sdk addon hook

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -56,6 +56,7 @@ code paths:
 * sdk_get_attributes_post_set_output
 * sdk_create_post_set_output
 * sdk_update_post_set_output
+* sdk_file_end
 * delta_pre_compare
 * delta_post_compare
 
@@ -90,6 +91,10 @@ The "post_set_output" hooks are called AFTER the the information from the API ca
 is merged with the copy of the original Kubernetes object. These hooks will
 have access to the updated Kubernetes object `ko`, the response of the API call
 (and the original Kubernetes CR object if its sdkUpdate)
+
+The "sdk_file_end" is a generic hook point that occurs outside the scope of any
+specific AWSResourceManager method and can be used to place commonly-generated
+code inside the sdk.go file
 
 The "delta_pre_compare" hooks are called BEFORE the generated code that
 compares two resources.

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -362,3 +362,6 @@ func (rm *resourceManager) handleImmutableFieldsChangedCondition(
 	return &resource{ko}
 }
 {{- end }}
+{{- if $hookCode := Hook .CRD "sdk_file_end" }}
+{{ $hookCode }}
+{{- end }}


### PR DESCRIPTION
Issue #, if available:

Ability for service controllers to add code (additional functions, variables etc as needed) to sdk.go file using hooks as extension mechanism.

Description of changes:

This PR adds `sdk_addon` hook to `sdk.go.tpl`. Using this hook, service controllers can append code to a custom resource's `sdk.go` file. It will help in placing reusable code/functions which are generated dynamically using hook templates.

Following PR contains changes showcasing how this facility helps service controllers auto generate reusable code: https://github.com/aws-controllers-k8s/elasticache-controller/pull/36

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
