### PR TITLE
Conditionally allow view secrets on ClusterRole

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-ack-generate:	## Build ack-generate binary
 	@go build ${GO_TAGS} ${GO_LDFLAGS} -o bin/ack-generate cmd/ack-generate/main.go
 	@echo "ok."
 
-build-controller:   ## Generate controller code for SERVICE
+build-controller: build-ack-generate ## Generate controller code for SERVICE
 	@./scripts/install-controller-gen.sh 
 	@./scripts/build-controller.sh $(AWS_SERVICE)
 

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
@@ -165,7 +166,12 @@ func Controller(
 			}
 		}
 	}
-	if err = ts.Add("pkg/resource/registry.go", "pkg/resource/registry.go.tpl", metaVars); err != nil {
+
+	configVars := &templateConfigVars{
+		metaVars,
+		g.GetConfig(),
+	}
+	if err = ts.Add("pkg/resource/registry.go", "pkg/resource/registry.go.tpl", configVars); err != nil {
 		return nil, err
 	}
 
@@ -202,4 +208,11 @@ func Controller(
 type templateCmdVars struct {
 	templateset.MetaVars
 	SnakeCasedCRDNames []string
+}
+
+// templateConfigVars contains template variables for the templates that require
+// access to the generator configuration definition
+type templateConfigVars struct {
+	templateset.MetaVars
+	GeneratorConfig *ackgenconfig.Config
 }

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -68,6 +68,19 @@ type PrefixConfig struct {
 	StatusField string `json:"status_field,omitempty"`
 }
 
+// ResourceContainsSecret returns true if any of the fields in any resource are
+// defined as secrets.
+func (c *Config) ResourceContainsSecret() bool {
+	for _, resource := range c.Resources {
+		for _, field := range resource.Fields {
+			if field.IsSecret {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // New returns a new Config object given a supplied
 // path to a config file
 func New(

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -682,6 +682,12 @@ func (g *Generator) ApplyShapeIgnoreRules() {
 	}
 }
 
+// GetConfig returns the configuration option used to define the current
+// generator.
+func (g *Generator) GetConfig() *ackgenconfig.Config {
+	return g.cfg
+}
+
 // New returns a new Generator struct for a supplied API model.
 // Optionally, pass a file path to a generator config file that can be used to
 // instruct the code generator how to handle the API properly

--- a/templates/pkg/resource/registry.go.tpl
+++ b/templates/pkg/resource/registry.go.tpl
@@ -11,6 +11,9 @@ import (
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+{{ if .GeneratorConfig.ResourceContainsSecret -}}
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+{{- end }}
 
 var (
 	reg = ackrt.NewRegistry()


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/745

Description of changes:
If any of the fields defined in the generator are set to `is_secret: True`, then add `get;list;watch` permissions for secrets on the controller `ClusterRole`

Output into `cluster-role-controller.yaml`:
```yaml
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
