### PR TITLE
Graceful cancellation for network dependent commands

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -91,7 +92,9 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if optOutputPath == "" {
 		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
-	if err := ensureSDKRepo(optCacheDir, optRefreshCache); err != nil {
+	ctx, cancel := contextWithSigterm(context.Background())
+	defer cancel()
+	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
 	sdkHelper := model.NewSDKHelper(sdkDir)

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -15,6 +15,7 @@ package command
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -57,7 +58,9 @@ func generateController(cmd *cobra.Command, args []string) error {
 		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 
-	if err := ensureSDKRepo(optCacheDir, optRefreshCache); err != nil {
+	ctx, cancel := contextWithSigterm(context.Background())
+	defer cancel()
+	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)

--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -49,7 +50,9 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("please specify the service alias for the AWS service API to generate")
 	}
-	if err := ensureSDKRepo(optCacheDir, optRefreshCache); err != nil {
+	ctx, cancel := contextWithSigterm(context.Background())
+	defer cancel()
+	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
 	svcAlias := strings.ToLower(args[0])

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -81,7 +82,9 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	version := args[1]
 
 	// get the generator inputs
-	if err := ensureSDKRepo(optCacheDir, optRefreshCache); err != nil {
+	ctx, cancel := contextWithSigterm(context.Background())
+	defer cancel()
+	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -65,7 +66,9 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	// version supplied hasn't been used (as a Git tag) before...
 	releaseVersion := strings.ToLower(args[1])
 
-	if err := ensureSDKRepo(optCacheDir, optRefreshCache); err != nil {
+	ctx, cancel := contextWithSigterm(context.Background())
+	defer cancel()
+	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)


### PR DESCRIPTION
Issue N/A

`ack-generate` uses go-git to clone and fetch repository tags, these
actions are time consuming (more than a minute for cloning) and do
not tolerate interruption (ctrl+C). Forcing a command to exit when it's
running a `git.Clone` or a `git.FetchTags` cause the process to write
incomplete data on disk,  therefore re-running `ack-generate` will
always return an error. The only solution for this problem is to delete
the local sdk cache and let `ack-generate` reclone (without interruption)

This patch adds a graceful cancellation system for `ack-generate`
subcommads. Which will allow users to safely ctrl+C and re-run their
commands without any errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
