### PR TITLE
Add primary identifiers for `ReadMany` operations

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -860,8 +860,11 @@ func SetResourceIdentifiers(
 	if primaryIdentifier == "" {
 		primaryIdentifierLookup := []string{
 			"Name",
+			"Names",
 			r.Names.Original + "Name",
+			r.Names.Original + "Names",
 			r.Names.Original + "Id",
+			r.Names.Original + "Ids",
 		}
 
 		for _, memberName := range inputShape.MemberNames() {


### PR DESCRIPTION
Related to https://github.com/aws-controllers-k8s/code-generator/pull/115

For some controllers we use `ReadMany` operations to read resource current
state. For these operations we need to lookup for identifiers ending with 
`Names` and not `Name`. e.g `RepositoryNames` in `DescribeRepositories`
operation.

Description of changes:
- Add primary identifiers for `ReadMany` operations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
