### PR TITLE
Mark status fields as optional

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -30,16 +30,19 @@ type {{ .CRD.Kind }}Status struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
 	{{- if $field.ShapeRef }}
 	{{ $field.ShapeRef.Documentation }}
 	{{- end }}
+	// +kubebuilder:validation:Optional
 	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
 {{- end }}
 }


### PR DESCRIPTION
Issue N/A

Description of changes:
- Mark status fields as optional using `+kubebuilder:validation:Optional` marker comment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
