### PR TITLE
fix template for create custom implementation scenario

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -56,7 +56,7 @@ func (rm *resourceManager) sdkCreate(
 {{- if $hookCode := Hook .CRD "sdk_create_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
-{{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Create -}}
+{{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Create }}
 	created, err = rm.{{ $customMethod }}(ctx, desired)
 	if created != nil || err != nil {
 		return created, err


### PR DESCRIPTION
Issue #, if available:
Code generator fails when custom implementation is provided for create scenario
Steps to reproduce:
1. Run `make build-ack-generate && make build-controller SERVICE=$SERVICE`
2. Observe: 
    > /Users/kumargsh/ws/github_ws/go/src/github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/snapshot/sdk.go:311:17: expected ';', found created
Error: not all generators ran successfully
3. Corresponding `sdk.go` code:
   > 	exit := rlog.Trace("rm.sdkCreate")
	defer exit(err)created, err = rm.CustomCreateSnapshot(ctx, desired)
	if created != nil || err != nil {
		return created, err
	}

Observe, missing newline after `defer exit(err)`

Description of changes:
Updated the template.

Testing
* `make test` passed.
* ElastiCache service controller gets generated fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
