### PR TITLE
use reflect to compare map/slice struct

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -36,6 +36,44 @@ import (
 // constructed from the Read operation, is compared to the Resource we got from
 // the Kubernetes API server's event bus. The code that is returned from this
 // function is the code that compares those two Resources.
+//
+// The Go code we return depends on the Go type of the various fields for the
+// resource being compared.
+//
+// For *scalar* Go types, the output Go code looks like this:
+//
+// if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
+//     delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+// } else if a.ko.Spec.GrantFullControl != nil && b.ko.Spec.GrantFullControl != nil {
+//     if *a.ko.Spec.GrantFullControl != *b.ko.Spec.GrantFullControl {
+//         delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+//     }
+// }
+//
+// For *struct* Go types, the output Go code looks like this (note that it is a
+// simple recursive-descent output of all the struct's fields...):
+//
+// if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
+//     delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
+// } else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
+//     if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
+//         delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+//     } else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil {
+//         if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
+//             delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+//         }
+//     }
+// }
+//
+// For *slice of strings* Go types, the output Go code looks like this:
+//
+// if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
+//     delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
+// } else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
+//     if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
+//         delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
+//     }
+// }
 func CompareResource(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
@@ -113,8 +151,6 @@ func CompareResource(
 				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
 			)
 			indentLevel++
-		} else {
-			out += "\n"
 		}
 
 		switch memberShape.Type {
@@ -531,8 +567,6 @@ func compareStruct(
 				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
 			)
 			indentLevel++
-		} else {
-			out += "\n"
 		}
 		switch memberShape.Type {
 		case "structure":

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -399,10 +399,15 @@ func compareMap(
 			indent, firstResVarName, secondResVarName,
 		)
 	case "structure":
-		// TODO(jaypipes): Implement this by walking the keys and struct values
-		// and comparing each struct individually, building up the fieldPath
-		// appropriately...
-		return ""
+		// NOTE(jaypipes): Using reflect here is really punting. We should
+		// implement this in a cleaner, more efficient fashion by walking the
+		// keys and struct values and comparing each struct individually,
+		// building up the fieldPath appropriately and calling into a
+		// struct-specific comparator function...
+		out += fmt.Sprintf(
+			"%sif !reflect.DeepEqual(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
 	default:
 		panic("Unsupported shape type in generate.code.compareMap: " + shape.Type)
 	}
@@ -467,10 +472,16 @@ func compareSlice(
 			indent, firstResVarName, secondResVarName,
 		)
 	case "structure":
-		// TODO(jaypipes): Implement this by walking the slice of struct values
-		// and comparing each struct individually, building up the fieldPath
-		// appropriately...
-		return ""
+		// NOTE(jaypipes): Using reflect here is really punting. We should
+		// implement this in a cleaner, more efficient fashion by walking the
+		// struct values and comparing each struct individually, building up
+		// the fieldPath appropriately and calling into a struct-specific
+		// comparator function...the tricky part of this is figuring out how to
+		// sort the slice of structs...
+		out += fmt.Sprintf(
+			"%sif !reflect.DeepEqual(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
 	default:
 		panic("Unsupported shape type in generate.code.compareSlice: " + shape.Type)
 	}

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -94,6 +94,9 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 					delta.Add("Spec.Logging.LoggingEnabled.TargetBucket", a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket)
 				}
 			}
+			if !reflect.DeepEqual(a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants) {
+				delta.Add("Spec.Logging.LoggingEnabled.TargetGrants", a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants)
+			}
 			if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix) {
 				delta.Add("Spec.Logging.LoggingEnabled.TargetPrefix", a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix)
 			} else if a.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil && b.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil {

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -94,7 +94,6 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 					delta.Add("Spec.Logging.LoggingEnabled.TargetBucket", a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket)
 				}
 			}
-
 			if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix) {
 				delta.Add("Spec.Logging.LoggingEnabled.TargetPrefix", a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix)
 			} else if a.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil && b.ko.Spec.Logging.LoggingEnabled.TargetPrefix != nil {
@@ -140,7 +139,6 @@ func TestCompareResource_Lambda_CodeSigningConfig(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
 		delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
 	} else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
-
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
 			delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
 		}

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -3,21 +3,28 @@
 package {{ .CRD.Names.Snake }}
 
 import (
+	"reflect"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &reflect.Method{}
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two
 // resources
 func newResourceDelta(
-    a *resource,
-    b *resource,
+	a *resource,
+	b *resource,
 ) *ackcompare.Delta {
-    delta := ackcompare.NewDelta()
-    if ((a == nil && b != nil) ||
-            (a != nil && b == nil)) {
-        delta.Add("", a, b)
-        return delta
-    }
+	delta := ackcompare.NewDelta()
+	if ((a == nil && b != nil) ||
+			(a != nil && b == nil)) {
+		delta.Add("", a, b)
+		return delta
+	}
 
 {{- if $hookCode := Hook .CRD "delta_pre_compare" }}
 {{ $hookCode }}
@@ -26,5 +33,5 @@ func newResourceDelta(
 {{- if $hookCode := Hook .CRD "delta_post_compare" }}
 {{ $hookCode }}
 {{- end }}
-    return delta
+	return delta
 }


### PR DESCRIPTION
Although it's not what I wanted and isn't the most efficient thing we
could do, I'm implementing the slice of struct and map of struct
comparisons using `reflect.DeepEqual`. Long-term, I'd like to enable our
generator-config CompareConfig for nested struct fields, and to do that
we cannot use `reflect.DeepEqual`, however for the time-being, since
slice and map of struct is a hole in our delta logic, I'm pushing up
this workaround.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
