### PR TITLE
Expose `SetSDKForStruct` and `SetResourceForStruct` in templates

### DIFF
--- a/pkg/generate/ack/apis.go
+++ b/pkg/generate/ack/apis.go
@@ -84,6 +84,7 @@ func APIs(
 		crdFileName := strcase.ToSnake(crd.Kind) + ".go"
 		crdVars := &templateCRDVars{
 			metaVars,
+			m.SDKAPI,
 			crd,
 		}
 		if err = ts.Add(crdFileName, "apis/crd.go.tpl", crdVars); err != nil {
@@ -105,5 +106,6 @@ type templateAPIVars struct {
 // code for a single top-level resource's API definition
 type templateCRDVars struct {
 	templateset.MetaVars
-	CRD *ackmodel.CRD
+	SDKAPI *ackmodel.SDKAPI
+	CRD    *ackmodel.CRD
 }

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -94,10 +94,10 @@ var (
 		"GoCodeSetDeleteInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetOperationStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceFieldPath string, sourceVarName string, indentLevel int) string {
+		"GoCodeSetSDKForStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceFieldPath string, sourceVarName string, indentLevel int) string {
 			return code.SetSDKForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceFieldPath, sourceVarName, indentLevel)
 		},
-		"GoCodeSetResourceStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceVarName string, sourceShapeRef *awssdkmodel.ShapeRef, indentLevel int) string {
+		"GoCodeSetResourceForStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceVarName string, sourceShapeRef *awssdkmodel.ShapeRef, indentLevel int) string {
 			return code.SetResourceForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceVarName, sourceShapeRef, indentLevel)
 		},
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -97,6 +97,9 @@ var (
 		"GoCodeSetOperationStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceFieldPath string, sourceVarName string, indentLevel int) string {
 			return code.SetSDKForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceFieldPath, sourceVarName, indentLevel)
 		},
+		"GoCodeSetResourceStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceVarName string, sourceShapeRef *awssdkmodel.ShapeRef, indentLevel int) string {
+			return code.SetResourceForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceVarName, sourceShapeRef, indentLevel)
+		},
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -22,6 +22,7 @@ import (
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
 var (
@@ -93,6 +94,9 @@ var (
 		"GoCodeSetDeleteInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeSetOperationStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceFieldPath string, sourceVarName string, indentLevel int) string {
+			return code.SetSDKForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceFieldPath, sourceVarName, indentLevel)
+		},
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
@@ -132,6 +136,7 @@ func Controller(
 	controllerFuncMap["Hook"] = func(r *ackmodel.CRD, hookID string) string {
 		crdVars := &templateCRDVars{
 			metaVars,
+			m.SDKAPI,
 			r,
 		}
 		code, err := ResourceHookCode(templateBasePaths, r, hookID, crdVars, controllerFuncMap)
@@ -165,6 +170,7 @@ func Controller(
 			tplPath := filepath.Join("pkg/resource", target)
 			crdVars := &templateCRDVars{
 				metaVars,
+				m.SDKAPI,
 				crd,
 			}
 			if err = ts.Add(outPath, tplPath, crdVars); err != nil {

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -990,7 +990,7 @@ func setResourceForContainer(
 ) string {
 	switch sourceShapeRef.Shape.Type {
 	case "structure":
-		return setResourceForStruct(
+		return SetResourceForStruct(
 			cfg, r,
 			targetFieldName,
 			targetVarName,
@@ -1031,9 +1031,9 @@ func setResourceForContainer(
 	}
 }
 
-// setResourceForStruct returns a string of Go code that sets a target variable
+// SetResourceForStruct returns a string of Go code that sets a target variable
 // value to a source variable when the type of the source variable is a struct.
-func setResourceForStruct(
+func SetResourceForStruct(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 	// The name of the CR field we're outputting for

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -739,7 +739,7 @@ func setSDKForContainer(
 ) string {
 	switch targetShapeRef.Shape.Type {
 	case "structure":
-		return setSDKForStruct(
+		return SetSDKForStruct(
 			cfg, r,
 			targetFieldName,
 			targetVarName,
@@ -874,9 +874,9 @@ func setSDKForSecret(
 	return out
 }
 
-// setSDKForStruct returns a string of Go code that sets a target variable
+// SetSDKForStruct returns a string of Go code that sets a target variable
 // value to a source variable when the type of the source variable is a struct.
-func setSDKForStruct(
+func SetSDKForStruct(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 	// The name of the CR field we're outputting for


### PR DESCRIPTION
Description of changes:
Makes `setSDKForStruct` and `setResourceForStruct` public, so that they are accessible for other parts of the generator. Exposes `SetSDKForStruct` as `GoCodeSetSDKForStruct` and `SetResourceForStruct` as `GoCodeSetResourceForStruct` in the generator, and includes `SDKAPI` as a template variable to allow querying of API shapes to use with parameters in the new template methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
