### PR TITLE
Add AWS_ENDPOINT_URL to Helm chart templates 

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
         - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
+        - --aws-endpoint-url
+        - "$(AWS_ENDPOINT_URL)"
         - --enable-development-logging
         - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
         - --log-level
@@ -64,6 +66,8 @@ spec:
           value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
+        - name: AWS_ENDPOINT_URL
+          value: {{ .Values.aws.endpoint_url | quote}}
         - name: ACK_WATCH_NAMESPACE
           value: {{ .Values.watchNamespace }}
         - name: ACK_ENABLE_DEVELOPMENT_LOGGING

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -37,6 +37,7 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   account_id: ""
+  endpoint_url: ""
 
 # log level for the controller
 log:


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/871

Description of changes:
Updates `codegenerator/templates/helm/templates/deployment.yaml.tpl` and `codegenerator/templates/helm/values.yaml.tpl `to support `AWS_ENDPOINT_URL`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
