### PR TITLE
Update for helm charts to use latest ecr-public repository.

### DIFF
--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -40,7 +40,7 @@ var releaseCmd = &cobra.Command{
 
 func init() {
 	releaseCmd.PersistentFlags().StringVar(
-		&optImageRepository, "image-repository", "amazon/aws-controllers-k8s", "the Docker image repository to use in release artifacts.",
+		&optImageRepository, "image-repository", "", "the Docker image repository to use in release artifacts. Defaults to 'public.ecr.aws/aws-controllers-k8s/$service-controller'",
 	)
 	releaseCmd.PersistentFlags().StringVar(
 		&optServiceAccountName, "service-account-name", "default", "The name of the ServiceAccount AND ClusterRole used for ACK service controller",
@@ -60,6 +60,9 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	svcAlias := strings.ToLower(args[0])
 	if optReleaseOutputPath == "" {
 		optReleaseOutputPath = filepath.Join(optServicesDir, svcAlias)
+	}
+	if optImageRepository == "" {
+		optImageRepository = fmt.Sprintf("public.ecr.aws/aws-controllers-k8s/%s-controller", svcAlias)
 	}
 	// TODO(jaypipes): We could do some git-fu here to verify that the release
 	// version supplied hasn't been used (as a Git tag) before...

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -8,7 +8,6 @@ set -eo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
-DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
 ACK_GENERATE_OLM=${ACK_GENERATE_OLM:-"false"}
 
 source "$SCRIPTS_DIR/lib/common.sh"
@@ -35,7 +34,6 @@ ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
 ACK_METADATA_CONFIG_PATH=${ACK_METADATA_CONFIG_PATH:-""}
-ACK_GENERATE_IMAGE_REPOSITORY=${ACK_GENERATE_IMAGE_REPOSITORY:-"$DEFAULT_IMAGE_REPOSITORY"}
 AWS_SDK_GO_VERSION=${AWS_SDK_GO_VERSION:-"v1.35.5"}
 
 DEFAULT_TEMPLATES_DIR="$ROOT_DIR/../../aws-controllers-k8s/code-generator/templates"
@@ -82,7 +80,7 @@ Environment variables:
                                         Default: services/{SERVICE}
   ACK_GENERATE_IMAGE_REPOSITORY:        Specify a Docker image repository to use
                                         for release artifacts
-                                        Default: $DEFAULT_IMAGE_REPOSITORY
+                                        Default: public.ecr.aws/u2r4f3v7/{SERVICE}-controller
   ACK_GENERATE_SERVICE_ACCOUNT_NAME:    Name of the Kubernetes Service Account and
                                         Cluster Role to use in Helm chart.
                                         Default: $ACK_GENERATE_SERVICE_ACCOUNT_NAME
@@ -123,6 +121,10 @@ SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 # $GOPATH/src/github.com/aws-controllers-k8s/$AWS_SERVICE-controller/
 DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$SERVICE-controller"
 SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+
+# TODO(vijat@): replace "u2r4f3v7" with aws-controllers-k8s
+DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/u2r4f3v7/$SERVICE-controller"
+ACK_GENERATE_IMAGE_REPOSITORY=${ACK_GENERATE_IMAGE_REPOSITORY:-"$DEFAULT_IMAGE_REPOSITORY"}
 
 if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2

--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: ack-{{ .ServiceIDClean }}-controller
+name: {{ .ServiceIDClean }}-chart
 description: A Helm chart for the ACK service controller for {{ .ServiceIDClean }}
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -4,7 +4,7 @@
 
 image:
   repository: {{ .ImageRepository }}
-  tag: {{ .ServiceIDClean }}-{{ .ReleaseVersion }}
+  tag: {{ .ReleaseVersion }}
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/829

Description of changes:
* Update `build-controller-release` script to use latest ecr-public repository as image repository
* Update Chart.yaml.tpl for chart name so that helm charts can be properly added as dependencies. (Fixing helm chart semver issue)
* Update values.yaml.tpl to form image url correctly due to latest changes

------

make test successful

```
➜  code-generator git:(new-ecr) make test
go test -tags codegen ./...
?       github.com/aws-controllers-k8s/code-generator/cmd/ack-generate  [no test files]
?       github.com/aws-controllers-k8s/code-generator/cmd/ack-generate/command  [no test files]
ok      github.com/aws-controllers-k8s/code-generator/pkg/generate/ack  0.883s
ok      github.com/aws-controllers-k8s/code-generator/pkg/generate/code (cached)
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/config       [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/crossplane   [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/olm  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/metadata      [no test files]
ok      github.com/aws-controllers-k8s/code-generator/pkg/model (cached)
ok      github.com/aws-controllers-k8s/code-generator/pkg/model/multiversion    (cached)
ok      github.com/aws-controllers-k8s/code-generator/pkg/names (cached)
?       github.com/aws-controllers-k8s/code-generator/pkg/testutil      [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/util  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/version       [no test files]

```

------

latest generated ecr dummy helm artifacts:

```
➜  code-generator git:(new-ecr) ✗ ./scripts/build-controller-release.sh ecr v0.0.9
Building release artifacts for ecr-v0.0.9
Generating common custom resource definitions
Generating custom resource definitions for ecr
Generating RBAC manifests for ecr
```

```
Chart.yaml

apiVersion: v1
name: ecr-chart
description: A Helm chart for the ACK service controller for ecr
version: v0.0.9
appVersion: v0.0.9
home: https://github.com/aws-controllers-k8s/ecr-controller
icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
sources:
  - https://github.com/aws-controllers-k8s/ecr-controller
maintainers:
  - name: ACK Admins
    url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
  - name: ecr Admins
    url: https://github.com/orgs/aws-controllers-k8s/teams/ecr-maintainer
keywords:
  - aws
  - kubernetes
  - ecr

```

```
values.yaml

# Default values for ack-ecr-controller.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

image:
  repository: public.ecr.aws/u2r4f3v7/ecr-controller
  tag: v0.0.9
  pullPolicy: IfNotPresent
  pullSecrets: []

nameOverride: ""
fullnameOverride: ""

deployment:
  annotations: {}
  labels: {}
  containerPort: 8080

metrics:
  service:
    # Set to true to automatically create a Kubernetes Service resource for the
    # Prometheus metrics server endpoint in controller
    create: false
    # Which Type to use for the Kubernetes Service?
    # See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
    type: "ClusterIP"

resources:
  requests:
    memory: "64Mi"
    cpu: "50m"
  limits:
    memory: "128Mi"
    cpu: "100m"

aws:
  # If specified, use the AWS region for AWS API calls
  region: ""
  account_id: ""
  endpoint_url: ""

# log level for the controller
log:
  enable_development_logging: false
  level: info

# If specified, the service controller will watch for object creation only in the provided namespace
watchNamespace: ""

resourceTags:
  # Configures the ACK service controller to always set key/value pairs tags on resources that it manages.
  - services.k8s.aws/managed=true
  - services.k8s.aws/created=%UTCNOW%
  - services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%

serviceAccount:
  # Specifies whether a service account should be created
  create: true
  # The name of the service account to use.
  name: ack-ecr-controller
  annotations: {}
    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
