### PR TITLE
Use the latest observed state to merge in the API update response

### DIFF
--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -40,7 +40,7 @@ func (rm *resourceManager) sdkUpdate(
 {{- end }}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := desired.ko.DeepCopy()
+	ko := latest.ko.DeepCopy()
 {{- if $hookCode := Hook .CRD "sdk_update_pre_set_output" }}
 {{ $hookCode }}
 {{- end }}


### PR DESCRIPTION
Use the latest observed state to merge in the API update response. Since `latest` will already be merged with `desired` from the `ReadOne` call (see https://github.com/aws-controllers-k8s/code-generator/blob/main/templates/pkg/resource/sdk_find_read_one.go.tpl#L43 and https://github.com/aws-controllers-k8s/runtime/blob/main/pkg/runtime/reconciler.go#L205)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
