### PR TITLE
Secret errors to be terminal code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.6.0"
+VERSION ?= "v0.7.0"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.6.0
+	github.com/aws-controllers-k8s/runtime v0.7.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.6.0 h1:Up9pn9FfItYiItiSdT+FOfHQNKO8oSb5GU8pKH9JF8E=
-github.com/aws-controllers-k8s/runtime v0.6.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.7.0 h1:A+55gZVCXiO9EUlCz8MCcquMrcyPYzMLUXdpfOiOUDc=
+github.com/aws-controllers-k8s/runtime v0.7.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
@@ -155,4 +156,7 @@ func TestRuntimeDependency(t *testing.T) {
 
 	// ACK runtime 0.6.0 modified pkg/types/AWSResourceManager.Delete signature.
 	require.Implements((*acktypes.AWSResourceManager)(nil), new(fakeRM))
+
+	// ACK runtime 0.7.0 introduced SecretNotFound error.
+	require.NotNil(ackerr.SecretNotFound)
 }

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1009,7 +1009,7 @@ func setSDKForSlice(
 	sourceAttributePath := sourceFieldPath
 	if targetShape.MemberRef.Shape.Type == "structure" {
 		containerFieldName = targetFieldName
-		sourceAttributePath = sourceFieldPath+"."
+		sourceAttributePath = sourceFieldPath + "."
 	}
 	out += setSDKForContainer(
 		cfg, r,

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -281,16 +281,16 @@ type PrintConfig struct {
 // ReconcileConfig describes options for controlling the reconciliation
 // logic for a particular resource.
 type ReconcileConfig struct {
-    // RequeueOnSuccessSeconds indicates the number of seconds after which to requeue a
-    // resource that has been successfully reconciled (i.e. ConditionTypeResourceSynced=true)
-    // This is useful for resources that are long-lived and may have observable status fields
-    // change over time that would be useful to refresh those field values for users.
-    // This field is optional and the default behaviour of the ACK runtime is to not requeue
-    // resources that have been successfully reconciled. Note that all ACK controllers will
-    // *flush and resync their watch caches* every 10 hours by default, which will end up
-    // causing ACK controllers to refresh the status views of all watched resources, but this
-    // behaviour is expensive and may be turned off in future ACK runtime options.
-    RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
+	// RequeueOnSuccessSeconds indicates the number of seconds after which to requeue a
+	// resource that has been successfully reconciled (i.e. ConditionTypeResourceSynced=true)
+	// This is useful for resources that are long-lived and may have observable status fields
+	// change over time that would be useful to refresh those field values for users.
+	// This field is optional and the default behaviour of the ACK runtime is to not requeue
+	// resources that have been successfully reconciled. Note that all ACK controllers will
+	// *flush and resync their watch caches* every 10 hours by default, which will end up
+	// causing ACK controllers to refresh the status views of all watched resources, but this
+	// behaviour is expensive and may be turned off in future ACK runtime options.
+	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
 }
 
 // ResourceConfig returns the ResourceConfig for a given named resource

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -212,16 +212,21 @@ func (rm *resourceManager) updateConditions (
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type:   ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present


### PR DESCRIPTION
For now secret errors would be terminal code to
be consistent with ACK behavior.

```
  Conditions:
    Message:  kubernetes secret not found
    Status:   True
    Type:     ACK.Terminal
```

Runtime PR - https://github.com/aws-controllers-k8s/runtime/pull/33

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
