### PR TITLE
Add a new sort option for `kubebuilder:printcolumns` marker comments

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -128,6 +128,12 @@ type PrintFieldConfig struct {
 	// view (using the -o wide flag). Fields with priority 0 are shown in standard view.
 	// Fields with priority greater than 0 are only shown in wide view. Default is 0
 	Priority int `json:"priority"`
+	// Index informs the code generator about the position/order of a specific field/column in
+	// `kubectl get` response. To enable ordering by index, `$resource.print.orderBy` must be set
+	// to `index`
+	// The field with the smallest index will be right next to the first column (NAME).
+	// The field with the biggest index will be positioned right before the last column (AGE).
+	Index int `json:"index"`
 }
 
 // FieldConfig contains instructions to the code generator about how

--- a/pkg/model/printer_column.go
+++ b/pkg/model/printer_column.go
@@ -26,6 +26,7 @@ type PrinterColumn struct {
 	Type     string
 	Priority int
 	JSONPath string
+	Index    int
 }
 
 // By can sort two PrinterColumns
@@ -64,7 +65,6 @@ func (pcs printerColumnSorter) Less(i, j int) bool {
 // sortFunction returns a Go function used the sort the printer columns.
 func sortFunction(sortByField string) func(a, b *PrinterColumn) bool {
 	switch strings.ToLower(sortByField) {
-	//TODO(a-hially): add Priority and Order sort functions
 	case "name":
 		return func(a, b *PrinterColumn) bool {
 			return a.Name < b.Name
@@ -77,8 +77,13 @@ func sortFunction(sortByField string) func(a, b *PrinterColumn) bool {
 		return func(a, b *PrinterColumn) bool {
 			return a.JSONPath < b.JSONPath
 		}
+	case "index":
+		return func(a, b *PrinterColumn) bool {
+			return a.Index < b.Index
+		}
 	default:
-		msg := fmt.Sprintf("unknown sort-by field: '%s'. must be one of 'Name', 'Type' and 'JSONPath'", sortByField)
+		msg := fmt.Sprintf("unknown sort-by field: '%s'. must be one of 'Name',"+
+			" 'Type', 'JSONPath' and 'Index'", sortByField)
 		panic(msg)
 	}
 }
@@ -143,6 +148,7 @@ func (r *CRD) addPrintableColumn(
 		Type:     printColumnType,
 		Priority: field.FieldConfig.Print.Priority,
 		JSONPath: jsonPath,
+		Index:    field.FieldConfig.Print.Index,
 	}
 	r.additionalPrinterColumns = append(r.additionalPrinterColumns, column)
 }


### PR DESCRIPTION
Issue N/A

This patch adds a new option `Index` for print column configuration.
Setting an index for a field and `resource.print.sortBy` to `index` will
intruct the code generator to sort the `kubebuilder:printcolumns` by the
`Index` value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
