### PR TITLE
Provide an option to configure a resource to requeue infinitely (Issue #826)

### DIFF
--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -56,7 +56,7 @@ type ResourceConfig struct {
 	// very little consistency to the APIs that we can use to instruct the code
 	// generator :(
 	UpdateOperation *UpdateOperationConfig `json:"update_operation,omitempty"`
-	// ReconcileConfig describes options for controlling the reconciliation
+	// Reconcile describes options for controlling the reconciliation
 	// logic for a particular resource.
 	Reconcile *ReconcileConfig `json:"reconcile,omitempty"`
 	// UpdateConditionsCustomMethodName provides the name of the custom method on the

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -56,6 +56,9 @@ type ResourceConfig struct {
 	// very little consistency to the APIs that we can use to instruct the code
 	// generator :(
 	UpdateOperation *UpdateOperationConfig `json:"update_operation,omitempty"`
+	// ReconcileConfig describes options for controlling the reconciliation
+	// logic for a particular resource.
+	Reconcile *ReconcileConfig `json:"reconcile,omitempty"`
 	// UpdateConditionsCustomMethodName provides the name of the custom method on the
 	// `resourceManager` struct that will set Conditions on a `resource` struct
 	// depending on the status of the resource.
@@ -273,6 +276,19 @@ type PrintConfig struct {
 	AddAgeColumn bool `json:"add_age_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
+// ReconcileConfig describes options for controlling the reconciliation
+// logic for a particular resource.
+type ReconcileConfig struct {
+    // RequeueOnSuccessSeconds indicates the number of seconds after which to requeue a
+    // resource that has been successfully reconciled (i.e. ConditionTypeResourceSynced=true)
+    // This is useful for resources that are long-lived and may have observable status fields
+    // change over time that would be useful to refresh those field values for users.
+    // This field is optional and the default behaviour of the ACK runtime is to not requeue
+    // resources that have been successfully reconciled. Note that all ACK controllers will
+    // *flush and resync their watch caches* every 10 hours by default, which will end up
+    // causing ACK controllers to refresh the status views of all watched resources, but this
+    // behaviour is expensive and may be turned off in future ACK runtime options.
+    RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
 }
 
 // ResourceConfig returns the ResourceConfig for a given named resource

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -276,6 +276,8 @@ type PrintConfig struct {
 	AddAgeColumn bool `json:"add_age_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
+}
+
 // ReconcileConfig describes options for controlling the reconciliation
 // logic for a particular resource.
 type ReconcileConfig struct {

--- a/pkg/generate/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
@@ -19,6 +19,9 @@ resources:
             404:
               code: ValidationException
               message_suffix: does not exist.
+  Endpoint:
+    reconcile: 
+      requeue_on_success_seconds: 10
 ignore:
     resource_names:
       - Algorithm
@@ -35,7 +38,7 @@ ignore:
       - Domain
       - EdgePackagingJob
       - EndpointConfig
-      - Endpoint
+      # - Endpoint
       - Experiment
       - FeatureGroup
       - FlowDefinition

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -554,6 +554,7 @@ func (r *CRD) GetResourcePrintOrderByName() string {
 // kubebuilder:printcolumn comment marker
 func (r *CRD) PrintAgeColumn() bool {
 	return r.cfg.GetResourcePrintAddAgeColumn(r.Names.Camel)
+}
 
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int, if specified in generator config. 

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -554,6 +554,24 @@ func (r *CRD) GetResourcePrintOrderByName() string {
 // kubebuilder:printcolumn comment marker
 func (r *CRD) PrintAgeColumn() bool {
 	return r.cfg.GetResourcePrintAddAgeColumn(r.Names.Camel)
+
+// ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
+// the custom resource as int, if specified in generator config. 
+func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {
+	if r.cfg == nil {
+		return 0
+	}
+	resGenConfig, found := r.cfg.Resources[r.Names.Original]
+	if !found {
+		return 0
+	}
+	reconcile := resGenConfig.Reconcile
+	// handles the default case
+	if reconcile == nil {
+		return 0
+	} else {
+		return reconcile.RequeueOnSuccessSeconds
+	}
 }
 
 // CustomUpdateMethodName returns the name of the custom resourceManager method

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -567,12 +567,11 @@ func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {
 		return 0
 	}
 	reconcile := resGenConfig.Reconcile
-	// handles the default case
-	if reconcile == nil {
-		return 0
-	} else {
+	if reconcile != nil {
 		return reconcile.RequeueOnSuccessSeconds
 	}
+	// handles the default case
+	return 0
 }
 
 // CustomUpdateMethodName returns the name of the custom resourceManager method

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -184,7 +184,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -204,7 +204,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -66,6 +66,16 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return {{ .CRD.IsAdoptable }}
 }
 
+// GetRequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success. 
+func (f *resourceManagerFactory) GetRequeueOnSuccessSeconds() (int, bool) {
+{{- if $reconcileRequeuOnSuccessSeconds := .CRD.ReconcileRequeuOnSuccessSeconds }}
+	return {{ $reconcileRequeuOnSuccessSeconds }}, true
+{{- else }}
+	return 0, false
+{{- end }}
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -66,13 +66,13 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return {{ .CRD.IsAdoptable }}
 }
 
-// GetRequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
 // Default is false which means resource will not be requeued after success. 
-func (f *resourceManagerFactory) GetRequeueOnSuccessSeconds() (int, bool) {
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
 {{- if $reconcileRequeuOnSuccessSeconds := .CRD.ReconcileRequeuOnSuccessSeconds }}
-	return {{ $reconcileRequeuOnSuccessSeconds }}, true
+	return {{ $reconcileRequeuOnSuccessSeconds }}
 {{- else }}
-	return 0, false
+	return 0
 {{- end }}
 }
 

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -189,6 +189,7 @@ func (rm *resourceManager) setStatusDefaults (
 // else it returns nil, false
 func (rm *resourceManager) updateConditions (
 	r *resource,
+	onSuccess bool,
 	err error,
 ) (*resource, bool) {
 	ko := r.ko.DeepCopy()
@@ -197,12 +198,16 @@ func (rm *resourceManager) updateConditions (
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
 	var recoverableCondition *ackv1alpha1.Condition = nil
+	var syncCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
 		}
 		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
 			recoverableCondition = condition
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			syncCondition = condition
 		}
 	}
 
@@ -245,15 +250,27 @@ func (rm *resourceManager) updateConditions (
 		}
 	}
 
+{{- if $reconcileRequeuOnSuccessSeconds := .CRD.ReconcileRequeuOnSuccessSeconds }}
+	if syncCondition == nil && onSuccess {
+		syncCondition = &ackv1alpha1.Condition{
+			Type:   ackv1alpha1.ConditionTypeResourceSynced,
+		}
+		syncCondition.Status = corev1.ConditionTrue
+		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
+	}
+{{- else }}
+	// Required to avoid the "declared but not used" error in the default case
+	syncCondition = nil
+{{- end }}
 
 {{- if $updateConditionsCustomMethodName := .CRD.UpdateConditionsCustomMethodName }}
 	// custom update conditions
 	customUpdate := rm.{{ $updateConditionsCustomMethodName }}(ko, r, err)
-	if terminalCondition != nil || recoverableCondition != nil || customUpdate {
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}
 {{- else }}
-	if terminalCondition != nil || recoverableCondition != nil {
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}
 {{- end }}

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -254,13 +254,13 @@ func (rm *resourceManager) updateConditions (
 	if syncCondition == nil && onSuccess {
 		syncCondition = &ackv1alpha1.Condition{
 			Type:   ackv1alpha1.ConditionTypeResourceSynced,
+			Status: corev1.ConditionTrue,
 		}
-		syncCondition.Status = corev1.ConditionTrue
 		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
 	}
 {{- else }}
 	// Required to avoid the "declared but not used" error in the default case
-	syncCondition = nil
+	_ = syncCondition
 {{- end }}
 
 {{- if $updateConditionsCustomMethodName := .CRD.UpdateConditionsCustomMethodName }}


### PR DESCRIPTION
This PR is one of two to implement [Issue #826](https://github.com/aws-controllers-k8s/community/issues/826) 
[Link to the runtime PR](https://github.com/aws-controllers-k8s/runtime/pull/23)

### Testing
I tested the change by enabling it for applicationAutoscaling (ScalableTarget) - [you can check the generated code on this branch just for reference. ](https://github.com/aws-controllers-k8s/applicationautoscaling-controller/pull/21)

### Unit Test Result
Added 2 unit tests for the cases where the requeue duration is specified in the config file and where it isnt. Locally tested the unit test fails for incorrect assertions. successful result as follows - 
```
(base) 147ddacd269c:code-generator mbaijal$ make test
go test -tags codegen ./...
?   	github.com/aws-controllers-k8s/code-generator/cmd/ack-generate	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/cmd/ack-generate/command	[no test files]
ok  	github.com/aws-controllers-k8s/code-generator/pkg/generate	(cached)
ok  	github.com/aws-controllers-k8s/code-generator/pkg/generate/ack	(cached)
ok  	github.com/aws-controllers-k8s/code-generator/pkg/generate/code	(cached)
?   	github.com/aws-controllers-k8s/code-generator/pkg/generate/config	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/pkg/generate/crossplane	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/pkg/generate/olm	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset	[no test files]
ok  	github.com/aws-controllers-k8s/code-generator/pkg/model	(cached)
ok  	github.com/aws-controllers-k8s/code-generator/pkg/names	(cached)
?   	github.com/aws-controllers-k8s/code-generator/pkg/testutil	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/pkg/util	[no test files]
?   	github.com/aws-controllers-k8s/code-generator/pkg/version	[no test files]
```