### PR TITLE
Returning the latest resource from the Delete() call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.4.0"
+VERSION ?= "v0.5.0"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.4.0
+	github.com/aws-controllers-k8s/runtime v0.5.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -129,11 +129,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.


### PR DESCRIPTION
Issue #, if available:

aws-controllers-k8s/community#836

Description of changes:

This PR is to related to https://github.com/aws-controllers-k8s/runtime/pull/21
It makes the code-generator changes for delete api as discussed under: https://github.com/aws-controllers-k8s/runtime/pull/21#discussion_r655729649

Testing:
* `make test` passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
