### PR TITLE
Allow member fields from other operations in spec

### DIFF
--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -81,6 +81,29 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 			delta.Add("Spec.GrantWriteACP", a.ko.Spec.GrantWriteACP, b.ko.Spec.GrantWriteACP)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Logging, b.ko.Spec.Logging) {
+		delta.Add("Spec.Logging", a.ko.Spec.Logging, b.ko.Spec.Logging)
+	} else if a.ko.Spec.Logging != nil && b.ko.Spec.Logging != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled, b.ko.Spec.Logging.LoggingEnabled) {
+			delta.Add("Spec.Logging.LoggingEnabled", a.ko.Spec.Logging.LoggingEnabled, b.ko.Spec.Logging.LoggingEnabled)
+		} else if a.ko.Spec.Logging.LoggingEnabled != nil && b.ko.Spec.Logging.LoggingEnabled != nil {
+			if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket) {
+				delta.Add("Spec.Logging.LoggingEnabled.TargetBucket", a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket)
+			} else if a.ko.Spec.Logging.LoggingEnabled.TargetBucket != nil && b.ko.Spec.Logging.LoggingEnabled.TargetBucket != nil {
+				if *a.ko.Spec.Logging.LoggingEnabled.TargetBucket != *b.ko.Spec.Logging.LoggingEnabled.TargetBucket {
+					delta.Add("Spec.Logging.LoggingEnabled.TargetBucket", a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket)
+				}
+			}
+
+			if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix) {
+				delta.Add("Spec.Logging.LoggingEnabled.TargetPrefix", a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix)
+			} else if a.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil && b.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil {
+				if *a.ko.Spec.Logging.LoggingEnabled.TargetPrefix != *b.ko.Spec.Logging.LoggingEnabled.TargetPrefix {
+					delta.Add("Spec.Logging.LoggingEnabled.TargetPrefix", a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix)
+				}
+			}
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -143,6 +143,11 @@ func (r *CRD) HasShapeAsMember(toFind string) bool {
 			}
 		}
 	}
+	for _, field := range r.SpecFields {
+		if shapeHasMember(field.ShapeRef.Shape, toFind) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -231,6 +236,17 @@ func (r *CRD) SpecFieldNames() []string {
 	res := make([]string, 0, len(r.SpecFields))
 	for fieldName := range r.SpecFields {
 		res = append(res, fieldName)
+	}
+	sort.Strings(res)
+	return res
+}
+
+// SpecFieldShapeNames returns a sorted slice of shape names for each of the
+// Spec fields
+func (r *CRD) SpecFieldShapeNames() []string {
+	res := make([]string, 0, len(r.SpecFields))
+	for _, field := range r.SpecFields {
+		res = append(res, field.ShapeRef.ShapeName)
 	}
 	sort.Strings(res)
 	return res

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -241,17 +241,6 @@ func (r *CRD) SpecFieldNames() []string {
 	return res
 }
 
-// SpecFieldShapeNames returns a sorted slice of shape names for each of the
-// Spec fields
-func (r *CRD) SpecFieldShapeNames() []string {
-	res := make([]string, 0, len(r.SpecFields))
-	for _, field := range r.SpecFields {
-		res = append(res, field.ShapeRef.ShapeName)
-	}
-	sort.Strings(res)
-	return res
-}
-
 // UnpacksAttributesMap returns true if the underlying API has
 // Get{Resource}Attributes/Set{Resource}Attributes API calls that map real,
 // schema'd fields to a raw `map[string]*string` for this resource (see SNS and

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -279,18 +279,6 @@ func (m *Model) IsShapeUsedInCRDs(shapeName string) bool {
 	return false
 }
 
-// IsShapeInSpec returns true if the supplied shape name is directly used as a 
-// field in the CRD's spec
-func (m *Model) IsShapeInSpec(shapeName string) bool {
-	crds, _ := m.GetCRDs()
-	for _, crd := range crds {
-		if util.InStrings(shapeName, crd.SpecFieldShapeNames()) {
-			return true
-		}
-	}
-	return false
-}
-
 // GetTypeDefs returns a slice of `TypeDef` pointers
 func (m *Model) GetTypeDefs() ([]*TypeDef, error) {
 	if m.typeDefs != nil {
@@ -322,20 +310,17 @@ func (m *Model) GetTypeDefs() ([]*TypeDef, error) {
 			trenames[shapeName] = tdefNames.Camel
 		}
 
-		// Shape is used directly in the spec
-		baseUsed := m.IsShapeInSpec(shapeName)
-
 		attrs := map[string]*Attr{}
 		for memberName, memberRef := range shape.MemberRefs {
 			memberNames := names.New(memberName)
 			memberShape := memberRef.Shape
-			if !baseUsed && !m.IsShapeUsedInCRDs(memberShape.ShapeName) {
+			if !m.IsShapeUsedInCRDs(memberShape.ShapeName) {
 				continue
 			}
 			gt := m.getShapeCleanGoType(memberShape)
 			attrs[memberName] = NewAttr(memberNames, gt, memberShape)
 		}
-		if !baseUsed && len(attrs) == 0 {
+		if len(attrs) == 0 {
 			// Just ignore these...
 			continue
 		}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -279,6 +279,18 @@ func (m *Model) IsShapeUsedInCRDs(shapeName string) bool {
 	return false
 }
 
+// IsShapeInSpec returns true if the supplied shape name is directly used as a 
+// field in the CRD's spec
+func (m *Model) IsShapeInSpec(shapeName string) bool {
+	crds, _ := m.GetCRDs()
+	for _, crd := range crds {
+		if util.InStrings(shapeName, crd.SpecFieldShapeNames()) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetTypeDefs returns a slice of `TypeDef` pointers
 func (m *Model) GetTypeDefs() ([]*TypeDef, error) {
 	if m.typeDefs != nil {
@@ -310,17 +322,20 @@ func (m *Model) GetTypeDefs() ([]*TypeDef, error) {
 			trenames[shapeName] = tdefNames.Camel
 		}
 
+		// Shape is used directly in the spec
+		baseUsed := m.IsShapeInSpec(shapeName)
+
 		attrs := map[string]*Attr{}
 		for memberName, memberRef := range shape.MemberRefs {
 			memberNames := names.New(memberName)
 			memberShape := memberRef.Shape
-			if !m.IsShapeUsedInCRDs(memberShape.ShapeName) {
+			if !baseUsed && !m.IsShapeUsedInCRDs(memberShape.ShapeName) {
 				continue
 			}
 			gt := m.getShapeCleanGoType(memberShape)
 			attrs[memberName] = NewAttr(memberNames, gt, memberShape)
 		}
-		if len(attrs) == 0 {
+		if !baseUsed && len(attrs) == 0 {
 			// Just ignore these...
 			continue
 		}

--- a/pkg/model/model_s3_test.go
+++ b/pkg/model/model_s3_test.go
@@ -75,6 +75,7 @@ func TestS3_Bucket(t *testing.T) {
 		"GrantReadACP",
 		"GrantWrite",
 		"GrantWriteACP",
+		"Logging",
 		// NOTE(jaypipes): Original field name in CreateBucket input is
 		// "Bucket" but should be renamed to "Name" from the generator.yaml (in
 		// order to match with the name of the field in the Output shape for a
@@ -88,4 +89,13 @@ func TestS3_Bucket(t *testing.T) {
 		"Location",
 	}
 	assert.Equal(expStatusFieldCamel, attrCamelNames(statusFields))
+
+	expTypeDefCamel := []string{
+		"BucketLoggingStatus",
+		"LoggingEnabled",
+		"TargetGrant",
+	}
+	for _, typeDef := range expTypeDefCamel {
+		assert.NotNil(testutil.GetTypeDefByName(t, g, typeDef))
+	}
 }

--- a/pkg/testdata/models/apis/s3/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/s3/0000-00-00/generator.yaml
@@ -24,3 +24,7 @@ resources:
         # should NOT be in a production generator.yaml...
         compare:
           is_ignored: true
+      Logging:
+        from:
+          operation: PutBucketLogging
+          path: BucketLoggingStatus


### PR DESCRIPTION
Description of changes:
Allow the use of member fields contained within other API operations within a resource's spec. For example, `LoggingStatus` for S3 is only in the `PutBucketLogging` operation, but should be settable from spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
