### PR TITLE
add vlan to initialisms

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -115,6 +115,7 @@ var (
 		// Need to prevent "security" from becoming "SecURIty"
 		{"Uri", "URI", "uri", regexp.MustCompile("(?!sec)uri(?!ty)|(Uri)", regexp.None)},
 		{"Url", "URL", "url", nil},
+		{"Vlan", "VLAN", "vlan", nil},
 		{"Vpc", "VPC", "vpc", nil},
 		{"Vpn", "VPN", "vpn", nil},
 		{"Vgw", "VGW", "vgw", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -53,6 +53,7 @@ func TestNames(t *testing.T) {
 		{"DpdTimeoutAction", "DPDTimeoutAction", "dpdTimeoutAction", "dpd_timeout_action"},
 		{"Iops", "IOPS", "iops", "iops"},
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance"},
+		{"Vlan", "VLAN", "vlan", "vlan"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* add vlan to initialisms; Subnet resource generates this field

Testing:
* `make test` ✅ 
* `make build-controller` ✅ 


```
type LocalGatewayVirtualInterface struct {
	LocalAddress   *string `json:"localAddress,omitempty"`
	LocalBGPASN    *int64  `json:"localBGPASN,omitempty"`
	LocalGatewayID *string `json:"localGatewayID,omitempty"`
	OwnerID        *string `json:"ownerID,omitempty"`
	PeerAddress    *string `json:"peerAddress,omitempty"`
	PeerBGPASN     *int64  `json:"peerBGPASN,omitempty"`
	Tags           []*Tag  `json:"tags,omitempty"`
	VLAN           *int64  `json:"vlan,omitempty"`
}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
