### PR TITLE
Add operator-sdk and olm scripts to code-generator repo.

### DIFF
--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-operator-sdk.sh
+#
+#
+# Installs Operator SDK if not installed. Optional parameters specifies the
+# version of Operator SDK to install. Defaults tot eh value of the environment
+# variable OPERATOR_SDK_VERSION and if that is not set, the value of the
+# DEFAULT_OPERATOR_SDK_VERSION variable.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/operator-sdk
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+DEFAULT_OPERATOR_SDK_VERSION="1.7.1"
+
+source "${SCRIPTS_DIR}/lib/common.sh"
+
+__operator_sdk_version="${1}"
+if [ "x${__operator_sdk_version}" == "x" ]; then
+    __operator_sdk_version=${OPERATOR_SDK_VERSION:-$DEFAULT_OPERATOR_SDK_VERSION}
+fi
+if ! is_installed operator-sdk; then
+    __platform=$(uname | tr '[:upper:]' '[:lower:]')
+    __tmp_install_dir=$(mktemp -d -t install-operator-sdk-XXX)
+    __operator_sdk_url="https://github.com/operator-framework/operator-sdk/releases/download/v${__operator_sdk_version}/operator-sdk_${__platform}_amd64"
+    echo -n "installing operator-sdk from ${__operator_sdk_url} ... "
+    curl -sq -L ${__operator_sdk_url} --output ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
+    chmod +x ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
+    sudo mv ${__tmp_install_dir}/operator-sdk_${__platform}_amd64 /usr/local/bin/operator-sdk
+    echo "ok."
+fi

--- a/scripts/olm-build-bundle-image.sh
+++ b/scripts/olm-build-bundle-image.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+ROOT_DIR=$DIR/..
+BUILD_DATE=$(date +%Y-%m-%dT%H:%M)
+QUIET=${QUIET:-"false"}
+DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
+DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
+
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+source $SCRIPTS_DIR/lib/common.sh
+
+check_is_installed docker
+
+# red hat operator certification requires additional labels and metadata
+# in the bundle container image. 
+
+# details on the required bundle labels
+# https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
+DEFAULT_ADD_RH_CERTIFICATION_LABELS="false"
+ADD_RH_CERTIFICATION_LABELS=${ADD_RH_CERTIFICATION_LABELS:-$DEFAULT_ADD_RH_CERTIFICATION_LABELS}
+
+# details on how versions are reflected by this label.
+# https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+cert_label_openshift_supported_version="com.redhat.openshift.versions"
+DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS="v4.6" # v4.6 and on
+SUPPORTED_OPENSHIFT_VERSIONS=${SUPPORTED_OPENSHIFT_VERSIONS:-$DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS}
+
+# Identifies that the delivery mechanism is the bundle format
+cert_label_operator_bundle_delivery="com.redhat.delivery.operator.bundle"
+DEFAULT_RED_HAT_DELIVERY_BUNDLE="true"
+RED_HAT_DELIVERY_BUNDLE=${RED_HAT_DELIVERY_BUNDLE:-$DEFAULT_RED_HAT_DELIVERY_BUNDLE}
+
+# Do not backport to OpenShift versions prior to v4.5 by default.
+cert_label_deliver_backport="com.redhat.deliver.backport"
+DEFAULT_RED_HAT_DELIVER_BACKPORT="false" # do not list in openshift <v4.5
+RED_HAT_DELIVER_BACKPORT=${RED_HAT_DELIVER_BACKPORT:-$DEFAULT_RED_HAT_DELIVER_BACKPORT}
+
+USAGE="
+Usage:
+  $(basename "$0") <aws_service> <bundle_version>
+
+Builds the Docker image for an ACK service controller. 
+
+Example: $(basename "$0") ecr
+
+<aws_service> should be an AWS Service name (ecr, sns, sqs, petstore, bookstore)
+<bundle_version> an operator lifecycle manager bundle version in semver (0.0.1, 1.0.0)
+
+
+Environment variables:
+  QUIET:                            Build bundle container image quietly (<true|false>)
+                                    Default: false
+  SERVICE_CONTROLLER_SOURCE_PATH:   Path to the service controller source code
+                                    repository.
+                                    Default: ../{SERVICE}-controller
+  DOCKER_REPOSITORY:                Name for the Docker repository to push to 
+                                    Default: $DEFAULT_DOCKER_REPOSITORY
+  BUNDLE_DOCKERFILE_DIR:            Specify the directory where the bundle.Dockerfile exists.
+                                    Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm
+  BUNDLE_DOCKER_IMG_TAG:            Bundle container image tag
+                                    Default: \$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  BUNDLE_DOCKER_IMG:                The bundle container image (including the tag).
+                                    Supercedes the use of BUNDLE_DOCKER_IMAGE_TAG
+                                    and DOCKER_REPOSITORY if set.
+                                    Default: $DEFAULT_DOCKER_REPOSITORY:\$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  ADD_RH_CERTIFICATION_LABELS       Adds the certification labels required by Red Hat
+                                    container certification (<true|false>)
+                                    Default: $DEFAULT_ADD_RH_CERTIFICATION_LABELS
+  SUPPORTED_OPENSHIFT_VERSIONS:     Indicates what versions of OpenShift are supported
+                                    Only used if the ADD_RH_CERTIFICATION_LABELS is
+                                    set to true.
+                                    Default: $DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS
+  RED_HAT_DELIVERY_BUNDLE:          Red Hat should deliver the operator as a bundle.
+                                    Only used if the ADD_RH_CERTIFICATION_LABELS is
+                                    set to true.
+                                    Default: $DEFAULT_RED_HAT_DELIVERY_BUNDLE
+  RED_HAT_DELIVER_BACKPORT:         Red Hat should backport the operator to versions of
+                                    OpenShift prior to v4.5. Only used if the
+                                    ADD_RH_CERTIFICATION_LABELS is set to true.
+                                    Default: $DEFAULT_RED_HAT_DELIVER_BACKPORT
+"
+
+if [ $# -ne 2 ]; then
+    echo "AWS_SERVICE or BUNDLE_VERSION is not defined. Script accepts two parameters, the <AWS_SERVICE> and the <BUNDLE_VERSION> to build." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+BUNDLE_VERSION="$2"
+
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$AWS_SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+DEFAULT_BUNDLE_DOCKERFILE_DIR="${SERVICE_CONTROLLER_SOURCE_PATH}/olm"
+BUNDLE_DOCKERFILE_DIR=${BUNDLE_DOCKERFILE_DIR:-$DEFAULT_BUNDLE_DOCKERFILE_DIR}
+BUNDLE_DOCKERFILE="$BUNDLE_DOCKERFILE_DIR/bundle.Dockerfile"
+
+# stop if the dockerfile was not found
+if [ ! -f $BUNDLE_DOCKERFILE ]; then
+  echo "The bundle.Dockerfile was not found at expected path $BUNDLE_DOCKERFILE."
+  exit 1
+fi
+
+DEFAULT_BUNDLE_DOCKER_IMG_TAG="$AWS_SERVICE-bundle-$BUNDLE_VERSION"
+BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
+BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
+
+build_args="--quiet=${QUIET} -t ${BUNDLE_DOCKER_IMG} -f ${BUNDLE_DOCKERFILE} --build-arg build_date=\"$BUILD_DATE\""
+
+if [[ $ADD_RH_CERTIFICATION_LABELS = "true" ]]; then 
+  # add additional labels with values for certification purposes.
+  build_args="$build_args --label=$cert_label_openshift_supported_version=$SUPPORTED_OPENSHIFT_VERSIONS --label=$cert_label_deliver_backport=$RED_HAT_DELIVER_BACKPORT --label=$cert_label_operator_bundle_delivery=$RED_HAT_DELIVERY_BUNDLE"
+fi
+
+if [[ $QUIET = "false" ]]; then
+    echo "building '$AWS_SERVICE' OLM bundle container image with tag: ${BUNDLE_DOCKER_IMG}"
+fi
+
+pushd $BUNDLE_DOCKERFILE_DIR 1>/dev/null
+docker build $build_args .
+
+if [ $? -ne 0 ]; then
+  exit 2
+fi
+
+popd 1>/dev/null

--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# A script that creates the Operator Lifecycle Manager bundle for a
+# specific ACK service controller
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+BUILD_DIR="$ROOT_DIR/build"
+DEFAULT_BUNDLE_CHANNEL="alpha"
+DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
+PRESERVE=${PRESERVE:-"false"}
+
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+check_is_installed uuidgen
+check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
+check_is_installed operator-sdk "You can install Operator SDK with the helmer scripts/install-operator-sdk.sh"
+
+function clean_up {
+    if [[ "$PRESERVE" == false ]]; then
+        rm -r "$TMP_DIR" || :
+        return
+    fi
+    echo "--"
+    echo "To regenerate bundle with the same kustomize configs, re-run with:
+    \"TMP_DIR=$TMP_DIR\""
+}
+
+USAGE="
+Usage:
+  $(basename "$0") <service> <version>
+
+<service> should be an AWS service API aliases that you wish to build -- e.g.
+'s3' 'sns' or 'sqs'
+
+Environment variables:
+  BUNDLE_DEFAULT_CHANNEL                    The default channel to publish the OLM bundle to.
+                                            Default: $DEFAULT_BUNDLE_CHANNEL
+  BUNDLE_VERSION                            The semantic version of the bundle should it need
+                                            to differ from the version of the controller which is
+                                            passed into the script. Optional. If unset, this
+                                            value will match that passed in by the user as the
+                                            <version> parameter (i.e. the controller version)
+  BUNDLE_CHANNELS                           A comma-separated list of channels the bundle belongs
+                                            to (e.g. \"alpha,beta\").
+                                            Default: $DEFAULT_BUNDLE_CHANNEL
+  BUNDLE_OUTPUT_PATH:                       Specify a path for the OLM bundle to output to.
+                                            Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm
+  AWS_SERVICE_DOCKER_IMG:                   Specify the docker image for the AWS service.
+                                            This should include the registry, namespace,
+                                            image name, and tag. Takes precedence over
+                                            SERVICE_CONTROLLER_CONTAINER_REPOSITORY
+  SERVICE_CONTROLLER_SOURCE_PATH:           Path to the service controller source code
+                                            repository.
+                                            Default: ../{SERVICE}-controller
+  SERVICE_CONTROLLER_CONTAINER_REPOSITORY   The container repository where the controller exists.
+                                            This should include the registry, namespace, and
+                                            image name.
+                                            Default: $DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY
+  TMP_DIR                                   Directory where kustomize assets will be temporarily
+                                            copied before they are modified and passed to bundle
+                                            generation logic.
+                                            Default: $BUILD_DIR/tmp-olm-{RANDOMSTRING}
+  PRESERVE:                                 Preserves modified kustomize configs for
+                                            inspection. (<true|false>)
+                                            Default: false
+  BUNDLE_GENERATE_EXTRA_ARGS                Extra arguments to pass into the command
+                                            'operator-sdk generate bundle'.
+"
+
+if [ $# -ne 2 ]; then
+    echo "ERROR: $(basename "$0") accepts two parameters, the SERVICE and VERSION" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+VERSION=$2
+BUNDLE_VERSION=${BUNDLE_VERSION:-$VERSION}
+
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+
+BUNDLE_OUTPUT_PATH=${BUNDLE_OUTPUT_PATH:-$SERVICE_CONTROLLER_SOURCE_PATH/olm}
+
+if [ -z "$TMP_DIR" ]; then
+    TMP_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    TMP_DIR=$BUILD_DIR/tmp-olm-$TMP_ID
+fi
+# if TMP_DIR is provided but doesn't exist, we still use
+# it and create it later.
+tmp_kustomize_config_dir="$TMP_DIR/config"
+
+if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
+    echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2
+    echo "$SERVICE_CONTROLLER_SOURCE_PATH is not a directory." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+# Set controller image.
+if [ -n "$AWS_SERVICE_DOCKER_IMG" ] && [ -n "$SERVICE_CONTROLLER_CONTAINER_REPOSITORY" ] ; then
+  # It's possible to set the repository (i.e. everything except the tag) as well as the
+  # entire path including the tag using AWS_SERVIC_DOCKER_IMG. If the latter is set, it
+  # will take precedence, so inform the user that this will happen in case the usage of
+  # each configurable is unclear before runtime. 
+  echo "both AWS_SERVICE_DOCKER_IMG and SERVICE_CONTROLLER_CONTAINER REPOSITORY are set."
+  echo "AWS_SERVICE_DOCKER_IMG is expected to be more complete and will take precedence."
+  echo "Ignoring SERVICE_CONTROLLER_CONTAINER_REPOSITORY."
+fi
+
+SERVICE_CONTROLLER_CONTAINER_REPOSITORY=${SERVICE_CONTROLLER_CONTAINER_REPOSITORY:-$DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY}
+DEFAULT_AWS_SERVICE_DOCKER_IMAGE="$SERVICE_CONTROLLER_CONTAINER_REPOSITORY:$SERVICE-$VERSION"
+AWS_SERVICE_DOCKER_IMG=${AWS_SERVICE_DOCKER_IMG:-$DEFAULT_AWS_SERVICE_DOCKER_IMAGE}
+
+trap "clean_up" EXIT
+
+# prepare the temporary config dir
+mkdir -p $TMP_DIR
+cp -a $SERVICE_CONTROLLER_SOURCE_PATH/config $TMP_DIR
+pushd $tmp_kustomize_config_dir/controller 1>/dev/null
+kustomize edit set image controller="$AWS_SERVICE_DOCKER_IMG"
+popd 1>/dev/null
+
+# prepare bundle generate arguments
+opsdk_gen_bundle_args="--version $BUNDLE_VERSION --package ack-$SERVICE-controller --kustomize-dir $SERVICE_CONTROLLER_SOURCE_PATH/config/manifests --overwrite "
+
+# specify default channel and all channels if not specified by user
+BUNDLE_DEFAULT_CHANNEL=${BUNDLE_DEFAULT_CHANNEL:-$DEFAULT_BUNDLE_CHANNEL}
+BUNDLE_CHANNELS=${BUNDLE_CHANNELS:-$DEFAULT_BUNDLE_CHANNEL}
+
+opsdk_gen_bundle_args="$opsdk_gen_bundle_args --default-channel $DEFAULT_BUNDLE_CHANNEL --channels $BUNDLE_CHANNELS"
+if [ -n "$BUNDLE_GENERATE_EXTRA_ARGS" ]; then
+    opsdk_gen_bundle_args="$opsdk_gen_bundle_args $BUNDLE_GENERATE_EXTRA_ARGS"
+fi
+
+# operator-sdk generate bundle creates a bundle.Dockerfile relative
+# to where it's called and it cannot be changed as of right now.
+# For the time being, keep the bundle.Dockerfile local to the actual
+# bundle assets.
+# TODO(): determine if it makes sense to keep the bundle.Dockerfiles
+# in the controller-specific repositories.
+mkdir -p $BUNDLE_OUTPUT_PATH
+pushd $BUNDLE_OUTPUT_PATH 1> /dev/null
+kustomize build $tmp_kustomize_config_dir/manifests | operator-sdk generate bundle $opsdk_gen_bundle_args 
+popd 1> /dev/null
+
+operator-sdk bundle validate $BUNDLE_OUTPUT_PATH/bundle

--- a/scripts/olm-publish-bundle-image.sh
+++ b/scripts/olm-publish-bundle-image.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
+DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
+
+source $SCRIPTS_DIR/lib/common.sh
+
+check_is_installed docker
+
+USAGE="
+Usage:
+  $(basename "$0") <AWS_SERVICE> <BUNDLE_VERSION>
+
+Publishes the Docker image for an ACK service OLM bundle. By default, the
+repository will be $DEFAULT_DOCKER_REPOSITORY and the image tag for the
+specific ACK service controller will be ":\$SERVICE-bundle-\$VERSION".
+
+<AWS_SERVICE> AWS Service name (ecr, sns, sqs)
+<BUNDLE_VERSION> OLM bundle version in SemVer (0.0.1, 1.0.0)
+
+Example: 
+export DOCKER_REPOSITORY=aws-controllers-k8s
+$(basename "$0") ecr 0.0.1
+
+Environment variables:
+  DOCKER_REPOSITORY:        Name for the Docker repository to push to 
+                            Default: $DEFAULT_DOCKER_REPOSITORY
+  BUNDLE_DOCKER_IMG_TAG:    Bundle container image tag
+                            Default: \$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  BUNDLE_DOCKER_IMG:        The bundle container image (including the tag).
+                            Supercedes the use of BUNDLE_DOCKER_IMAGE_TAG
+                            and DOCKER_REPOSITORY if set.
+                            Default: $DEFAULT_DOCKER_REPOSITORY:\$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+"
+
+if [ $# -ne 2 ]; then
+    echo "AWS_SERVICE or BUNDLE_VERSION is not defined. Script accepts two parameters, the <AWS_SERVICE> and the <BUNDLE_VERSION> to build." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+BUNDLE_VERSION="$2"
+
+DEFAULT_BUNDLE_DOCKER_IMG_TAG="$AWS_SERVICE-bundle-$BUNDLE_VERSION"
+BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
+BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
+
+export BUNDLE_DOCKER_IMG
+${SCRIPTS_DIR}/olm-build-bundle-image.sh ${AWS_SERVICE} ${BUNDLE_VERSION}
+
+echo "Pushing '$AWS_SERVICE' operator lifecycle manager bundle image with tag: ${BUNDLE_DOCKER_IMG_TAG}"
+
+docker push ${BUNDLE_DOCKER_IMG}
+
+if [ $? -ne 0 ]; then
+  exit 2
+fi


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/863

Description of changes:
Migrate operator-sdk and olm scripts out of community repo to code-gen repo.
https://github.com/aws-controllers-k8s/community/pull/897

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
