### PR TITLE
Generate resource identifiers from `ReadOne` or `ReadMany`

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -109,6 +109,9 @@ var (
 		"GoCodeRequiredFieldsMissingFromSetAttributesInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
 			return code.CheckRequiredFieldsMissingFromShape(r, ackmodel.OpTypeSetAttributes, koVarName, indentLevel)
 		},
+		"GoCodeSetResourceIdentifiers": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return code.SetResourceIdentifiers(r.Config(), r, sourceVarName, targetVarName, indentLevel)
+		},
 	}
 )
 

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -841,6 +841,7 @@ func SetResourceIdentifiers(
 		"MaxResults",
 	}
 
+	additionalKeyCount := 0
 	for _, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
@@ -893,13 +894,17 @@ func SetResourceIdentifiers(
 		if isPrimaryIdentifier {
 			primaryKeyOut += fmt.Sprintf("%s%s.%s.%s = %s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
 		} else {
+			fieldIndexName := fmt.Sprintf("f%d", additionalKeyCount)
 			sourceAdaptedVarName := fmt.Sprintf("%s.AdditionalKeys[\"%s\"]", sourceVarName, cleanMemberNames.CamelLower)
 
 			// TODO(RedbackThomson): If the identifiers don't exist, we should be
 			// throwing an error accessible to the user
-			additionalKeyOut += fmt.Sprintf("%sif %s != nil {\n", indent, sourceAdaptedVarName)
-			additionalKeyOut += fmt.Sprintf("%s\t%s.%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, sourceAdaptedVarName)
+			additionalKeyOut += fmt.Sprintf("%s%s,%sok := %s \n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
+			additionalKeyOut += fmt.Sprintf("%sif %sok {\n", indent, fieldIndexName)
+			additionalKeyOut += fmt.Sprintf("%s\t%s.%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s}\n", indent)
+
+			additionalKeyCount++
 		}
 	}
 

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -867,7 +867,7 @@ func SetResourceIdentifiers(
 		if r.IsPrimaryARNField(memberName) {
 			// r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 			arnOut += fmt.Sprintf(
-				"\n%s%s.Status.%s.ARN = %s.ARN\n",
+				"\n%s%s.Status.ACKResourceMetadata.ARN = %s.ARN\n",
 				indent, targetVarName, sourceVarName,
 			)
 			continue
@@ -892,14 +892,20 @@ func SetResourceIdentifiers(
 		}
 
 		if isPrimaryIdentifier {
+			// r.ko.Status.BrokerID = identifier.NameOrID
 			primaryKeyOut += fmt.Sprintf("%s%s.%s.%s = %s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
 		} else {
+			// f0, f0ok := identifier.AdditionalKeys["scalableDimension"]
+			// if f0ok {
+			// 	r.ko.Spec.ScalableDimension = f0
+			// }
+
 			fieldIndexName := fmt.Sprintf("f%d", additionalKeyCount)
 			sourceAdaptedVarName := fmt.Sprintf("%s.AdditionalKeys[\"%s\"]", sourceVarName, cleanMemberNames.CamelLower)
 
 			// TODO(RedbackThomson): If the identifiers don't exist, we should be
 			// throwing an error accessible to the user
-			additionalKeyOut += fmt.Sprintf("%s%s,%sok := %s \n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
+			additionalKeyOut += fmt.Sprintf("%s%s, %sok := %s\n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
 			additionalKeyOut += fmt.Sprintf("%sif %sok {\n", indent, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s\t%s.%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s}\n", indent)

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -940,7 +940,7 @@ func SetResourceIdentifiers(
 
 		if isPrimaryIdentifier {
 			// r.ko.Status.BrokerID = identifier.NameOrID
-			primaryKeyOut += fmt.Sprintf("%s%s.%s.%s = %s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
+			primaryKeyOut += fmt.Sprintf("%s%s%s.%s = %s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
 		} else {
 			// f0, f0ok := identifier.AdditionalKeys["scalableDimension"]
 			// if f0ok {
@@ -954,7 +954,7 @@ func SetResourceIdentifiers(
 			// throwing an error accessible to the user
 			additionalKeyOut += fmt.Sprintf("%s%s, %sok := %s\n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
 			additionalKeyOut += fmt.Sprintf("%sif %sok {\n", indent, fieldIndexName)
-			additionalKeyOut += fmt.Sprintf("%s\t%s.%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
+			additionalKeyOut += fmt.Sprintf("%s\t%s%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s}\n", indent)
 
 			additionalKeyCount++

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2645,3 +2645,73 @@ func TestGetWrapperOutputShape(t *testing.T) {
 		})
 	}
 }
+
+func TestSetResource_MQ_Broker_SetResourceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "mq")
+
+	crd := testutil.GetCRDByName(t, g, "Broker")
+	require.NotNil(crd)
+
+	expected := `
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Status.BrokerID = identifier.NameOrID
+
+`
+	assert.Equal(
+		expected,
+		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
+	)
+}
+
+func TestSetResource_RDS_DBInstances_SetResourceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "rds")
+
+	crd := testutil.GetCRDByName(t, g, "DBInstance")
+	require.NotNil(crd)
+
+	expected := `
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.DBInstanceIdentifier = identifier.NameOrID
+
+`
+	assert.Equal(
+		expected,
+		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
+	)
+}
+
+func TestSetResource_APIGWV2_ApiMapping_SetResourceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+
+	crd := testutil.GetCRDByName(t, g, "ApiMapping")
+	require.NotNil(crd)
+
+	expected := `
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Status.APIMappingID = identifier.NameOrID
+
+	f0, f0ok := identifier.AdditionalKeys["domainName"]
+	if f0ok {
+		r.ko.Spec.DomainName = f0
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
+	)
+}

--- a/pkg/generate/config/operation.go
+++ b/pkg/generate/config/operation.go
@@ -37,6 +37,10 @@ type OperationConfig struct {
 	// Override for operation type in case of heuristic failure
 	// An example of this is `Put...` or `Register...` API operations not being correctly classified as `Create` op type
 	OperationType string `json:"operation_type"`
+	// PrimaryIdentifierFieldName provides the name of the field that should be
+	// interpreted as the "primary" identifier field. This field will be used as
+	// the primary field for resource adoption.
+	PrimaryIdentifierFieldName string `json:"primary_identifier_field_name,omitempty"`
 }
 
 // IsIgnoredOperation returns true if Operation Name is configured to be ignored

--- a/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
@@ -1,6 +1,9 @@
 ignore:
   shape_names:
     - DBSecurityGroupMembershipList
+operations:
+  DescribeDBInstances:
+    primary_identifier_field_name: DBInstanceIdentifier
 resources:
   DBSubnetGroup:
     renames:

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -507,7 +507,10 @@ func (r *CRD) UpdateConditionsCustomMethodName() string {
 	return resGenConfig.UpdateConditionsCustomMethodName
 }
 
-// SpecIdentifierField returns the name of the "Name" or string identifier field in the Spec
+// SpecIdentifierField returns the name of the "Name" or string identifier field
+// in the Spec.
+// This method does not guarantee that the identifier field returned is the
+// primary identifier used in any of the `Read*` operations.
 func (r *CRD) SpecIdentifierField() *string {
 	if r.cfg != nil {
 		rConfig, found := r.cfg.Resources[r.Names.Original]

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -82,5 +82,6 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 {{- else }}
 	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 {{- end }}
+{{ GoCodeSetResourceIdentifiers .CRD "r.ko" "res" 1}}
 	return nil
 }

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -74,14 +74,6 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
-{{- if $idField := .CRD.SpecIdentifierField }}
-	if identifier.NameOrID == nil {
-		return ackerrors.MissingNameIdentifier
-	}
-	r.ko.Spec.{{ $idField }} = identifier.NameOrID
-{{- else }}
-	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
-{{- end }}
-{{ GoCodeSetResourceIdentifiers .CRD "r.ko" "res" 1}}
+{{- GoCodeSetResourceIdentifiers .CRD "identifier" "r.ko" 1}}
 	return nil
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/842

Description of changes:
This pull request introduces a smarter system for detecting resource primary identifiers by using the fields from the `ReadOne` (or optionally `ReadMany`) operations.
It detects if a field is attempting to use the resource ARN and will set the status metadata to the corresponding identifier element. Otherwise, it will search through each of the required fields in the operation to attempt to identify the "primary" identifier field (such as `*Name`, `Name`, `*ID`). All other fields in the operation can be configured through the use of the new `AdditionalKeys` map (https://github.com/aws-controllers-k8s/runtime/pull/13/files). Optionally, the primary identifier field can be configured in the generator under `operations.<operation>.primary_identifier_field_name` if one cannot be (or is incorrectly) identified.

Example output from `applicationautoscaling` `ScalingPolicy`:
```golang
func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
	if identifier.NameOrID == nil {
		return ackerrors.MissingNameIdentifier
	}
	r.ko.Spec.ResourceID = identifier.NameOrID

	f0, f0ok := identifier.AdditionalKeys["scalableDimension"]
	if f0ok {
		r.ko.Spec.ScalableDimension = f0
	}
	f1, f1ok := identifier.AdditionalKeys["serviceNamespace"]
	if f1ok {
		r.ko.Spec.ServiceNamespace = f1
	}

	return nil
}
```

Example output from `mq` `Broker`:
```golang
func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
	if identifier.NameOrID == nil {
		return ackerrors.MissingNameIdentifier
	}
	r.ko.Status.BrokerID = identifier.NameOrID

	return nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
