### PR TITLE
Minor Refactor in `pkg/generate/code`

### DIFF
--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -14,22 +14,21 @@
 package code
 
 import (
-	"errors"
-	"fmt"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
-
-	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
-// FindIdentifierInShape returns the identifier field of a given shape which
+// FindIdentifiersInShape returns the identifier fields of a given shape which
 // can be singular or plural. Errors iff multiple identifier fields detected
 // in the shape.
-func FindIdentifierInShape(
+func FindIdentifiersInShape(
 	r *model.CRD,
-	shape *awssdkmodel.Shape) (string, error) {
+	shape *awssdkmodel.Shape) []string {
 	identifierLookup := []string{
+		"Id",
+		"Ids",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",
@@ -37,29 +36,25 @@ func FindIdentifierInShape(
 		r.Names.Original + "Id",
 		r.Names.Original + "Ids",
 	}
-	identifier := ""
+	var identifiers []string
 
 	for _, memberName := range shape.MemberNames() {
 		if util.InStrings(memberName, identifierLookup) {
-			if identifier == "" {
-				identifier = memberName
-			} else {
-				return "", errors.New(fmt.Sprintf(
-					"Found multiple possible identifiers for %s: %s, %s ",
-					r.Names.Original, identifier, memberName))
-			}
+			identifiers = append(identifiers, memberName)
 		}
 	}
 
-	return identifier, nil
+	return identifiers
 }
 
-// FindIdentifierInCRD returns the identifier field of a given CRD which
+// FindIdentifiersInCRD returns the identifier field of a given CRD which
 // can be singular or plural. Errors iff multiple identifier fields detected
 // in the CRD.
-func FindIdentifierInCRD(
-	r *model.CRD) (string, error) {
+func FindIdentifiersInCRD(
+	r *model.CRD) []string {
 	identifierLookup := []string{
+		"Id",
+		"Ids",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",
@@ -67,7 +62,7 @@ func FindIdentifierInCRD(
 		r.Names.Original + "Id",
 		r.Names.Original + "Ids",
 	}
-	identifier := ""
+	var identifiers []string
 
 	for _, id := range identifierLookup {
 		_, found := r.SpecFields[id]
@@ -75,15 +70,9 @@ func FindIdentifierInCRD(
 			_, found = r.StatusFields[id]
 		}
 		if found {
-			if identifier == "" {
-				identifier = id
-			} else {
-				return "", errors.New(fmt.Sprintf(
-					"Found multiple possible identifiers for %s: %s, %s ",
-					r.Names.Original, identifier, id))
-			}
+			identifiers = append(identifiers, id)
 		}
 	}
 
-	return identifier, nil
+	return identifiers
 }

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+)
+
+// FindIdentifierInShape returns the identifier field of a given shape which
+// can be singular or plural. Errors iff multiple identifier fields detected
+// in the shape.
+func FindIdentifierInShape(
+	r *model.CRD,
+	shape *awssdkmodel.Shape) (string, error) {
+	identifierLookup := []string{
+		"Name",
+		"Names",
+		r.Names.Original + "Name",
+		r.Names.Original + "Names",
+		r.Names.Original + "Id",
+		r.Names.Original + "Ids",
+	}
+	identifier := ""
+
+	for _, memberName := range shape.MemberNames() {
+		if util.InStrings(memberName, identifierLookup) {
+			if identifier == "" {
+				identifier = memberName
+			} else {
+				return "", errors.New(fmt.Sprintf(
+					"Found multiple possible identifiers for %s: %s, %s ",
+					r.Names.Original, identifier, memberName))
+			}
+		}
+	}
+
+	return identifier, nil
+}
+
+// FindIdentifierInCRD returns the identifier field of a given CRD which
+// can be singular or plural. Errors iff multiple identifier fields detected
+// in the CRD.
+func FindIdentifierInCRD(
+	r *model.CRD) (string, error) {
+	identifierLookup := []string{
+		"Name",
+		"Names",
+		r.Names.Original + "Name",
+		r.Names.Original + "Names",
+		r.Names.Original + "Id",
+		r.Names.Original + "Ids",
+	}
+	identifier := ""
+
+	for _, id := range identifierLookup {
+		_, found := r.SpecFields[id]
+		if !found {
+			_, found = r.StatusFields[id]
+		}
+		if found {
+			if identifier == "" {
+				identifier = id
+			} else {
+				return "", errors.New(fmt.Sprintf(
+					"Found multiple possible identifiers for %s: %s, %s ",
+					r.Names.Original, identifier, id))
+			}
+		}
+	}
+
+	return identifier, nil
+}

--- a/pkg/generate/code/common_test.go
+++ b/pkg/generate/code/common_test.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindIdentifierInShape_EC2_VPC_ReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expIdentifier := "VpcIds"
+	actualIdentifier, _ := code.FindIdentifierInShape(crd,
+		crd.Ops.ReadMany.InputRef.Shape)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifier),
+	)
+}
+
+func TestFindIdentifierInCRD_S3_Bucket_ReadMany_Empty(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	expIdentifier := ""
+	actualIdentifier, _ := code.FindIdentifierInShape(crd,
+		crd.Ops.ReadMany.InputRef.Shape)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifier),
+	)
+}
+
+func TestFindIdentifierInCRD_EC2_VPC_StatusField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expIdentifier := "VpcId"
+	actualIdentifier, _ := code.FindIdentifierInCRD(crd)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifier),
+	)
+}
+
+func TestFindIdentifierInCRD_S3_Bucket_SpecField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	expIdentifier := "Name"
+	actualIdentifier, _ := code.FindIdentifierInCRD(crd)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifier),
+	)
+}

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -52,7 +52,7 @@ ignore:
     - VpcEndpointConnectionNotification
     - VpcEndpointServiceConfiguration
     - VpcEndpoint
-    - Vpc
+    # - Vpc
     - VpcCidrBlock
     - VpcPeeringConnection
     - VpnConnectionRoute


### PR DESCRIPTION
Issue #, if available: [#890](https://github.com/aws-controllers-k8s/community/issues/890)
* This is preliminary work to aid in resolving this issue. A PR will follow to close out this issue completely.

Description of changes:
* Adds `getSanitizedMemberPath` helper to **check.go**
* Adds new file `common.go` containing helpers that can be used throughout `code` pkg. These 2 helpers make it easier to extract identifier(s) from a given Shape or CRD

Testing:
* `make test` ✅

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
