### PR TITLE
Update to ACK Runtime `v0.9.2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.9.0"
+VERSION ?= "v0.9.2"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.9.0
+	github.com/aws-controllers-k8s/runtime v0.9.2
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.9.0 h1:7Af+PDcxVcx/xrm0nVQJxUm/qM5Of2nhtLIz/QZoshk=
-github.com/aws-controllers-k8s/runtime v0.9.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.9.2 h1:53ahm38Cn6DTfQdHNrTgbXmUbCjuKntvhkuWGHkAQ18=
+github.com/aws-controllers-k8s/runtime v0.9.2/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -64,10 +64,6 @@ func (fd *fakeDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta {
 	return nil
 }
 
-func (fd *fakeDescriptor) UpdateCRStatus(acktypes.AWSResource) (bool, error) {
-	return false, nil
-}
-
 func (fd *fakeDescriptor) IsManaged(acktypes.AWSResource) bool {
 	return false
 }
@@ -163,8 +159,12 @@ func TestRuntimeDependency(t *testing.T) {
 
 	// ACK runtime 0.8.0 removed the unused UpdateCRStatus method from
 	// AWSResourceDescriptor
-	rd := new(acktypes.AWSResourceDescriptor)
-	rdType := reflect.TypeOf(rd)
+	rdType := reflect.TypeOf((*acktypes.AWSResourceDescriptor)(nil)).Elem()
 	_, found := rdType.MethodByName("UpdateCRStatus")
 	require.False(found)
+
+	// ACK runtime 0.9.2 introduced the SetStatus method into AWSResource
+	resType := reflect.TypeOf((*acktypes.AWSResource)(nil)).Elem()
+	_, found = resType.MethodByName("SetStatus")
+	require.True(found)
 }


### PR DESCRIPTION
Update the dependent version of ACK runtime to `v0.9.2` and update the `code-generator` version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
