### PR TITLE
add DPD and IO to initialisms

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -81,6 +81,7 @@ var (
 		{"Cpu", "CPU", "cpu", nil},
 		{"Dhcp", "DHCP", "dhcp", nil},
 		{"Dns", "DNS", "dns", nil},
+		{"Dpd", "DPD", "dpd", nil},
 		{"Ebs", "EBS", "ebs", nil},
 		{"Ec2", "EC2", "ec2", nil},
 		{"Ecr", "ECR", "ecr", nil},
@@ -93,6 +94,8 @@ var (
 		{"Https", "HTTPS", "https", nil},
 		{"Iam", "IAM", "iam", nil},
 		{"Icmp", "ICMP", "icmp", nil},
+		// Prevent "IOPS" from becoming "IOps"
+		{"Io", "IO", "io", regexp.MustCompile("Io(?!ps)", regexp.None)},
 		{"Iops", "IOPS", "iops", nil},
 		{"Json", "JSON", "json", nil},
 		{"Jwt", "JWT", "jwt", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -50,6 +50,9 @@ func TestNames(t *testing.T) {
 		{"MultipartUpload", "MultipartUpload", "multipartUpload", "multipart_upload"},
 		{"Package", "Package", "package_", "package_"},
 		{"LdapServerMetadata", "LDAPServerMetadata", "ldapServerMetadata", "ldap_server_metadata"},
+		{"DpdTimeoutAction", "DPDTimeoutAction", "dpdTimeoutAction", "dpd_timeout_action"},
+		{"Iops", "IOPS", "iops", "iops"},
+		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Issue #, if available: [#889](https://github.com/aws-controllers-k8s/community/issues/889)

Description of changes:
* Adding DPD and IO to initialisms after generating vpc resource for ec2-controller
* Update unit test

Testing:
* make test ✅
* make build controller SERVICE=ec2 ✅

```
// The VPN tunnel options.
type TunnelOption struct {
	DPDTimeoutAction     *string `json:"dpdTimeoutAction,omitempty"`
        ...
}
type VolumeStatusAttachmentStatus struct {
	InstanceID    *string `json:"instanceID,omitempty"`
	IOPerformance *string `json:"ioPerformance,omitempty"`
        ...
} 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
