### PR TITLE
handle renamed fields for resource identifiers

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -922,21 +922,25 @@ func SetResourceIdentifiers(
 			continue
 
 		}
+		// Check that the field has potentially been renamed
+		renamedName, _ := r.InputFieldRename(
+			op.Name, memberName,
+		)
 
 		isPrimaryIdentifier := memberName == primaryIdentifier
-		cleanMemberNames := names.New(memberName)
+		cleanMemberNames := names.New(renamedName)
 		cleanMemberName := cleanMemberNames.Camel
 
 		memberPath := ""
-		_, inSpec := r.SpecFields[memberName]
-		_, inStatus := r.StatusFields[memberName]
+		_, inSpec := r.SpecFields[renamedName]
+		_, inStatus := r.StatusFields[renamedName]
 		switch {
 		case inSpec:
 			memberPath = cfg.PrefixConfig.SpecField
 		case inStatus:
 			memberPath = cfg.PrefixConfig.StatusField
 		case isPrimaryIdentifier:
-			panic("Primary identifier field '" + memberName + "' cannot be found in either spec or status.")
+			panic("Primary identifier field '" + memberName + "' in operation '" + op.Name + "' cannot be found in either spec or status.")
 		default:
 			continue
 		}

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2690,6 +2690,30 @@ func TestSetResource_RDS_DBInstances_SetResourceIdentifiers(t *testing.T) {
 	)
 }
 
+func TestSetResource_RDS_DBSubnetGroup_SetResourceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "rds")
+
+	crd := testutil.GetCRDByName(t, g, "DBSubnetGroup")
+	require.NotNil(crd)
+
+	// In our testdata generator.yaml file, we've renamed the original
+	// DBSubnetGroupName to just Name...
+	expected := `
+	if identifier.NameOrID == "" {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.Name = &identifier.NameOrID
+
+`
+	assert.Equal(
+		expected,
+		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
+	)
+}
+
 func TestSetResource_APIGWV2_ApiMapping_SetResourceIdentifiers(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
The code that outputs Go code that sets `Spec` or `Status` fields to a
resource identifier field was not accounting for cases where we renamed
the field. Such is the case for many of the RDS controller's resources,
since all the identifier fields for all resources are "de-stuttured" by
renaming, for example, `DBSubnetGroupName` to just `Name` or
`DBClusterParameterGroupName` to just `Name`.

This patch simply ensures we account for renamed fields in the Spec and
Status during calls to `pkg/generate/code.SetResourceIdentifiers` and
adds a unit test to ensure we don't regress in the future.

Issue aws-controllers-k8s/community#852

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
