### PR TITLE
Add script and Github workflow for ensuring version in sync

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,0 +1,21 @@
+name: version-check
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Makefile
+      - go.mod
+
+jobs:
+  version-check:
+    name: runtime version in-sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - name: make check-versions
+        run: make check-versions

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ local-build-controller-image: export LOCAL_MODULES = true
 local-build-controller-image:	## Build container image for SERVICE allowing local modules
 	@./scripts/build-controller-image.sh $(AWS_SERVICE)
 
+check-versions: ## Checks the code-generator version matches the runtime dependency version
+	@./scripts/check-versions.sh $(VERSION)
+
 test: 				## Run code tests
 	go test ${GO_TAGS} ./...
 

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -31,7 +31,7 @@ if [ $# -ne 1 ]; then
 fi
 
 RUNTIME_DEPENDENCY_VERSION="aws-controllers-k8s/runtime"
-GO_MOD_VERSION=$(cat go.mod | grep $RUNTIME_DEPENDENCY_VERSION | cut -d ' ' -f2)
+GO_MOD_VERSION=$(go list -m -f '{{ .Version }}' github.com/aws-controllers-k8s/runtime)
 
 if [[ "$1" != "$GO_MOD_VERSION" ]]; then
     echo "Code-generator version in Makefile $1 does not match $RUNTIME_DEPENDENCY_VERSION version $GO_MOD_VERSION"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# A script that ensures the code-generator binary version matches its associated
+# runtime version
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+DEFAULT_GO_MOD_PATH="$ROOT_DIR/go.mod"
+GO_MOD_PATH=${GO_MOD_PATH:-$DEFAULT_GO_MOD_PATH}
+
+USAGE="
+Usage:
+  $(basename "$0") <Makefile version>
+
+Checks that the code-generator version located in the Makefile matches the
+runtime version pinned in go.mod
+
+Environment variables:
+  GO_MOD_PATH:              Overrides the path to the go.mod file containing the
+                            pinned runtime version.
+                            Default: $DEFAULT_GO_MOD_PATH
+"
+
+if [ $# -ne 1 ]; then
+    echo "ERROR: $(basename "$0") only accepts a single parameter" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+RUNTIME_DEPENDENCY_VERSION="aws-controllers-k8s/runtime"
+GO_MOD_VERSION=$(cat go.mod | grep $RUNTIME_DEPENDENCY_VERSION | cut -d ' ' -f2)
+
+if [[ "$1" != "$GO_MOD_VERSION" ]]; then
+    echo "Code-generator version in Makefile $1 does not match $RUNTIME_DEPENDENCY_VERSION version $GO_MOD_VERSION"
+    exit 1
+fi
+
+exit 0

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -8,20 +8,12 @@ set -eo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 
-DEFAULT_GO_MOD_PATH="$ROOT_DIR/go.mod"
-GO_MOD_PATH=${GO_MOD_PATH:-$DEFAULT_GO_MOD_PATH}
-
 USAGE="
 Usage:
   $(basename "$0") <Makefile version>
 
 Checks that the code-generator version located in the Makefile matches the
 runtime version pinned in go.mod
-
-Environment variables:
-  GO_MOD_PATH:              Overrides the path to the go.mod file containing the
-                            pinned runtime version.
-                            Default: $DEFAULT_GO_MOD_PATH
 "
 
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
Description of changes:
Adds a script that compares the `aws-controllers-k8s/runtime` version listed in the `go.mod` is identical to the `VERSION` variable in the `Makefile`. This way we can ensure the generation metadata is kept in line with the version of the runtime it was built against.

/assign @A-Hilaly 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
