### PR TITLE
Implement ReadMany for CheckRequiredFieldsMissingFromShape

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -109,6 +109,9 @@ var (
 		"GoCodeRequiredFieldsMissingFromReadOneInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
 			return code.CheckRequiredFieldsMissingFromShape(r, ackmodel.OpTypeGet, koVarName, indentLevel)
 		},
+		"GoCodeRequiredFieldsMissingFromReadManyInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
+			return code.CheckRequiredFieldsMissingFromShape(r, ackmodel.OpTypeList, koVarName, indentLevel)
+		},
 		"GoCodeRequiredFieldsMissingFromGetAttributesInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
 			return code.CheckRequiredFieldsMissingFromShape(r, ackmodel.OpTypeGetAttributes, koVarName, indentLevel)
 		},

--- a/pkg/generate/code/check.go
+++ b/pkg/generate/code/check.go
@@ -196,6 +196,10 @@ func checkRequiredFieldsMissingFromShapeReadMany(
 		for _, ci := range crIdentifiers {
 			if strings.EqualFold(pluralize.Singular(si),
 				pluralize.Singular(ci)) {
+				// The CRD identifiers being used for comparison reflect the
+				// *original* field names in the API model shape.
+				// Field renames are handled below in the call to
+				// getSanitizedMemberPath.
 				if reqIdentifier == "" {
 					reqIdentifier = ci
 				} else {

--- a/pkg/generate/code/check_test.go
+++ b/pkg/generate/code/check_test.go
@@ -115,3 +115,24 @@ func TestCheckRequiredFields_RenamedSpecField(t *testing.T) {
 		strings.TrimSpace(gotCode),
 	)
 }
+
+func TestCheckRequiredFields_StatusField_ReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expRequiredFieldsCode := `
+	return r.ko.Status.VPCID == nil
+`
+	gotCode := code.CheckRequiredFieldsMissingFromShape(
+		crd, model.OpTypeList, "r.ko", 1,
+	)
+	assert.Equal(
+		strings.TrimSpace(expRequiredFieldsCode),
+		strings.TrimSpace(gotCode),
+	)
+}

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -32,12 +32,12 @@ func FindIdentifiersInShape(
 	identifierLookup := []string{
 		"Id",
 		"Ids",
+		r.Names.Original + "Id",
+		r.Names.Original + "Ids",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",
 		r.Names.Original + "Names",
-		r.Names.Original + "Id",
-		r.Names.Original + "Ids",
 	}
 
 	for _, memberName := range shape.MemberNames() {
@@ -50,7 +50,8 @@ func FindIdentifiersInShape(
 }
 
 // FindIdentifiersInCRD returns the identifier fields of a given CRD which
-// can be singular or plural.
+// can be singular or plural. Note, these fields will be the *original* field
+// names from the API model shape, not renamed field names.
 func FindIdentifiersInCRD(
 	r *model.CRD) []string {
 	var identifiers []string
@@ -60,12 +61,12 @@ func FindIdentifiersInCRD(
 	identifierLookup := []string{
 		"Id",
 		"Ids",
+		r.Names.Original + "Id",
+		r.Names.Original + "Ids",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",
 		r.Names.Original + "Names",
-		r.Names.Original + "Id",
-		r.Names.Original + "Ids",
 	}
 
 	for _, id := range identifierLookup {

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -21,11 +21,14 @@ import (
 )
 
 // FindIdentifiersInShape returns the identifier fields of a given shape which
-// can be singular or plural. Errors iff multiple identifier fields detected
-// in the shape.
+// can be singular or plural.
 func FindIdentifiersInShape(
 	r *model.CRD,
 	shape *awssdkmodel.Shape) []string {
+	var identifiers []string
+	if r == nil || shape == nil {
+		return identifiers
+	}
 	identifierLookup := []string{
 		"Id",
 		"Ids",
@@ -36,7 +39,6 @@ func FindIdentifiersInShape(
 		r.Names.Original + "Id",
 		r.Names.Original + "Ids",
 	}
-	var identifiers []string
 
 	for _, memberName := range shape.MemberNames() {
 		if util.InStrings(memberName, identifierLookup) {
@@ -47,11 +49,14 @@ func FindIdentifiersInShape(
 	return identifiers
 }
 
-// FindIdentifiersInCRD returns the identifier field of a given CRD which
-// can be singular or plural. Errors iff multiple identifier fields detected
-// in the CRD.
+// FindIdentifiersInCRD returns the identifier fields of a given CRD which
+// can be singular or plural.
 func FindIdentifiersInCRD(
 	r *model.CRD) []string {
+	var identifiers []string
+	if r == nil {
+		return identifiers
+	}
 	identifierLookup := []string{
 		"Id",
 		"Ids",
@@ -62,7 +67,6 @@ func FindIdentifiersInCRD(
 		r.Names.Original + "Id",
 		r.Names.Original + "Ids",
 	}
-	var identifiers []string
 
 	for _, id := range identifierLookup {
 		_, found := r.SpecFields[id]


### PR DESCRIPTION
Issue #, if available: [#890](https://github.com/aws-controllers-k8s/community/issues/890)

Description of changes:
* Adds checkRequiredFieldsMissingFromShapeReadMany to `check.go` to handle ReadMany operations without a corresponding ReadOne. 
* The new method will **require resource identifier field** should there exist an *identifier* or *identifierS* field in the ReadMany operation. 
  * Eventually `newListRequestPayload` will use this identifier field to populate its request in order to guarantee the ReadMany operation returns the desired resource.
  * ex: DescribeVpcs has a VpcIds field. Therefore, Vpc shape should require VpcId, which is part of its status field.
* Updated tests and templates

Testing:
* `make test` ✅
* `make build-controller`  ✅

```
func (rm *resourceManager) sdkFind(
	ctx context.Context,
	r *resource,
) (latest *resource, err error) {
	rlog := ackrtlog.FromContext(ctx)
	exit := rlog.Trace("rm.sdkFind")
	defer exit(err)
	// If any required fields in the input shape are missing, AWS resource is
	// not created yet. Return NotFound here to indicate to callers that the
	// resource isn't yet created.
	if rm.requiredFieldsMissingFromReadManyInput(r) {
		return nil, ackerr.NotFound
	}

	input, err := rm.newListRequestPayload(r)

...


// requiredFieldsMissingFromReadManyInput returns true if there are any fields
// for the ReadMany Input shape that are required but not present in the
// resource's Spec or Status
func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
	r *resource,
) bool {
	return r.ko.Status.VPCID == nil

}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
