### PR TITLE
prevent unused variable error

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -70,7 +70,7 @@ func (rm *resourceManager) sdkCreate(
 {{ $hookCode }} 
 {{- end }}
 
-	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.Create }}
+	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.Create }}; _ = resp;
 	resp, err = rm.sdkapi.{{ .CRD.Ops.Create.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_create_post_request" }}
 {{ $hookCode }}

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -26,7 +26,7 @@ func (rm *resourceManager) sdkUpdate(
 {{ $hookCode }} 
 {{- end }}
 
-	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.Update }}
+	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.Update }}; _ = resp;
 	resp, err = rm.sdkapi.{{ .CRD.Ops.Update.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_update_post_request" }}
 {{ $hookCode }}


### PR DESCRIPTION
A [previous commit][0] that changed the ACK pkg/resource templates
introduced an error for controllers that have CREATE or UPDATE
implementations where the Output shape from the operation sets no fields
on the CR.

In these cases, attempting to build these controllers was resulting in a
build failure, like this for the RDS controller:

```
pkg/resource/db_parameter_group/sdk.go:205:6: resp declared but not used
```

This corrects that by using a blanking technique immediately after the
variable declaration:

```
var resp *SomeSDKShape; _ = resp;
```

[0]: a42b4a1a9081824ff60a29b8a5f31ccf79026372

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
