### PR TITLE
Initial implementation of AWSResourceManager.LateInitialize() method.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.9.2"
+VERSION ?= "v0.10.0"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.9.2
+	github.com/aws-controllers-k8s/runtime v0.10.0
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.9.2 h1:53ahm38Cn6DTfQdHNrTgbXmUbCjuKntvhkuWGHkAQ18=
-github.com/aws-controllers-k8s/runtime v0.9.2/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.10.0 h1:MPZ4mPeap2mP/EKU6Pk7a7phiBSYaeZ9QJX38OPecXo=
+github.com/aws-controllers-k8s/runtime v0.10.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -118,6 +118,12 @@ var (
 		"GoCodeSetResourceIdentifiers": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetResourceIdentifiers(r.Config(), r, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeFindLateInitializedFields": func(r *ackmodel.CRD, indentLevel int) string {
+			return code.FindLateInitializedFieldsWithDelay(r.Config(), r, indentLevel)
+		},
+		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, koSourceVarName string, koTargetVarName string, indentLevel int) string {
+			return code.LateInitializeFromReadOne(r.Config(), r, koSourceVarName, koTargetVarName, indentLevel)
+		},
 	}
 )
 

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -124,8 +124,8 @@ var (
 		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, koSourceVarName string, koTargetVarName string, indentLevel int) string {
 			return code.LateInitializeFromReadOne(r.Config(), r, koSourceVarName, koTargetVarName, indentLevel)
 		},
-		"GoCodeCalculateRequeueDelay": func(r *ackmodel.CRD, koVarName string, numLateInitAttemptVarName string, requeueDelayVarName string, incompleteInitializationVarName string, indentLevel int) string {
-			return code.CalculateRequeueDelay(r.Config(), r, koVarName, numLateInitAttemptVarName, requeueDelayVarName, incompleteInitializationVarName, indentLevel)
+		"GoCodeCalculateRequeueDelay": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
+			return code.CalculateRequeueDelay(r.Config(), r, resVarName, indentLevel)
 		},
 	}
 )

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -121,8 +121,8 @@ var (
 		"GoCodeFindLateInitializedFieldNames": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
 			return code.FindLateInitializedFieldNames(r.Config(), r, resVarName, indentLevel)
 		},
-		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, koSourceVarName string, koTargetVarName string, indentLevel int) string {
-			return code.LateInitializeFromReadOne(r.Config(), r, koSourceVarName, koTargetVarName, indentLevel)
+		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, sourceResVarName string, targetResVarName string, indentLevel int) string {
+			return code.LateInitializeFromReadOne(r.Config(), r, sourceResVarName, targetResVarName, indentLevel)
 		},
 		"GoCodeIncompleteLateInitialization": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
 			return code.IncompleteLateInitialization(r.Config(), r, resVarName, indentLevel)

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -124,8 +124,8 @@ var (
 		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, koSourceVarName string, koTargetVarName string, indentLevel int) string {
 			return code.LateInitializeFromReadOne(r.Config(), r, koSourceVarName, koTargetVarName, indentLevel)
 		},
-		"GoCodeCalculateRequeueDelay": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
-			return code.CalculateRequeueDelay(r.Config(), r, resVarName, indentLevel)
+		"GoCodeIncompleteLateInitialization": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
+			return code.IncompleteLateInitialization(r.Config(), r, resVarName, indentLevel)
 		},
 	}
 )

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -118,11 +118,14 @@ var (
 		"GoCodeSetResourceIdentifiers": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetResourceIdentifiers(r.Config(), r, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeFindLateInitializedFields": func(r *ackmodel.CRD, indentLevel int) string {
-			return code.FindLateInitializedFieldsWithDelay(r.Config(), r, indentLevel)
+		"GoCodeFindLateInitializedFieldNames": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
+			return code.FindLateInitializedFieldNames(r.Config(), r, resVarName, indentLevel)
 		},
 		"GoCodeLateInitializeFromReadOne": func(r *ackmodel.CRD, koSourceVarName string, koTargetVarName string, indentLevel int) string {
 			return code.LateInitializeFromReadOne(r.Config(), r, koSourceVarName, koTargetVarName, indentLevel)
+		},
+		"GoCodeCalculateRequeueDelay": func(r *ackmodel.CRD, koVarName string, numLateInitAttemptVarName string, requeueDelayVarName string, incompleteInitializationVarName string, indentLevel int) string {
+			return code.CalculateRequeueDelay(r.Config(), r, koVarName, numLateInitAttemptVarName, requeueDelayVarName, incompleteInitializationVarName, indentLevel)
 		},
 	}
 )

--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -59,6 +59,8 @@ code paths:
 * sdk_file_end
 * delta_pre_compare
 * delta_post_compare
+* late_initialize_pre_read_one
+* late_initialize_post_read_one
 
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE
@@ -101,6 +103,12 @@ compares two resources.
 
 The "delta_post_compare" hooks are called AFTER the generated code that
 compares two resources.
+
+The "late_initialize_pre_read_one" hooks are called BEFORE making the
+readOne call inside AWSResourceManager.LateInitialize() method
+
+The "late_initialize_post_read_one" hooks are called AFTER making the
+readOne call inside AWSResourceManager.LateInitialize() method
 
 */
 

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -30,7 +30,6 @@ import (
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
-	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
@@ -118,7 +117,7 @@ func (frm *fakeRM) Delete(context.Context, acktypes.AWSResource) (acktypes.AWSRe
 
 func (frm *fakeRM) ARNFromName(string) string { return "" }
 
-func (frm *fakeRM) LateInitialize(context.Context, acktypes.AWSResource) (acktypes.AWSResource, *ackrequeue.RequeueNeededAfter) {
+func (frm *fakeRM) LateInitialize(context.Context, acktypes.AWSResource) (acktypes.AWSResource, error) {
 	return nil, nil
 }
 

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -30,6 +30,7 @@ import (
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
@@ -116,6 +117,10 @@ func (frm *fakeRM) Delete(context.Context, acktypes.AWSResource) (acktypes.AWSRe
 }
 
 func (frm *fakeRM) ARNFromName(string) string { return "" }
+
+func (frm *fakeRM) LateInitialize(context.Context, acktypes.AWSResource) (acktypes.AWSResource, *ackrequeue.RequeueNeededAfter) {
+	return nil, nil
+}
 
 // This test is mostly just a hack to introduce a Go module dependency between
 // the ACK runtime library and the code generator. The code generator doesn't

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -27,7 +27,7 @@ import (
 func FindLateInitializedFieldsWithDelay(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
-// Number of levels of indentation to use
+	// Number of levels of indentation to use
 	indentLevel int,
 ) string {
 	//Sample output
@@ -37,18 +37,18 @@ func FindLateInitializedFieldsWithDelay(
 	fieldNameToConfig := cfg.ResourceFields(r.Names.Original)
 	if len(fieldNameToConfig) > 0 {
 		fieldNameToDelaySeconds := make(map[string]int)
-		sortedFieldNames := make([]string, 0)
+		sortedLateInitFieldNames := make([]string, 0)
 		for fName, fConfig := range fieldNameToConfig {
 			if fConfig != nil && fConfig.LateInitialize != nil {
 				fieldNameToDelaySeconds[fName] = fConfig.LateInitialize.DelaySeconds
-				sortedFieldNames = append(sortedFieldNames, fName)
+				sortedLateInitFieldNames = append(sortedLateInitFieldNames, fName)
 			}
 		}
-		sort.Strings(sortedFieldNames)
+		sort.Strings(sortedLateInitFieldNames)
 		lateInitFieldToDelayValues := ""
-		if len(sortedFieldNames) > 0 {
-			for _, fName := range sortedFieldNames {
-				lateInitFieldToDelayValues += fmt.Sprintf("\"%s\":%d,",fName, fieldNameToDelaySeconds[fName])
+		if len(sortedLateInitFieldNames) > 0 {
+			for _, fName := range sortedLateInitFieldNames {
+				lateInitFieldToDelayValues += fmt.Sprintf("%q:%d,", fName, fieldNameToDelaySeconds[fName])
 			}
 			out += fmt.Sprintf("%svar lateInitializeFieldToDelaySeconds = map[string]int{%s}\n", indent, lateInitFieldToDelayValues)
 		}
@@ -56,8 +56,8 @@ func FindLateInitializedFieldsWithDelay(
 	return out
 }
 
-// lateInitializedFieldNames returns the field names which have LateInitialization configuration inside generator config
-func lateInitializedFieldNames(
+// findLateInitializedFieldNames returns the field names which have LateInitialization configuration inside generator config
+func findLateInitializedFieldNames(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 ) []string {
@@ -77,63 +77,65 @@ func lateInitializedFieldNames(
 // Field path separated by '.' indicates members in a struct
 // Field path separated by '..' indicates member/key in a map
 // Note: Unlike Map, updating individual element of a list is not supported. LateInitializing complete list is supported.
-func LateInitializeFromReadOne (
+//
+// Sample generator config:
+// fields:
+//      Name:
+//        late_initialize: {}
+//      ImageScanningConfiguration.ScanOnPush:
+//        late_initialize:
+//          delay_seconds: 5
+//      map..subfield.x:
+//        late_initialize:
+//          delay_seconds: 5
+//      another.map..lastfield:
+//        late_initialize:
+//          delay_seconds: 5
+//      some.list:
+//        late_initialize:
+//          delay_seconds: 10
+//
+// Sample output:
+//if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
+//	if observed.Spec.ImageScanningConfiguration.ScanOnPush != nil && koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush == nil {
+//		koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
+//	}
+//}
+//if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
+//	koWithDefaults.Spec.Name = observed.Spec.Name
+//}
+//if observed.Spec.another != nil && koWithDefaults.Spec.another != nil {
+//	if observed.Spec.another.map != nil && koWithDefaults.Spec.another.map != nil {
+//		if observed.Spec.another.map[lastfield] != nil && koWithDefaults.Spec.another.map[lastfield] == nil {
+//		koWithDefaults.Spec.another.map[lastfield] = observed.Spec.another.map[lastfield]
+//	}
+//	}
+//}
+//if observed.Spec.map != nil && koWithDefaults.Spec.map != nil {
+//	if observed.Spec.map[subfield] != nil && koWithDefaults.Spec.map[subfield] != nil {
+//	if observed.Spec.map[subfield].x != nil && koWithDefaults.Spec.map[subfield].x == nil {
+//	koWithDefaults.Spec.map[subfield].x = observed.Spec.map[subfield].x
+//}
+//}
+//}
+//if observed.Spec.some != nil && koWithDefaults.Spec.some != nil {
+//	if observed.Spec.some.list != nil && koWithDefaults.Spec.some.list == nil {
+//		koWithDefaults.Spec.some.list = observed.Spec.some.list
+//	}
+//}
+func LateInitializeFromReadOne(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 	sourceKoVarName string,
 	targetKoVarName string,
-// Number of levels of indentation to use
+	// Number of levels of indentation to use
 	indentLevel int,
 ) string {
-	// Sample generator config:
-	// fields:
-	//      Name:
-	//        late_initialize: {}
-	//      ImageScanningConfiguration.ScanOnPush:
-	//        late_initialize:
-	//          delay_seconds: 5
-	//      map..subfield.x:
-	//        late_initialize:
-	//          delay_seconds: 5
-	//      another.map..lastfield:
-	//        late_initialize:
-	//          delay_seconds: 5
-	//      some.list:
-	//        late_initialize:
-	//          delay_seconds: 10
-	//
-	// Sample output:
-	//if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
-	//	if observed.Spec.ImageScanningConfiguration.ScanOnPush != nil && koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush == nil {
-	//		koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
-	//	}
-	//}
-	//if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
-	//	koWithDefaults.Spec.Name = observed.Spec.Name
-	//}
-	//if observed.Spec.another != nil && koWithDefaults.Spec.another != nil {
-	//	if observed.Spec.another.map != nil && koWithDefaults.Spec.another.map != nil {
-	//		if observed.Spec.another.map[lastfield] != nil && koWithDefaults.Spec.another.map[lastfield] == nil {
-	//		koWithDefaults.Spec.another.map[lastfield] = observed.Spec.another.map[lastfield]
-	//	}
-	//	}
-	//}
-	//if observed.Spec.map != nil && koWithDefaults.Spec.map != nil {
-	//	if observed.Spec.map[subfield] != nil && koWithDefaults.Spec.map[subfield] != nil {
-	//	if observed.Spec.map[subfield].x != nil && koWithDefaults.Spec.map[subfield].x == nil {
-	//	koWithDefaults.Spec.map[subfield].x = observed.Spec.map[subfield].x
-	//}
-	//}
-	//}
-	//if observed.Spec.some != nil && koWithDefaults.Spec.some != nil {
-	//	if observed.Spec.some.list != nil && koWithDefaults.Spec.some.list == nil {
-	//		koWithDefaults.Spec.some.list = observed.Spec.some.list
-	//	}
-	//}
 	out := ""
-	lateInitializedFieldNames := lateInitializedFieldNames(cfg, r)
+	lateInitializedFieldNames := findLateInitializedFieldNames(cfg, r)
 	// sorting helps produce consistent output for unit test reliability
 	sort.Strings(lateInitializedFieldNames)
+	// TODO(vijat@): Add validation for correct field path in lateInitializedFieldNames
 	for _, fName := range lateInitializedFieldNames {
 		// split the field name by period
 		// each substring represents a field. No support for '..' currently
@@ -146,7 +148,7 @@ func LateInitializeFromReadOne (
 		mapShapedParent := false
 		// for every part except last, perform the nil check
 		// entries in both source and target koVarName should not be nil
-		for i,fNamePart := range fNameParts {
+		for i, fNamePart := range fNameParts {
 			if fNamePart == "" {
 				mapShapedParent = true
 				continue

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -98,8 +98,8 @@ func getSortedLateInitFieldsAndConfig(
 //          min_backoff_seconds: 20
 //
 // Sample output:
-//	observedKo := observed.ko
-//	latestKo := latest.ko
+//	observedKo := rm.concreteResource(observed).ko
+//	latestKo := rm.concreteResource(latest).ko
 //	if observedKo.Spec.ImageScanningConfiguration != nil && latestKo.Spec.ImageScanningConfiguration != nil {
 //		if observedKo.Spec.ImageScanningConfiguration.ScanOnPush != nil && latestKo.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 //			latestKo.Spec.ImageScanningConfiguration.ScanOnPush = observedKo.Spec.ImageScanningConfiguration.ScanOnPush
@@ -151,8 +151,8 @@ func LateInitializeFromReadOne(
 	if len(lateInitializedFieldNames) == 0 {
 		return fmt.Sprintf("%sreturn %s", indent, targetResVarName)
 	}
-	out += fmt.Sprintf("%sobservedKo := %s.ko\n", indent, sourceResVarName)
-	out += fmt.Sprintf("%slatestKo := %s.ko\n", indent, targetResVarName)
+	out += fmt.Sprintf("%sobservedKo := rm.concreteResource(%s).ko\n", indent, sourceResVarName)
+	out += fmt.Sprintf("%slatestKo := rm.concreteResource(%s).ko\n", indent, targetResVarName)
 	// TODO(vijat@): Add validation for correct field path in lateInitializedFieldNames
 	for _, fName := range lateInitializedFieldNames {
 		// split the field name by period
@@ -235,7 +235,7 @@ func LateInitializeFromReadOne(
 //
 //
 // Sample Output:
-//	ko := latestWithDefaults.ko
+//	ko := rm.concreteResource(latest).ko
 //	if ko.Spec.ImageScanningConfiguration != nil {
 //		if ko.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 //			return true
@@ -288,7 +288,7 @@ func IncompleteLateInitialization(
 		out += fmt.Sprintf("%sreturn false", indent)
 		return out
 	}
-	out += fmt.Sprintf("%sko := %s.ko\n", indent, resVarName)
+	out += fmt.Sprintf("%sko := rm.concreteResource(%s).ko\n", indent, resVarName)
 	for _, fName := range sortedLateInitFieldNames {
 		// split the field name by period
 		// each substring represents a field.

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -1,0 +1,130 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+)
+
+// FindLateInitializedFieldsWithDelay outputs the code to create a map of fieldName to
+// late intialization delay in seconds.
+func FindLateInitializedFieldsWithDelay(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	//Sample output
+	//var lateInitializeFieldToDelaySeconds = map[string]int{"Name": 0}
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+	fieldNameToConfig := cfg.ResourceFields(r.Names.Original)
+	if len(fieldNameToConfig) > 0 {
+		fieldNameToDelaySeconds := make(map[string]int)
+		sortedFieldNames := make([]string, 0)
+		for fName, fConfig := range fieldNameToConfig {
+			if fConfig != nil && fConfig.LateInitialize != nil {
+				fieldNameToDelaySeconds[fName] = fConfig.LateInitialize.DelaySeconds
+				sortedFieldNames = append(sortedFieldNames, fName)
+			}
+		}
+		sort.Strings(sortedFieldNames)
+		lateInitFieldToDelayValues := ""
+		if len(sortedFieldNames) > 0 {
+			for _, fName := range sortedFieldNames {
+				lateInitFieldToDelayValues += fmt.Sprintf("\"%s\":%d,",fName, fieldNameToDelaySeconds[fName])
+			}
+			out += fmt.Sprintf("%svar lateInitializeFieldToDelaySeconds = map[string]int{%s}\n", indent, lateInitFieldToDelayValues)
+		}
+	}
+	return out
+}
+
+// lateInitializedFieldNames returns the field names which have LateInitialization configuration inside generator config
+func lateInitializedFieldNames(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+) []string {
+	fieldNames := make([]string, 0)
+	fieldNameToConfig := cfg.ResourceFields(r.Names.Original)
+	if len(fieldNameToConfig) > 0 {
+		for fName, fConfig := range fieldNameToConfig {
+			if fConfig != nil && fConfig.LateInitialize != nil {
+				fieldNames = append(fieldNames, fName)
+			}
+		}
+	}
+	return fieldNames
+}
+
+// LateInitializeFromReadOne returns the gocode to set LateInitialization fields from the ReadOne output
+// TODO(vijat@): add support for Map and list. Currently only structs are supported.
+func LateInitializeFromReadOne (
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	sourceKoVarName string,
+	targetKoVarName string,
+// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	//Sample output
+	//if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
+	//	if observed.Spec.ScanOnPush != nil && koWithDefaults.Spec.ScanOnPush == nil {
+	//		koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
+	//	}
+	//}
+	//if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
+	//	koWithDefaults.Spec.Name = observed.Spec.Name
+	//}
+	out := ""
+	lateInitializedFieldNames := lateInitializedFieldNames(cfg, r)
+	sort.Strings(lateInitializedFieldNames)
+	for _, fName := range lateInitializedFieldNames {
+		if strings.Contains(fName, "..") {
+			// TODO(vijat@): add support for Map and list.
+			continue
+		}
+		// split the field name
+		fNameParts := strings.Split(fName, ".")
+		fNameIndentLevel := indentLevel
+		// for every part except last, perform the nil check
+		for i,fNamePart := range fNameParts {
+			indent := strings.Repeat("\t", fNameIndentLevel)
+			// ignore last part
+			if i != len(fNameParts)-1 {
+				out += fmt.Sprintf("%sif %s.Spec.%s != nil && %s.Spec.%s != nil {\n", indent, sourceKoVarName, fNamePart, targetKoVarName, fNamePart)
+				fNameIndentLevel = fNameIndentLevel + 1
+			}
+		}
+		// for last part, set the lateInitialized field if user did not specify field value and readOne has server side defaulted value.
+		indent := strings.Repeat("\t", fNameIndentLevel)
+		lastfNamePart := fNameParts[len(fNameParts)-1]
+		out += fmt.Sprintf("%sif %s.Spec.%s != nil && %s.Spec.%s == nil {\n", indent, sourceKoVarName, lastfNamePart,targetKoVarName,lastfNamePart)
+		fNameIndentLevel = fNameIndentLevel + 1
+		indent = strings.Repeat("\t", fNameIndentLevel)
+		out += fmt.Sprintf("%s%s.Spec.%s = %s.Spec.%s\n", indent, targetKoVarName, fName, sourceKoVarName, fName)
+		// Close all if blocks with ptoper indentation
+		fNameIndentLevel = fNameIndentLevel - 1
+		for fNameIndentLevel >= indentLevel {
+			out += fmt.Sprintf("%s}\n", strings.Repeat("\t", fNameIndentLevel))
+			fNameIndentLevel = fNameIndentLevel - 1
+		}
+	}
+	return out
+}

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -156,7 +156,7 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "koWithDefaults", 1))
 }
 
-func Test_CalculateRequeueDelay(t *testing.T) {
+func Test_IncompleteLateInitialization(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -170,58 +170,43 @@ func Test_CalculateRequeueDelay(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 		`	ko := latestWithDefaults.ko
-	numLateInitializationAttempt := ackannotation.GetNumLateInitializationAttempt(ko)
-	requeueDelay := time.Duration(0)*time.Second
-	incompleteInitialization := false
 	if ko.Spec.ImageScanningConfiguration != nil {
 		if ko.Spec.ImageScanningConfiguration.ScanOnPush == nil {
-			fDelay := (&acktypes.Exponential{Initial:time.Duration(5)*time.Second, Factor: 2, MaxDelay: time.Duration(15)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-			requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-			incompleteInitialization= true
+			return true
 		}
 	}
 	if ko.Spec.Name == nil {
-		fDelay := (&acktypes.Exponential{Initial:time.Duration(0)*time.Second, Factor: 2, MaxDelay: time.Duration(0)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-		requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-		incompleteInitialization= true
+		return true
 	}
 	if ko.Spec.another != nil {
 		if ko.Spec.another.map != nil {
 			if ko.Spec.another.map["lastfield"] == nil {
-				fDelay := (&acktypes.Exponential{Initial:time.Duration(5)*time.Second, Factor: 2, MaxDelay: time.Duration(0)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-				requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-				incompleteInitialization= true
+				return true
 			}
 		}
 	}
 	if ko.Spec.map != nil {
 		if ko.Spec.map["subfield"] != nil {
 			if ko.Spec.map["subfield"].x == nil {
-				fDelay := (&acktypes.Exponential{Initial:time.Duration(5)*time.Second, Factor: 2, MaxDelay: time.Duration(0)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-				requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-				incompleteInitialization= true
+				return true
 			}
 		}
 	}
 	if ko.Spec.some != nil {
 		if ko.Spec.some.list == nil {
-			fDelay := (&acktypes.Exponential{Initial:time.Duration(10)*time.Second, Factor: 2, MaxDelay: time.Duration(0)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-			requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-			incompleteInitialization= true
+			return true
 		}
 	}
 	if ko.Spec.structA != nil {
 		if ko.Spec.structA.mapB != nil {
 			if ko.Spec.structA.mapB["structC"] != nil {
 				if ko.Spec.structA.mapB["structC"].valueD == nil {
-					fDelay := (&acktypes.Exponential{Initial:time.Duration(20)*time.Second, Factor: 2, MaxDelay: time.Duration(0)*time.Second,}).GetBackoff(numLateInitializationAttempt)
-					requeueDelay = time.Duration(math.Max(requeueDelay.Seconds(), fDelay.Seconds()))*time.Second
-					incompleteInitialization= true
+					return true
 				}
 			}
 		}
 	}
-	return requeueDelay, incompleteInitialization
+	return false
 `
-	assert.Equal(expected, code.CalculateRequeueDelay(crd.Config(), crd, "latestWithDefaults", 1))
+	assert.Equal(expected, code.IncompleteLateInitialization(crd.Config(), crd, "latestWithDefaults", 1))
 }

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -1,6 +1,19 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package code_test
 
-import(
+import (
 	"testing"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
@@ -80,7 +93,7 @@ func Test_LateInitializeFromReadOne_NonNestedPath(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
-`	if observed.Spec.ImageTagMutability != nil && koWithDefaults.Spec.ImageTagMutability == nil {
+		`	if observed.Spec.ImageTagMutability != nil && koWithDefaults.Spec.ImageTagMutability == nil {
 		koWithDefaults.Spec.ImageTagMutability = observed.Spec.ImageTagMutability
 	}
 	if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
@@ -104,7 +117,7 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
-`	if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
+		`	if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
 		if observed.Spec.ImageScanningConfiguration.ScanOnPush != nil && koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 			koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
 		}
@@ -129,6 +142,15 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	if observed.Spec.some != nil && koWithDefaults.Spec.some != nil {
 		if observed.Spec.some.list != nil && koWithDefaults.Spec.some.list == nil {
 			koWithDefaults.Spec.some.list = observed.Spec.some.list
+		}
+	}
+	if observed.Spec.structA != nil && koWithDefaults.Spec.structA != nil {
+		if observed.Spec.structA.mapB != nil && koWithDefaults.Spec.structA.mapB != nil {
+			if observed.Spec.structA.mapB[structC] != nil && koWithDefaults.Spec.structA.mapB[structC] != nil {
+				if observed.Spec.structA.mapB[structC].valueD != nil && koWithDefaults.Spec.structA.mapB[structC].valueD == nil {
+					koWithDefaults.Spec.structA.mapB[structC].valueD = observed.Spec.structA.mapB[structC].valueD
+				}
+			}
 		}
 	}
 `

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -100,8 +100,8 @@ func Test_LateInitializeFromReadOne_NonNestedPath(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
-		`	observedKo := observed.ko
-	latestKo := latest.ko
+		`	observedKo := rm.concreteResource(observed).ko
+	latestKo := rm.concreteResource(latest).ko
 	if observedKo.Spec.ImageTagMutability != nil && latestKo.Spec.ImageTagMutability == nil {
 		latestKo.Spec.ImageTagMutability = observedKo.Spec.ImageTagMutability
 	}
@@ -125,8 +125,8 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
-		`	observedKo := observed.ko
-	latestKo := latest.ko
+		`	observedKo := rm.concreteResource(observed).ko
+	latestKo := rm.concreteResource(latest).ko
 	if observedKo.Spec.ImageScanningConfiguration != nil && latestKo.Spec.ImageScanningConfiguration != nil {
 		if observedKo.Spec.ImageScanningConfiguration.ScanOnPush != nil && latestKo.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 			latestKo.Spec.ImageScanningConfiguration.ScanOnPush = observedKo.Spec.ImageScanningConfiguration.ScanOnPush
@@ -193,7 +193,7 @@ func Test_IncompleteLateInitialization(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
-		`	ko := latestWithDefaults.ko
+		`	ko := rm.concreteResource(latest).ko
 	if ko.Spec.ImageScanningConfiguration != nil {
 		if ko.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 			return true
@@ -231,5 +231,5 @@ func Test_IncompleteLateInitialization(t *testing.T) {
 		}
 	}
 	return false`
-	assert.Equal(expected, code.IncompleteLateInitialization(crd.Config(), crd, "latestWithDefaults", 1))
+	assert.Equal(expected, code.IncompleteLateInitialization(crd.Config(), crd, "latest", 1))
 }

--- a/pkg/generate/code/late_intialize_test.go
+++ b/pkg/generate/code/late_intialize_test.go
@@ -1,0 +1,117 @@
+package code_test
+
+import(
+	"testing"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FindLateInitializedFieldsWithDelay_EmptyFieldConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ecr")
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// NO fieldConfig
+	assert.Empty(crd.Config().ResourceFields(crd.Names.Original))
+	assert.Empty(code.FindLateInitializedFieldsWithDelay(crd.Config(), crd, 1))
+}
+
+func Test_FindLateInitializedFieldsWithDelay_NoLateInitializations(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ecr", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-field-config.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// FieldConfig without lateInitialize
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
+	assert.Nil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.Empty(code.FindLateInitializedFieldsWithDelay(crd.Config(), crd, 1))
+}
+
+func Test_FindLateInitializedFieldsWithDelay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ecr", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-late-initialize.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// FieldConfig without lateInitialize
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	expected := "\tvar lateInitializeFieldToDelaySeconds = map[string]int{\"ImageTagMutability\":5,\"Name\":0,}\n"
+	assert.Equal(expected, code.FindLateInitializedFieldsWithDelay(crd.Config(), crd, 1))
+}
+
+func Test_LateInitializeFromReadOne_NoFieldsToLateInitialize(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ecr")
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// NO fieldConfig
+	assert.Empty(crd.Config().ResourceFields(crd.Names.Original))
+	assert.Empty(code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "koWithDefaults", 1))
+}
+
+func Test_LateInitializeFromReadOne_NonNestedPath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ecr", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-late-initialize.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// FieldConfig without lateInitialize
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	expected :=
+`	if observed.Spec.ImageTagMutability != nil && koWithDefaults.Spec.ImageTagMutability == nil {
+		koWithDefaults.Spec.ImageTagMutability = observed.Spec.ImageTagMutability
+	}
+	if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
+		koWithDefaults.Spec.Name = observed.Spec.Name
+	}
+`
+	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "koWithDefaults", 1))
+}
+
+func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ecr", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-nested-path-late-initialize.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+	// FieldConfig without lateInitialize
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
+	expected :=
+`	if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
+		if observed.Spec.ScanOnPush != nil && koWithDefaults.Spec.ScanOnPush == nil {
+			koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
+		}
+	}
+	if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
+		koWithDefaults.Spec.Name = observed.Spec.Name
+	}
+`
+	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "koWithDefaults", 1))
+}

--- a/pkg/generate/code/late_intialize_test.go
+++ b/pkg/generate/code/late_intialize_test.go
@@ -112,6 +112,25 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	if observed.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
 		koWithDefaults.Spec.Name = observed.Spec.Name
 	}
+	if observed.Spec.another != nil && koWithDefaults.Spec.another != nil {
+		if observed.Spec.another.map != nil && koWithDefaults.Spec.another.map != nil {
+			if observed.Spec.another.map[lastfield] != nil && koWithDefaults.Spec.another.map[lastfield] == nil {
+				koWithDefaults.Spec.another.map[lastfield] = observed.Spec.another.map[lastfield]
+			}
+		}
+	}
+	if observed.Spec.map != nil && koWithDefaults.Spec.map != nil {
+		if observed.Spec.map[subfield] != nil && koWithDefaults.Spec.map[subfield] != nil {
+			if observed.Spec.map[subfield].x != nil && koWithDefaults.Spec.map[subfield].x == nil {
+				koWithDefaults.Spec.map[subfield].x = observed.Spec.map[subfield].x
+			}
+		}
+	}
+	if observed.Spec.some != nil && koWithDefaults.Spec.some != nil {
+		if observed.Spec.some.list != nil && koWithDefaults.Spec.some.list == nil {
+			koWithDefaults.Spec.some.list = observed.Spec.some.list
+		}
+	}
 `
 	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "koWithDefaults", 1))
 }

--- a/pkg/generate/code/late_intialize_test.go
+++ b/pkg/generate/code/late_intialize_test.go
@@ -105,7 +105,7 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 `	if observed.Spec.ImageScanningConfiguration != nil && koWithDefaults.Spec.ImageScanningConfiguration != nil {
-		if observed.Spec.ScanOnPush != nil && koWithDefaults.Spec.ScanOnPush == nil {
+		if observed.Spec.ImageScanningConfiguration.ScanOnPush != nil && koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush == nil {
 			koWithDefaults.Spec.ImageScanningConfiguration.ScanOnPush = observed.Spec.ImageScanningConfiguration.ScanOnPush
 		}
 	}

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -138,6 +138,9 @@ type PrintFieldConfig struct {
 
 // LateInitializeConfig contains instructions for how to handle the
 // retrieval and setting of server-side defaulted fields.
+// NOTE: Currently the members of this have no effect on late initialization of fields.
+// Currently the late initialization is requeued with static delay of 5 second.
+// TODO: (vijat@) Add support of retry/backoff for late initialization.
 type LateInitializeConfig struct {
 	// MinBackoffSeconds provides the minimum backoff to attempt late initialization again after an unsuccessful
 	// attempt to late initialized fields from ReadOne output

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -136,6 +136,14 @@ type PrintFieldConfig struct {
 	Index int `json:"index"`
 }
 
+// LateInitializeConfig contains instructions for how to handle the
+// retrieval and setting of server-side defaulted fields.
+type LateInitializeConfig struct {
+	// DelaySeconds provides the number of seconds to wait to set
+	// late initialized field after successful Create/Update call
+	DelaySeconds int `json:"delay_seconds,omitempty"`
+}
+
 // FieldConfig contains instructions to the code generator about how
 // to interpret the value of an Attribute and how to map it to a CRD's Spec or
 // Status field
@@ -184,4 +192,7 @@ type FieldConfig struct {
 	// influence hows field are printed in `kubectl get` response. If this field
 	// is not nil, it will be added to the columns of `kubectl get`.
 	Print *PrintFieldConfig `json:"print,omitempty"`
+	// Late Initialize instructs the code generator how to handle the late initialization
+	// of the field.
+	LateInitialize *LateInitializeConfig `json:"late_initialize,omitempty"`
 }

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -139,9 +139,14 @@ type PrintFieldConfig struct {
 // LateInitializeConfig contains instructions for how to handle the
 // retrieval and setting of server-side defaulted fields.
 type LateInitializeConfig struct {
-	// DelaySeconds provides the number of seconds to wait to set
-	// late initialized field after successful Create/Update call
-	DelaySeconds int `json:"delay_seconds,omitempty"`
+	// MinBackoffSeconds provides the minimum backoff to attempt late initialization again after an unsuccessful
+	// attempt to late initialized fields from ReadOne output
+	// For every attempt, the reconciler will calculate the delay between MinBackoffSeconds and MaxBackoffSeconds
+	// using exponential backoff and retry strategy
+	MinBackoffSeconds int `json:"min_backoff_seconds,omitempty"`
+	// MaxBackoffSeconds provide the maximum allowed backoff when retrying late initialization after an
+	// unsuccessful attempt.
+	MaxBackoffSeconds int `json:"max_backoff_seconds"`
 }
 
 // FieldConfig contains instructions to the code generator about how

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-field-config.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-field-config.yaml
@@ -1,0 +1,12 @@
+resources:
+  Repository:
+    fields:
+      Name:
+        is_name: true
+    exceptions:
+      errors:
+        404:
+          code: RepositoryNotFoundException
+    list_operation:
+      match_fields:
+        - RepositoryName

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-late-initialize.yaml
@@ -1,0 +1,15 @@
+resources:
+  Repository:
+    fields:
+      Name:
+        late_initialize: {}
+      ImageTagMutability:
+        late_initialize:
+          delay_seconds: 5
+    exceptions:
+      errors:
+        404:
+          code: RepositoryNotFoundException
+    list_operation:
+      match_fields:
+        - RepositoryName

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-late-initialize.yaml
@@ -5,7 +5,7 @@ resources:
         late_initialize: {}
       ImageTagMutability:
         late_initialize:
-          delay_seconds: 5
+          min_backoff_seconds: 5
     exceptions:
       errors:
         404:

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
@@ -6,6 +6,15 @@ resources:
       ImageScanningConfiguration.ScanOnPush:
         late_initialize:
           delay_seconds: 5
+      map..subfield.x:
+        late_initialize:
+          delay_seconds: 5
+      another.map..lastfield:
+        late_initialize:
+          delay_seconds: 5
+      some.list:
+        late_initialize:
+          delay_seconds: 10
     exceptions:
       errors:
         404:

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
@@ -1,0 +1,15 @@
+resources:
+  Repository:
+    fields:
+      Name:
+        late_initialize: {}
+      ImageScanningConfiguration.ScanOnPush:
+        late_initialize:
+          delay_seconds: 5
+    exceptions:
+      errors:
+        404:
+          code: RepositoryNotFoundException
+    list_operation:
+      match_fields:
+        - RepositoryName

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
@@ -15,6 +15,9 @@ resources:
       some.list:
         late_initialize:
           delay_seconds: 10
+      structA.mapB..structC.valueD:
+        late_initialize:
+          delay_seconds: 20
     exceptions:
       errors:
         404:

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-nested-path-late-initialize.yaml
@@ -5,19 +5,20 @@ resources:
         late_initialize: {}
       ImageScanningConfiguration.ScanOnPush:
         late_initialize:
-          delay_seconds: 5
+          min_backoff_seconds: 5
+          max_backoff_seconds: 15
       map..subfield.x:
         late_initialize:
-          delay_seconds: 5
+          min_backoff_seconds: 5
       another.map..lastfield:
         late_initialize:
-          delay_seconds: 5
+          min_backoff_seconds: 5
       some.list:
         late_initialize:
-          delay_seconds: 10
+          min_backoff_seconds: 10
       structA.mapB..structC.valueD:
         late_initialize:
-          delay_seconds: 20
+          min_backoff_seconds: 20
     exceptions:
       errors:
         404:

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -197,8 +197,7 @@ func (rm *resourceManager) LateInitialize(
 		ackcondition.SetLateInitialized(latestWithDefaults, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
 		return latestWithDefaults, ackrequeue.NeededAfter(err, time.Duration(0)*time.Second)
 	}
-	observedKo := observed.ko
-{{ GoCodeLateInitializeFromReadOne .CRD "observedKo" "koWithDefaults" 1 }}
+	latestWithDefaults = rm.lateInitializeFromReadOneOutput(observed, latestWithDefaults)
 	incompleteInitialization := rm.incompleteLateInitialization(latestWithDefaults)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
@@ -209,7 +208,7 @@ func (rm *resourceManager) LateInitialize(
 	}
 	// Set LateIntialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
-    lateInitConditionReason = "Late initialization successful"
+	lateInitConditionReason = "Late initialization successful"
 	ackcondition.SetLateInitialized(latestWithDefaults, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
 {{- if $hookCode := Hook .CRD "late_initialize_post_read_one" }}
 {{ $hookCode }}
@@ -223,6 +222,15 @@ func (rm *resourceManager) incompleteLateInitialization(
 	latestWithDefaults *resource,
 ) bool {
 {{ GoCodeIncompleteLateInitialization .CRD "latestWithDefaults" 1 }}
+}
+
+// lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
+// resource and returns 'latest' resource
+func (rm *resourceManager) lateInitializeFromReadOneOutput(
+	observed *resource,
+	latest *resource,
+) *resource {
+{{ GoCodeLateInitializeFromReadOne .CRD "observed" "latest" 1 }}
 }
 
 // newResourceManager returns a new struct implementing

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -171,7 +171,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 func (rm *resourceManager) LateInitialize(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) (acktypes.AWSResource, *ackrequeue.RequeueNeededAfter) {
+) (acktypes.AWSResource, error) {
 	rlog := ackrtlog.FromContext(ctx)
 {{- if $hookCode := Hook .CRD "late_initialize_pre_read_one" }}
 {{ $hookCode }}

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -169,10 +169,9 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // object passed in the parameter.
 func (rm *resourceManager) LateInitialize(
 	ctx context.Context,
-	resLatest acktypes.AWSResource,
+	latest acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
 	rlog := ackrtlog.FromContext(ctx)
-	latest := rm.concreteResource(resLatest)
 	// If there are no fields to late initialize, do nothing
 	if len(lateInitializeFieldNames) == 0 {
 		rlog.Debug("no late initialization required.")
@@ -183,7 +182,7 @@ func (rm *resourceManager) LateInitialize(
 {{- if $hookCode := Hook .CRD "late_initialize_pre_read_one" }}
 {{ $hookCode }}
 {{- end }}
-	observedRes, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latest)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
@@ -193,7 +192,6 @@ func (rm *resourceManager) LateInitialize(
 {{- if $hookCode := Hook .CRD "late_initialize_post_read_one" }}
 {{ $hookCode }}
 {{- end }}
-	observed := rm.concreteResource(observedRes)
 	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
 	incompleteInitialization := rm.incompleteLateInitialization(latest)
 	if incompleteInitialization {
@@ -213,7 +211,7 @@ func (rm *resourceManager) LateInitialize(
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest *resource,
+	latest acktypes.AWSResource,
 ) bool {
 {{ GoCodeIncompleteLateInitialization .CRD "latest" 1 }}
 }
@@ -221,9 +219,9 @@ func (rm *resourceManager) incompleteLateInitialization(
 // lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
 // resource and returns 'latest' resource
 func (rm *resourceManager) lateInitializeFromReadOneOutput(
-	observed *resource,
-	latest *resource,
-) *resource {
+	observed acktypes.AWSResource,
+	latest acktypes.AWSResource,
+) acktypes.AWSResource {
 {{ GoCodeLateInitializeFromReadOne .CRD "observed" "latest" 1 }}
 }
 

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -187,7 +187,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(err, time.Duration(0)*time.Second)
+		return latest, err
 	}
 {{- if $hookCode := Hook .CRD "late_initialize_post_read_one" }}
 {{ $hookCode }}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/812

Description of changes:

* Initial implementation of `AWSResourceManager.LateInitialize()` method code generator
* Adds two new hooks `late_initialize_pre_read_one` & `late_initialize_post_read_one`
* Introduces new LateInitializeConfig with DelaySeconds as single parameter
* Corresponding runtime PR : https://github.com/aws-controllers-k8s/runtime/pull/37

------------------------------------

Testing
* Unit Tests Successful
```
➜  code-generator git:(li-mlp) ✗ make test
go test -tags codegen ./...
?       github.com/aws-controllers-k8s/code-generator/cmd/ack-generate  [no test files]
?       github.com/aws-controllers-k8s/code-generator/cmd/ack-generate/command  [no test files]
ok      github.com/aws-controllers-k8s/code-generator/pkg/generate/ack  2.346s
ok      github.com/aws-controllers-k8s/code-generator/pkg/generate/code 17.798s
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/config       [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/crossplane   [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/olm  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/metadata      [no test files]
ok      github.com/aws-controllers-k8s/code-generator/pkg/model 14.671s
ok      github.com/aws-controllers-k8s/code-generator/pkg/model/multiversion    5.152s
ok      github.com/aws-controllers-k8s/code-generator/pkg/names (cached)
?       github.com/aws-controllers-k8s/code-generator/pkg/testutil      [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/util  [no test files]
?       github.com/aws-controllers-k8s/code-generator/pkg/version       [no test files]

```

* Controller generation successful
```
➜  code-generator git:(li-mlp) ✗ make build-controller                
building ack-generate ... ok.
installing controller-gen v0.6.1 ... ok.
Copying common custom resource definitions into ecr
Building Kubernetes API objects for ecr
Generating deepcopy code for ecr
Generating custom resource definitions for ecr
Building service controller for ecr
Generating RBAC manifests for ecr
Running gofmt against generated code for ecr

```

* Sample generated code for ecr repository
```go
// LateInitialize returns an acktypes.AWSResource after setting the late initialized
// fields from the readOne call. This method will initialize the optional fields
// which were not provided by the k8s user but were defaulted by the AWS service.
// If there are no such fields to be initialized, the returned object is similar to
// object passed in the parameter.
func (rm *resourceManager) LateInitialize(
	ctx context.Context,
	res acktypes.AWSResource,
) (acktypes.AWSResource, error) {
	rlog := ackrtlog.FromContext(ctx)
	// If there are no fields to late initialize, do nothing
	if len(lateInitializeFieldNames) == 0 {
		rlog.Debug("no late initialization required.")
		return res, nil
	}
	r := rm.concreteResource(res)
	if r.ko == nil {
		// Should never happen... if it does, it's buggy code.
		panic("resource manager's LateInitialize() method received resource with nil CR object")
	}
	koWithDefaults := r.ko.DeepCopy()
	latestWithDefaults := &resource{koWithDefaults}
	lateInitConditionReason := ""
	lateInitConditionMessage := ""

	observed, err := rm.sdkFind(ctx, latestWithDefaults)
	if err != nil {
		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
		lateInitConditionReason = "Late Initialization Failure"
		ackcondition.SetLateInitialized(latestWithDefaults, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
		return latestWithDefaults, ackrequeue.NeededAfter(err, time.Duration(0)*time.Second)
	}
	observedKo := observed.ko
	if observedKo.Spec.Name != nil && koWithDefaults.Spec.Name == nil {
		koWithDefaults.Spec.Name = observedKo.Spec.Name
	}

	incompleteInitialization := rm.incompleteLateInitialization(latestWithDefaults)
	if incompleteInitialization {
		// Add the condition with LateInitialized=False
		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
		lateInitConditionReason = "Delayed Late Initialization"
		ackcondition.SetLateInitialized(latestWithDefaults, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
		return latestWithDefaults, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
	}
	// Set LateIntialized condition to True
	lateInitConditionMessage = "Late initialization successful"
	lateInitConditionReason = "Late initialization successful"
	ackcondition.SetLateInitialized(latestWithDefaults, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
	return latestWithDefaults, nil
}

// incompleteLateInitialization return true if there are fields which were supposed to be
// late initialized but are not. If all the fields are late initialized, false is returned
func (rm *resourceManager) incompleteLateInitialization(
	latestWithDefaults *resource,
) bool {
	ko := latestWithDefaults.ko
	if ko.Spec.Name == nil {
		return true
	}
	return false

}

```

* local-kind-e2e-test logs
```
                                                                                                    │
│ 2021-07-26T19:38:08.701Z    DEBUG    ackrt    > r.Sync    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "kind": "Repository" │
│ 2021-07-26T19:38:08.701Z    DEBUG    ackrt    >> rm.ReadOne    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted": f │
│ 2021-07-26T19:38:08.701Z    DEBUG    ackrt    >>> rm.sdkFind    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted":  │
│ 2021-07-26T19:38:09.641Z    DEBUG    ackrt    <<< rm.sdkFind    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted":  │
│ 2021-07-26T19:38:09.641Z    DEBUG    ackrt    << rm.ReadOne    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted": f │
│ 2021-07-26T19:38:09.641Z    DEBUG    ackrt    >> r.setResourceManaged    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_a │
│ 2021-07-26T19:38:09.641Z    DEBUG    ackrt    >>> kc.Patch (metadata + spec)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2" │
│ 2021-07-26T19:38:09.694Z    DEBUG    ackrt    <<< kc.Patch (metadata + spec)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2" │
│ 2021-07-26T19:38:09.694Z    DEBUG    ackrt    marked resource as managed    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "i │
│ 2021-07-26T19:38:09.694Z    DEBUG    ackrt    << r.setResourceManaged    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_a │
│ 2021-07-26T19:38:09.694Z    DEBUG    ackrt    >> rm.Create    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted": fa │
│ 2021-07-26T19:38:09.694Z    DEBUG    ackrt    >>> rm.sdkCreate    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted" │
│ 2021-07-26T19:38:09.725Z    DEBUG    ackrt    <<< rm.sdkCreate    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted" │
│ 2021-07-26T19:38:09.725Z    DEBUG    ackrt    << rm.Create    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted": fa │
│ 2021-07-26T19:38:09.725Z    INFO    ackrt    created new resource    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopt │
│ 2021-07-26T19:38:09.725Z    DEBUG    ackrt    >> rm.LateInitialize    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adop │
│ 2021-07-26T19:38:09.725Z    INFO    ackrt    calculated late initialization delay is 0 seconds    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "re │
│ 2021-07-26T19:38:09.725Z    DEBUG    ackrt    >>> rm.sdkFind    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted":  │
│ 2021-07-26T19:38:09.748Z    DEBUG    ackrt    <<< rm.sdkFind    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted":  │
│ 2021-07-26T19:38:09.748Z    DEBUG    ackrt    << rm.LateInitialize    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adop │
│ 2021-07-26T19:38:09.748Z    DEBUG    ackrt    >> r.patchResourceMetadataAndSpec    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west │
│ 2021-07-26T19:38:09.748Z    DEBUG    ackrt    >>> kc.Patch (metadata + spec)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2" │
│ 2021-07-26T19:38:09.758Z    DEBUG    ackrt    <<< kc.Patch (metadata + spec)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2" │
│ 2021-07-26T19:38:09.759Z    DEBUG    ackrt    patched resource metadata and spec    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-wes │
│ 2021-07-26T19:38:09.759Z    DEBUG    ackrt    << r.patchResourceMetadataAndSpec    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west │
│ 2021-07-26T19:38:09.759Z    DEBUG    ackrt    >> r.patchResourceStatus    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_ │
│ 2021-07-26T19:38:09.759Z    DEBUG    ackrt    >>> kc.Patch (status)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_ado │
│ 2021-07-26T19:38:09.794Z    DEBUG    ackrt    <<< kc.Patch (status)    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_ado │
│ 2021-07-26T19:38:09.795Z    DEBUG    ackrt    patched resource status    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_a │
│ 2021-07-26T19:38:09.795Z    DEBUG    ackrt    << r.patchResourceStatus    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_ │
│ 2021-07-26T19:38:09.795Z    DEBUG    ackrt    < r.Sync    {"kind": "Repository", "namespace": "default", "name": "ecr-repository-wy6n6wjm8", "generation": 1, "account": "309117047740", "role": "", "region": "us-west-2", "is_adopted": false, │
│ 2021-07-26T19:38:09.795Z    DEBUG    controller-runtime.controller    Successfully Reconciled    {"controller": "repository", "request": "default/ecr-repository-wy6n6wjm8"}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
