### PR TITLE
Bump ack-generate `VERSION` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.2.3"
+VERSION ?= "v0.3.1"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator


### PR DESCRIPTION
Description of changes:
- Bump `ack-generate` version in Makefile

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
