### PR TITLE
Implement ReadMany operation for SetSDK generator function

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1106,7 +1106,7 @@ func SetSDKForStruct(
 }
 
 // setSDKForSlice returns a string of Go code that sets a target variable value
-// to a source variable when the type of the source variable is a struct.
+// to a source variable when the type of the source variable is a slice.
 func setSDKForSlice(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
@@ -1171,7 +1171,7 @@ func setSDKForSlice(
 }
 
 // setSDKForMap returns a string of Go code that sets a target variable value
-// to a source variable when the type of the source variable is a struct.
+// to a source variable when the type of the source variable is a map.
 func setSDKForMap(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -19,10 +19,12 @@ import (
 	"strings"
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+	"github.com/gertd/go-pluralize"
 
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/names"
+	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
 // SetSDK returns the Go code that sets an SDK input shape's member fields from
@@ -98,6 +100,8 @@ func SetSDK(
 		op = r.Ops.ReadOne
 	case model.OpTypeList:
 		op = r.Ops.ReadMany
+		return setSDKReadMany(cfg, r, op,
+			sourceVarName, targetVarName, indentLevel)
 	case model.OpTypeUpdate:
 		op = r.Ops.Update
 	case model.OpTypeDelete:
@@ -715,6 +719,139 @@ func SetSDKSetAttributes(
 			"%s}\n", indent,
 		)
 	}
+	return out
+}
+
+// setSDKReadMany is a special-case handling of those APIs where there is no
+// ReadOne operation and instead the only way to grab information for a single
+// object is to call the ReadMany/List operation with one of more filtering
+// fields-- specifically identifier(s). This method populates this identifier
+// field with the identifier shared between the shape and the CR. Note, in the
+// case of multiple matching identifiers, the identifier field containing 'Id'
+// will be the only field populated.
+//
+// As an example, DescribeVpcs EC2 API call doesn't have a ReadOne operation or
+// required fields. However, the input shape VpcIds field can be populated using
+// a VpcId, a field in the VPC CR's Status. Therefore, populate VpcIds field
+// with the *single* VpcId value to ensure the returned array from the API call
+// consists only of the desired Vpc.
+func setSDKReadMany(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	op *awssdkmodel.Operation,
+	sourceVarName string,
+	targetVarName string,
+	indentLevel int,
+) string {
+	inputShape := op.InputRef.Shape
+	if inputShape == nil {
+		return ""
+	}
+
+	out := "\n"
+	indent := strings.Repeat("\t", indentLevel)
+
+	resVarPath := ""
+	pluralize := pluralize.NewClient()
+	opConfig, override := cfg.OverrideValues(op.Name)
+	shapeIdentifiers := FindIdentifiersInShape(r, inputShape)
+	var err error
+	for memberIndex, memberName := range inputShape.MemberNames() {
+		if override {
+			value, ok := opConfig[memberName]
+			memberShapeRef, _ := inputShape.MemberRefs[memberName]
+			memberShape := memberShapeRef.Shape
+			if ok {
+				switch memberShape.Type {
+				case "boolean", "integer":
+				case "string":
+					value = "\"" + value + "\""
+				default:
+					panic("Member type not handled")
+				}
+
+				out += fmt.Sprintf("%s%s.Set%s(%s)\n", indent, targetVarName, memberName, value)
+				continue
+			}
+		}
+
+		// Field renames are handled in getSanitizedMemberPath
+		resVarPath, err = getSanitizedMemberPath(memberName, r, op, sourceVarName)
+		if err != nil {
+			// if it's an identifier field check for singular/plural
+			if util.InStrings(memberName, shapeIdentifiers) {
+				var flipped string
+				if pluralize.IsPlural(memberName) {
+					flipped = pluralize.Singular(memberName)
+				} else {
+					flipped = pluralize.Plural(memberName)
+				}
+				// If there are multiple identifiers, then prioritize the
+				// 'Id' identifier.
+				if resVarPath == "" || (!strings.HasSuffix(resVarPath, "Id") ||
+					!strings.HasSuffix(resVarPath, "Ids")) {
+					resVarPath, err = getSanitizedMemberPath(flipped, r, op, sourceVarName)
+				}
+			} else {
+				// TODO(jaypipes): check generator config for exceptions?
+				continue
+			}
+		}
+
+		memberShapeRef, _ := inputShape.MemberRefs[memberName]
+		memberShape := memberShapeRef.Shape
+		out += fmt.Sprintf(
+			"%sif %s != nil {\n", indent, resVarPath,
+		)
+
+		switch memberShape.Type {
+		case "list":
+			// Expecting slice of identifiers
+			{
+				memberVarName := fmt.Sprintf("f%d", memberIndex)
+				// f0 := []*string{}
+				out += varEmptyConstructorSDKType(
+					cfg, r,
+					memberVarName,
+					memberShape,
+					indentLevel+1,
+				)
+
+				//  f0 = append(f0, sourceVarName)
+				out += fmt.Sprintf("%s\t%s = append(%s, %s)\n", indent,
+					memberVarName, memberVarName, resVarPath)
+
+				// res.SetIds(f0)
+				out += setSDKForScalar(
+					cfg, r,
+					memberName,
+					targetVarName,
+					inputShape.Type,
+					sourceVarName,
+					memberVarName,
+					memberShapeRef,
+					indentLevel+1,
+				)
+			}
+		default:
+			// For rare ReadMany that have a singular identifier field.
+			// ex: DescribeReplicationGroups
+			out += setSDKForScalar(
+				cfg, r,
+				memberName,
+				targetVarName,
+				inputShape.Type,
+				sourceVarName,
+				resVarPath,
+				memberShapeRef,
+				indentLevel+1,
+			)
+		}
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
+	}
+
 	return out
 }
 

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -1778,3 +1778,28 @@ func TestSetSDK_MQ_Broker_Create(t *testing.T) {
 		code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1),
 	)
 }
+
+func TestSetSDK_EC2_VPC_ReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Spec.DryRun != nil {
+		res.SetDryRun(*r.ko.Spec.DryRun)
+	}
+	if r.ko.Status.VPCID != nil {
+		f4 := []*string{}
+		f4 = append(f4, r.ko.Status.VPCID)
+		res.SetVpcIds(f4)
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeList, "r.ko", "res", 1),
+	)
+}

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -1789,9 +1789,6 @@ func TestSetSDK_EC2_VPC_ReadMany(t *testing.T) {
 	require.NotNil(crd)
 
 	expected := `
-	if r.ko.Spec.DryRun != nil {
-		res.SetDryRun(*r.ko.Spec.DryRun)
-	}
 	if r.ko.Status.VPCID != nil {
 		f4 := []*string{}
 		f4 = append(f4, r.ko.Status.VPCID)

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -1,4 +1,6 @@
 ignore:
+  field_paths:
+    - CreateVpcInput.DryRun
   resource_names:
     - AccountAttribute
     - CapacityReservation


### PR DESCRIPTION
Issue #, if available: [#891](https://github.com/aws-controllers-k8s/community/issues/891)

Description of changes:
* adds `setSDKReadMany` func to SetSDK
* adds unit test

Testing:
* `make test` ✅
* `make build-controller`  ✅

```
// newListRequestPayload returns SDK-specific struct for the HTTP request
// payload of the List API call for the resource
func (rm *resourceManager) newListRequestPayload(
	r *resource,
) (*svcsdk.DescribeVpcsInput, error) {
	res := &svcsdk.DescribeVpcsInput{}

	if r.ko.Spec.DryRun != nil {
		res.SetDryRun(*r.ko.Spec.DryRun)
	}
	if r.ko.Status.VPCID != nil {
		f4 := []*string{}
		f4 = append(f4, r.ko.Status.VPCID)
		res.SetVpcIds(f4)
	}

	return res, nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
