### PR TITLE
Migrate image build and release scripts from `community`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Base image to use for the final stage
+ARG base_image=amazonlinux:2
+# Build the manager binary
+FROM golang:1.14.1 as builder
+
+ARG service_alias
+# The tuple of controller image version information
+ARG service_controller_git_version
+ARG service_controller_git_commit
+ARG build_date
+# The directory within the builder container into which we will copy our
+# service controller code.
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR $work_dir
+# For building Go Module required
+ENV GOPROXY=direct
+ENV GO111MODULE=on
+ENV GOARCH=amd64
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version
+# Copy the Go Modules manifests and LICENSE/ATTRIBUTION
+COPY $service_alias-controller/LICENSE $work_dir/LICENSE
+COPY $service_alias-controller/ATTRIBUTION.md $work_dir/ATTRIBUTION.md
+# Copy Go mod files
+COPY $service_alias-controller/go.mod $work_dir/go.mod
+COPY $service_alias-controller/go.sum $work_dir/go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Now copy the go source code for the controller...
+COPY $service_alias-controller/apis $work_dir/apis
+COPY $service_alias-controller/cmd $work_dir/cmd
+COPY $service_alias-controller/pkg $work_dir/pkg
+# Build
+RUN GIT_VERSION=$service_controller_git_version && \
+    GIT_COMMIT=$service_controller_git_commit && \
+    BUILD_DATE=$build_date && \
+    go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
+    -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
+    -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
+
+FROM $base_image
+ARG service_alias
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR /
+COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
+ENTRYPOINT ["/bin/controller"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,62 @@
+# Base image to use at runtime
+ARG base_image=amazonlinux:2
+# Build the manager binary
+FROM golang:1.14.1 as builder
+
+ARG service_alias
+# The tuple of controller image version information
+ARG service_controller_git_version
+ARG service_controller_git_commit
+ARG build_date
+# The directory within the builder container into which we will copy our
+# service controller code.
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR $work_dir
+# For building Go Module required
+ENV GOPROXY=https://proxy.golang.org,direct
+ENV GO111MODULE=on
+ENV GOARCH=amd64
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version
+# Copy the Go Modules manifests and LICENSE/ATTRIBUTION
+COPY $service_alias-controller/LICENSE $work_dir/LICENSE
+COPY $service_alias-controller/ATTRIBUTION.md $work_dir/ATTRIBUTION.md
+# use local mod files
+COPY $service_alias-controller/go.local.mod $work_dir/go.local.mod
+COPY $service_alias-controller/go.local.sum $work_dir/go.local.sum
+COPY $service_alias-controller/go.mod $work_dir/go.mod
+
+# for local development, copy local runtime repo
+COPY runtime/pkg $work_dir/../runtime/pkg
+COPY runtime/apis $work_dir/../runtime/apis
+COPY runtime/go.mod $work_dir/../runtime/go.mod
+COPY runtime/go.sum $work_dir/../runtime/go.sum
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+WORKDIR $work_dir/../runtime
+RUN  go mod download
+WORKDIR $work_dir
+RUN  go mod download
+
+# Now copy the go source code for the service controller...
+COPY $service_alias-controller/apis $work_dir/apis
+COPY $service_alias-controller/cmd $work_dir/cmd
+COPY $service_alias-controller/pkg $work_dir/pkg
+# Build
+RUN GIT_VERSION=$service_controller_git_version && \
+    GIT_COMMIT=$service_controller_git_commit && \
+    BUILD_DATE=$build_date && \
+    go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
+    -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
+    -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -modfile="${work_dir}/go.local.mod" \
+    -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
+
+FROM $base_image
+ARG service_alias
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR /
+COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
+ENTRYPOINT ["/bin/controller"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ GO_LDFLAGS=-ldflags "-X $(IMPORT_PATH)/pkg/version.Version=$(VERSION) \
 # aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...
 GO_TAGS=-tags codegen
 
-.PHONY: all build-ack-generate build-controller test
+.PHONY: all build-ack-generate build-controller test \
+	build-controller-image local-build-controller-image
 
 all: test
 
@@ -30,6 +31,14 @@ build-ack-generate:	## Build ack-generate binary
 build-controller: build-ack-generate ## Generate controller code for SERVICE
 	@./scripts/install-controller-gen.sh 
 	@./scripts/build-controller.sh $(AWS_SERVICE)
+
+build-controller-image: export LOCAL_MODULES = false
+build-controller-image:	## Build container image for SERVICE
+	@./scripts/build-controller-image.sh $(AWS_SERVICE)
+
+local-build-controller-image: export LOCAL_MODULES = true
+local-build-controller-image:	## Build container image for SERVICE allowing local modules
+	@./scripts/build-controller-image.sh $(AWS_SERVICE)
 
 test: 				## Run code tests
 	go test ${GO_TAGS} ./...

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+ROOT_DIR=$DIR/..
+DOCKERFILE_PATH=$ROOT_DIR/Dockerfile
+ACK_DIR=$ROOT_DIR/..
+DOCKERFILE=${DOCKERFILE:-"$DOCKERFILE_PATH"}
+LOCAL_MODULES=${LOCAL_MODULES:-"false"}
+BUILD_DATE=$(date +%Y-%m-%dT%H:%M)
+QUIET=${QUIET:-"false"}
+
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+source $SCRIPTS_DIR/lib/common.sh
+
+check_is_installed docker
+
+USAGE="
+Usage:
+  $(basename "$0") <aws_service>
+
+Builds the Docker image for an ACK service controller. 
+
+Example: $(basename "$0") ecr
+
+<aws_service> should be an AWS Service name (ecr, sns, sqs, petstore, bookstore)
+
+Environment variables:
+  QUIET:                            Build controller container image quietly (<true|false>)
+                                    Default: false
+  LOCAL_MODULES:                    Enables use of local modules during AWS Service controller docker image build
+                                    Default: false
+  AWS_SERVICE_DOCKER_IMG:           Controller container image tag
+                                    Default: aws-controllers-k8s:\$AWS_SERVICE-\$VERSION
+  SERVICE_CONTROLLER_SOURCE_PATH:   Directory to find the service controller to build an image for.
+                                    Default: ../\$AWS_SERVICE-controller
+"
+
+if [ $# -ne 1 ]; then
+    echo "AWS_SERVICE is not defined. Script accepts one parameter, the <AWS_SERVICE> to build a container image of that service" 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+# Source code for the controller will be in a separate repo, typically in
+# $GOPATH/src/github.com/aws-controllers-k8s/$AWS_SERVICE-controller/
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$AWS_SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+
+if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
+    echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2
+    echo "$SERVICE_CONTROLLER_SOURCE_PATH is not a directory." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+pushd $SERVICE_CONTROLLER_SOURCE_PATH 1>/dev/null
+
+SERVICE_CONTROLLER_GIT_VERSION=`git describe --tags --always --dirty || echo "unknown"`
+SERVICE_CONTROLLER_GIT_COMMIT=`git rev-parse HEAD`
+
+popd 1>/dev/null
+
+DEFAULT_AWS_SERVICE_DOCKER_IMG="aws-controllers-k8s:$AWS_SERVICE-$SERVICE_CONTROLLER_GIT_VERSION"
+AWS_SERVICE_DOCKER_IMG=${AWS_SERVICE_DOCKER_IMG:-"$DEFAULT_AWS_SERVICE_DOCKER_IMG"}
+
+if [[ $QUIET = "false" ]]; then
+    echo "building '$AWS_SERVICE' controller docker image with tag: ${AWS_SERVICE_DOCKER_IMG}"
+    echo " git commit: $SERVICE_CONTROLLER_GIT_COMMIT"
+fi
+
+# if local build
+# then use Dockerfile which allows references to local modules from service controller
+DOCKER_BUILD_CONTEXT="$ACK_DIR"
+if [[ "$LOCAL_MODULES" = "true" ]]; then
+  DOCKERFILE="${ROOT_DIR}"/Dockerfile.local
+fi
+
+docker build \
+  --quiet=${QUIET} \
+  -t "${AWS_SERVICE_DOCKER_IMG}" \
+  -f "${DOCKERFILE}" \
+  --build-arg service_alias=${AWS_SERVICE} \
+  --build-arg service_controller_git_version="$SERVICE_CONTROLLER_GIT_VERSION" \
+  --build-arg service_controller_git_commit="$SERVICE_CONTROLLER_GIT_COMMIT" \
+  --build-arg build_date="$BUILD_DATE" \
+  "${DOCKER_BUILD_CONTEXT}"
+
+if [ $? -ne 0 ]; then
+  exit 2
+fi

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+# A script that builds release artifacts for a single ACK service controller
+# for an AWS service API
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+BIN_DIR="$ROOT_DIR/bin"
+DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
+ACK_GENERATE_OLM=${ACK_GENERATE_OLM:-"false"}
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/helm.sh"
+
+check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
+check_is_installed helm "You can install Helm with the helper scripts/install-helm.sh"
+
+if [[ $ACK_GENERATE_OLM == "true" ]]; then
+    check_is_installed operator-sdk "You can install Operator SDK with the helper scripts/install-operator-sdk.sh"
+fi
+
+if ! k8s_controller_gen_version_equals "$CONTROLLER_TOOLS_VERSION"; then
+    echo "FATAL: Existing version of controller-gen "`controller-gen --version`", required version is $CONTROLLER_TOOLS_VERSION."
+    echo "FATAL: Please uninstall controller-gen and install the required version with scripts/install-controller-gen.sh."
+    exit 1
+fi
+
+ACK_GENERATE_CACHE_DIR=${ACK_GENERATE_CACHE_DIR:-"$HOME/.cache/aws-controllers-k8s"}
+# The ack-generate code generator is in a separate source code repository,
+# typically at $GOPATH/src/github.com/aws-controllers-k8s/code-generator
+DEFAULT_ACK_GENERATE_BIN_PATH="$ROOT_DIR/../../aws-controllers-k8s/code-generator/bin/ack-generate"
+ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
+ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
+ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
+ACK_GENERATE_IMAGE_REPOSITORY=${ACK_GENERATE_IMAGE_REPOSITORY:-"$DEFAULT_IMAGE_REPOSITORY"}
+AWS_SDK_GO_VERSION=${AWS_SDK_GO_VERSION:-"v1.35.5"}
+
+DEFAULT_TEMPLATES_DIR="$ROOT_DIR/../../aws-controllers-k8s/code-generator/templates"
+TEMPLATES_DIR=${TEMPLATES_DIR:-$DEFAULT_TEMPLATES_DIR}
+
+DEFAULT_RUNTIME_DIR="$ROOT_DIR/../runtime"
+RUNTIME_DIR=${RUNTIME_DIR:-$DEFAULT_RUNTIME_DIR}
+RUNTIME_API_VERSION=${RUNTIME_API_VERSION:-"v1alpha1"}
+
+USAGE="
+Usage:
+  $(basename "$0") <service> <release_version>
+
+<service> should be an AWS service API aliases that you wish to build -- e.g.
+'s3' 'sns' or 'sqs'
+
+<release_version> should be the SemVer version tag for the release -- e.g.
+'v0.1.3'
+
+Environment variables:
+  ACK_GENERATE_CACHE_DIR                Overrides the directory used for caching
+                                        AWS API models used by the ack-generate
+                                        tool.
+                                        Default: $ACK_GENERATE_CACHE_DIR
+  ACK_GENERATE_BIN_PATH:                Overrides the path to the the ack-generate
+                                        binary.
+                                        Default: $ACK_GENERATE_BIN_PATH
+  SERVICE_CONTROLLER_SOURCE_PATH:       Path to the service controller source code
+                                        repository.
+                                        Default: ../{SERVICE}-controller
+  ACK_GENERATE_OLM:                     Enable Operator Lifecycle Manager generators.
+                                        Default: false
+  ACK_GENERATE_OLMCONFIG_PATH:          Path to the service OLM configuration file. Ignored
+                                        if ACK_GENERATE_OLM is not true.
+                                        Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm/olmconfig.yaml
+  ACK_GENERATE_CONFIG_PATH:             Specify a path to the generator config YAML file to
+                                        instruct the code generator for the service.
+                                        Default: {SERVICE_CONTROLLER_SOURCE_PATH}/generator.yaml
+  ACK_GENERATE_OUTPUT_PATH:             Specify a path for the generator to output
+                                        to.
+                                        Default: services/{SERVICE}
+  ACK_GENERATE_IMAGE_REPOSITORY:        Specify a Docker image repository to use
+                                        for release artifacts
+                                        Default: $DEFAULT_IMAGE_REPOSITORY
+  ACK_GENERATE_SERVICE_ACCOUNT_NAME:    Name of the Kubernetes Service Account and
+                                        Cluster Role to use in Helm chart.
+                                        Default: $ACK_GENERATE_SERVICE_ACCOUNT_NAME
+  AWS_SDK_GO_VERSION:                   Overrides the version of github.com/aws/aws-sdk-go used
+                                        by 'ack-generate' to fetch the service API Specifications.
+                                        Default: $AWS_SDK_GO_VERSION
+  K8S_RBAC_ROLE_NAME:                   Name of the Kubernetes Role to use when
+                                        generating the RBAC manifests for the
+                                        custom resource definitions.
+                                        Default: $K8S_RBAC_ROLE_NAME
+"
+
+if [ $# -ne 2 ]; then
+    echo "ERROR: $(basename "$0") accepts exactly two parameters, the SERVICE and the RELEASE_VERSION" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+if [ ! -f $ACK_GENERATE_BIN_PATH ]; then
+    if is_installed "ack-generate"; then
+        ACK_GENERATE_BIN_PATH=$(which "ack-generate")
+    else
+        echo "ERROR: Unable to find an ack-generate binary.
+Either set the ACK_GENERATE_BIN_PATH to a valid location or
+run:
+ 
+   make build-ack-generate
+ 
+from the root directory or install ack-generate using:
+
+   go get -u github.com/aws/aws-controllers-k8s/cmd/ack-generate" 1>&2
+        exit 1;
+    fi
+fi
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+# Source code for the controller will be in a separate repo, typically in
+# $GOPATH/src/github.com/aws-controllers-k8s/$AWS_SERVICE-controller/
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+
+if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
+    echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2
+    echo "$SERVICE_CONTROLLER_SOURCE_PATH is not a directory." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+RELEASE_VERSION="$2"
+K8S_RBAC_ROLE_NAME=${K8S_RBAC_ROLE_NAME:-"ack-$SERVICE-controller"}
+ACK_GENERATE_SERVICE_ACCOUNT_NAME=${ACK_GENERATE_SERVICE_ACCOUNT_NAME:-"ack-$SERVICE-controller"}
+
+# If there's a generator.yaml in the service's directory and the caller hasn't
+# specified an override, use that.
+if [ -z "$ACK_GENERATE_CONFIG_PATH" ]; then
+    if [ -f "$SERVICE_CONTROLLER_SOURCE_PATH/generator.yaml" ]; then
+        ACK_GENERATE_CONFIG_PATH="$SERVICE_CONTROLLER_SOURCE_PATH/generator.yaml"
+    fi
+fi
+
+helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
+ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --aws-sdk-go-version $AWS_SDK_GO_VERSION"
+if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
+    ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
+fi
+if [ -n "$ACK_GENERATE_OUTPUT_PATH" ]; then
+    ag_args="$ag_args --output $ACK_GENERATE_OUTPUT_PATH"
+    helm_output_dir="$ACK_GENERATE_OUTPUT_PATH/helm"
+fi
+if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
+    ag_args="$ag_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
+fi
+if [ -n "$ACK_GENERATE_IMAGE_REPOSITORY" ]; then
+    ag_args="$ag_args --image-repository $ACK_GENERATE_IMAGE_REPOSITORY"
+fi
+if [ -n "$ACK_GENERATE_SERVICE_ACCOUNT_NAME" ]; then
+    ag_args="$ag_args --service-account-name $ACK_GENERATE_SERVICE_ACCOUNT_NAME"
+fi
+
+echo "Building release artifacts for $SERVICE-$RELEASE_VERSION"
+$ACK_GENERATE_BIN_PATH release $ag_args
+
+pushd $RUNTIME_DIR/apis/core/$RUNTIME_API_VERSION 1>/dev/null
+
+echo "Generating common custom resource definitions"
+controller-gen crd:allowDangerousTypes=true paths=./... output:crd:artifacts:config=$helm_output_dir/crds
+
+popd 1>/dev/null
+
+pushd $SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION 1>/dev/null
+
+echo "Generating custom resource definitions for $SERVICE"
+controller-gen crd:allowDangerousTypes=true paths=./... output:crd:artifacts:config=$helm_output_dir/crds
+
+popd 1>/dev/null
+
+pushd $SERVICE_CONTROLLER_SOURCE_PATH/pkg/resource 1>/dev/null
+
+echo "Generating RBAC manifests for $SERVICE"
+controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifacts:config=$helm_output_dir/templates
+# controller-gen rbac outputs a ClusterRole definition in a
+# $config_output_dir/rbac/role.yaml file. We have some other standard Role
+# files for a reader and writer role, so here we rename the `role.yaml` file to
+# `cluster-role-controller.yaml` to better reflect what is in that file.
+mv $helm_output_dir/templates/role.yaml $helm_output_dir/templates/cluster-role-controller.yaml
+
+popd 1>/dev/null
+
+if [[ $ACK_GENERATE_OLM == "true" ]]; then
+    echo "Generating operator lifecycle manager bundle assets for $SERVICE"
+
+    DEFAULT_ACK_GENERATE_OLMCONFIG_PATH="$SERVICE_CONTROLLER_SOURCE_PATH/olm/olmconfig.yaml"
+    ACK_GENERATE_OLMCONFIG_PATH=${ACK_GENERATE_OLMCONFIG_PATH:-$DEFAULT_ACK_GENERATE_OLMCONFIG_PATH}
+
+    olm_version=$(echo $RELEASE_VERSION | tr -d "v")
+    ag_olm_args="$SERVICE $olm_version -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --olm-config $ACK_GENERATE_OLMCONFIG_PATH --aws-sdk-go-version $AWS_SDK_GO_VERSION"
+
+    if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
+        ag_olm_args="$ag_olm_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
+    fi
+
+    $ACK_GENERATE_BIN_PATH olm $ag_olm_args
+fi

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -13,7 +13,6 @@ ACK_GENERATE_OLM=${ACK_GENERATE_OLM:-"false"}
 
 source "$SCRIPTS_DIR/lib/common.sh"
 source "$SCRIPTS_DIR/lib/k8s.sh"
-source "$SCRIPTS_DIR/lib/helm.sh"
 
 check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
 check_is_installed helm "You can install Helm with the helper scripts/install-helm.sh"


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/860

Description of changes:
Migrates the `build-controller-image` and `build-controller-release` scripts and Makefile targets from the `community` repository. Also migrates the `Dockerfile` and `Dockerfile.local` files for building the release images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
