### PR TITLE
Copy `generator.yaml` to apis/version directory

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -24,6 +24,7 @@ import (
 	generate "github.com/aws-controllers-k8s/code-generator/pkg/generate"
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
 type contentType int
@@ -65,7 +66,19 @@ func saveGeneratedMetadata(cmd *cobra.Command, args []string) error {
 		optAWSSDKGoVersion,
 		optGeneratorConfigPath,
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("cannot create generation metadata file: %v", err)
+	}
+
+	copyDest := filepath.Join(
+		optOutputPath, "apis", optGenVersion, "generator.yaml",
+	)
+	err = util.CopyFile(optGeneratorConfigPath, copyDest)
+	if err != nil {
+		return fmt.Errorf("cannot copy generator configuration file: %v", err)
+	}
+
+	return nil
 }
 
 // generateAPIs generates the Go files for each resource in the AWS service

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -13,10 +13,40 @@
 
 package util
 
-import "os"
+import (
+	"io"
+	"os"
+)
 
 // FileExists returns True if the supplied file path exists, false otherwise
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
+}
+
+// CopyFile copies a file from a source path to a destination path.
+func CopyFile(src, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	err = destFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Part of aws-controllers-k8s/community#835

Adding some logic to create copies of the `generator.yaml` within the
apis versions directories. These generator.yaml files we be reused by
the conversion webhook generator to understand the difference between
each two different API versions.

This patch Also adds a new utility function to copy files from a
source to a destination path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
