### PR TITLE
Correct type mismatch errors in `SetResourceIdentifiers` generated code

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -844,7 +844,7 @@ func SetResourceIdentifiers(
 
 	indent := strings.Repeat("\t", indentLevel)
 
-	primaryKeyOut += fmt.Sprintf("%sif %s.NameOrID == nil {\n", indent, sourceVarName)
+	primaryKeyOut += fmt.Sprintf("%sif %s.NameOrID == \"\" {\n", indent, sourceVarName)
 	primaryKeyOut += fmt.Sprintf("%s\treturn ackerrors.MissingNameIdentifier\n", indent)
 	primaryKeyOut += fmt.Sprintf("%s}\n", indent)
 
@@ -940,7 +940,7 @@ func SetResourceIdentifiers(
 
 		if isPrimaryIdentifier {
 			// r.ko.Status.BrokerID = identifier.NameOrID
-			primaryKeyOut += fmt.Sprintf("%s%s%s.%s = %s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
+			primaryKeyOut += fmt.Sprintf("%s%s%s.%s = &%s.NameOrID\n", indent, targetVarName, memberPath, cleanMemberName, sourceVarName)
 		} else {
 			// f0, f0ok := identifier.AdditionalKeys["scalableDimension"]
 			// if f0ok {
@@ -954,7 +954,7 @@ func SetResourceIdentifiers(
 			// throwing an error accessible to the user
 			additionalKeyOut += fmt.Sprintf("%s%s, %sok := %s\n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
 			additionalKeyOut += fmt.Sprintf("%sif %sok {\n", indent, fieldIndexName)
-			additionalKeyOut += fmt.Sprintf("%s\t%s%s.%s = %s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
+			additionalKeyOut += fmt.Sprintf("%s\t%s%s.%s = &%s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s}\n", indent)
 
 			additionalKeyCount++

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2656,10 +2656,10 @@ func TestSetResource_MQ_Broker_SetResourceIdentifiers(t *testing.T) {
 	require.NotNil(crd)
 
 	expected := `
-	if identifier.NameOrID == nil {
+	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Status.BrokerID = identifier.NameOrID
+	r.ko.Status.BrokerID = &identifier.NameOrID
 
 `
 	assert.Equal(
@@ -2678,10 +2678,10 @@ func TestSetResource_RDS_DBInstances_SetResourceIdentifiers(t *testing.T) {
 	require.NotNil(crd)
 
 	expected := `
-	if identifier.NameOrID == nil {
+	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.DBInstanceIdentifier = identifier.NameOrID
+	r.ko.Spec.DBInstanceIdentifier = &identifier.NameOrID
 
 `
 	assert.Equal(
@@ -2700,14 +2700,14 @@ func TestSetResource_APIGWV2_ApiMapping_SetResourceIdentifiers(t *testing.T) {
 	require.NotNil(crd)
 
 	expected := `
-	if identifier.NameOrID == nil {
+	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Status.APIMappingID = identifier.NameOrID
+	r.ko.Status.APIMappingID = &identifier.NameOrID
 
 	f0, f0ok := identifier.AdditionalKeys["domainName"]
 	if f0ok {
-		r.ko.Spec.DomainName = f0
+		r.ko.Spec.DomainName = &f0
 	}
 `
 	assert.Equal(


### PR DESCRIPTION
Related to https://github.com/aws-controllers-k8s/code-generator/pull/105 and https://github.com/aws-controllers-k8s/runtime/pull/13

Description of changes:
- replace nil pointer checks with string zero value checks
- replace `string` value assignment with `string` ptr assignments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
