### PR TITLE
Install flag for helm and additional kustomize file for raw yaml for pure Namespace scoping

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -201,8 +201,12 @@ controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifac
 # controller-gen rbac outputs a ClusterRole definition in a
 # $config_output_dir/rbac/role.yaml file. We have some other standard Role
 # files for a reader and writer role, so here we rename the `role.yaml` file to
-# `cluster-role-controller.yaml` to better reflect what is in that file.
-mv $helm_output_dir/templates/role.yaml $helm_output_dir/templates/cluster-role-controller.yaml
+# `cluster-role-controller.yaml` to better reflect what is in that file. We additionally add the ability
+# for the user to specify if they want the role to be ClusterRole or Role by specifying installation scope
+# in the helm values.yaml
+cp -r $ROOT_DIR/templates/helm/templates/_namespaced-install.tpl $helm_output_dir/templates/
+sed -e '1r '"$helm_output_dir/templates/_namespaced-install.tpl"''  -e '1, 7d'  $helm_output_dir/templates/role.yaml > $helm_output_dir/templates/cluster-role-controller.yaml
+rm $helm_output_dir/templates/role.yaml
 
 popd 1>/dev/null
 

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -207,8 +207,13 @@ controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifac
 # controller-gen rbac outputs a ClusterRole definition in a
 # $config_output_dir/rbac/role.yaml file. We have some other standard Role
 # files for a reader and writer role, so here we rename the `role.yaml` file to
-# `cluster-role-controller.yaml` to better reflect what is in that file.
-mv $config_output_dir/rbac/role.yaml $config_output_dir/rbac/cluster-role-controller.yaml
+# `role-controller.yaml` to better reflect what is in that file.
+mv $config_output_dir/rbac/role.yaml $config_output_dir/rbac/role-controller.yaml
+# Copy definitions for json patches which allow the user to patch the controller
+# with Role/Rolebinding and be purely namespaced scoped instead of using Cluster/ClusterRoleBinding
+# using kustomize
+mkdir -p $config_output_dir/overlays/namespaced
+cp -r $ROOT_DIR/templates/config/overlays/namespaced/* $config_output_dir/overlays/namespaced
 
 popd 1>/dev/null
 

--- a/templates/config/overlays/namespaced/kustomization.yaml.tpl
+++ b/templates/config/overlays/namespaced/kustomization.yaml.tpl
@@ -1,0 +1,15 @@
+resources:
+- ../../default
+patches:
+- path: role.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: ack-sagemaker-controller
+- path: role-binding.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: ack-sagemaker-controller-rolebinding

--- a/templates/config/overlays/namespaced/role-binding.json
+++ b/templates/config/overlays/namespaced/role-binding.json
@@ -1,0 +1,14 @@
+[{"op": "replace",
+    "path": "/kind",
+    "value": "RoleBinding"},
+ 
+ 
+   {"op": "add",
+    "path": "/metadata/namespace",
+    "value":  "ack-system"},
+
+
+    {"op": "replace",
+        "path": "/roleRef/kind",
+        "value": "Role"}
+   ]

--- a/templates/config/overlays/namespaced/role.json
+++ b/templates/config/overlays/namespaced/role.json
@@ -1,0 +1,9 @@
+  [{"op": "replace",
+   "path": "/kind",
+   "value": "Role"},
+
+   
+  {"op": "add",
+   "path": "/metadata/namespace",
+   "value": "ack-system"}
+  ]

--- a/templates/helm/templates/_namespaced-install.tpl
+++ b/templates/helm/templates/_namespaced-install.tpl
@@ -1,0 +1,15 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{ if not .Values.namespacedInstallation }}
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ack-sagemaker-controller
+{{ else }}
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-sagemaker-controller
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/templates/helm/templates/cluster-role-binding.yaml.tpl
+++ b/templates/helm/templates/cluster-role-binding.yaml.tpl
@@ -1,4 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{ "{{ if not .Values.namespacedInstallation }}" }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ "{{ include \"app.fullname\" . }}" }}
@@ -6,6 +7,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ack-{{ .ServiceIDClean }}-controller
+{{ "{{ else }}" }}
+kind: RoleBinding
+metadata:
+  name: {{ "{{ include \"app.fullname\" . }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ack-{{ .ServiceIDClean }}-controller
+{{ "{{ end }}" }}
 subjects:
 - kind: ServiceAccount
   name: {{ "{{ include \"service-account.name\" . }}" }}

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -47,6 +47,10 @@ log:
 # If specified, the service controller will watch for object creation only in the provided namespace
 watchNamespace: ""
 
+# If specified, the service controller will use Role/Rolebinding instead of ClusterRole/ClusterRoleBindings
+# If set to true, user must set watchNamespace as well.
+namespacedInstallation: false
+
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on resources that it manages.
   - services.k8s.aws/managed=true


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/770

Description of changes:

- Adds `namespacedInstallation` flag for helm` values.yaml` to specify that `Role `and` RoleBinding` should be used instead of `ClusterRole `and `ClusterRoleBinding`
- Specifies that `watchNamespace `in helm` values.yaml` must be set if using `namespacedInstallation` flag.
- Contains a sed to replace the original output of the `role-controller.yaml` file with the template code that allows for the programmatic setting of `namespacedInstallation` in the helm` values.yaml`
- Adds a `overlays/namespaced` directory for the raw yamls in config. This folder contains the json patch files, `role.yaml` and `role-binding.yaml` that will modify the `ClusterRole` and `ClusterRoleBinding` files to be `Role `and `RoleBinding`. This allows the user to apply these changes using raw yaml and not helm if these wish.

Tested locally 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
