### PR TITLE
Support default non-release version in build-controller-release.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ build-ack-generate:	## Build ack-generate binary
 	@echo "ok."
 
 build-controller: build-ack-generate ## Generate controller code for SERVICE
-	@./scripts/install-controller-gen.sh 
+	@./scripts/install-controller-gen.sh
+	@echo "==== building $(AWS_SERVICE)-controller ===="
 	@./scripts/build-controller.sh $(AWS_SERVICE)
+	@echo "==== building $(AWS_SERVICE)-controller release artifacts ===="
+	@./scripts/build-controller-release.sh $(AWS_SERVICE)
 
 build-controller-image: export LOCAL_MODULES = false
 build-controller-image:	## Build container image for SERVICE

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -44,13 +44,13 @@ RUNTIME_API_VERSION=${RUNTIME_API_VERSION:-"v1alpha1"}
 
 USAGE="
 Usage:
-  $(basename "$0") <service> <release_version>
+  $(basename "$0") <service> [<release_version>]
 
 <service> should be an AWS service API aliases that you wish to build -- e.g.
 's3' 'sns' or 'sqs'
 
 <release_version> should be the SemVer version tag for the release -- e.g.
-'v0.1.3'
+'v0.1.3' . If no release_version is specified 'v0.0.0-non-release-version' is used.
 
 Environment variables:
   ACK_GENERATE_CACHE_DIR                Overrides the directory used for caching
@@ -91,9 +91,14 @@ Environment variables:
                                         custom resource definitions.
                                         Default: $K8S_RBAC_ROLE_NAME
 "
+if [ $# -lt 1 ]; then
+    echo "ERROR: $(basename "$0") needs one required parameter, the SERVICE" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
 
-if [ $# -ne 2 ]; then
-    echo "ERROR: $(basename "$0") accepts exactly two parameters, the SERVICE and the RELEASE_VERSION" 1>&2
+if [ $# -gt 2 ]; then
+    echo "ERROR: $(basename "$0") accepts atmost two parameters, the SERVICE(required) and the RELEASE_VERSION(optional)" 1>&2
     echo "$USAGE"
     exit 1
 fi
@@ -131,7 +136,28 @@ if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     exit 1
 fi
 
-RELEASE_VERSION="$2"
+if [[ $# -eq 2 ]]; then
+  RELEASE_VERSION="$2"
+  # validate that release version is in the format vx.y.z , where x,y,z are
+  # positive real numbers
+  if ! (echo "$RELEASE_VERSION" | grep -Eq "^v[0-9]+\.[0-9]+\.[0-9]+$"); then
+    echo "Release version should have following regex format: ^v[0-9]+\.[0-9]+\.[0-9]+$"
+    exit 1
+  fi
+else
+  # If the release version is not provided, use "v0.0.0-non-release-version".
+  # This non-release version will allow generation of release artifacts and
+  # executing presubmit 'release-test' job on those artifacts.
+  # ACK postsubmit release job makes sure this version does not get released to
+  # public ecr repository.
+  #
+  # Using a static non-release version works because this is only a placeholder
+  # value which gets replaced during presubmit 'release-test' job. Having a
+  # default non-release value also helps AWS service teams to develop the
+  # controller without worrying about the version until actual controller
+  # release.
+  RELEASE_VERSION="v0.0.0-non-release-version"
+fi
 K8S_RBAC_ROLE_NAME=${K8S_RBAC_ROLE_NAME:-"ack-$SERVICE-controller"}
 ACK_GENERATE_SERVICE_ACCOUNT_NAME=${ACK_GENERATE_SERVICE_ACCOUNT_NAME:-"ack-$SERVICE-controller"}
 


### PR DESCRIPTION
Description of changes:
* With the latest addition of presubmit 'release-test' job, service teams are required to execute 'build-controller-release.sh ' script for a successful PR build. 'build-controller-release.sh' script takes VERSION as required parameter.
* Sagemaker team provided the feedback on how they do not want to worry about controller versions until they are doing an actual release. which is fair. 
* So this code change, introduces a default version 'v0.0.0-non-release-version' which allows for successful release-test for service teams without worrying about what VERSION to use until actual release.
* This code change also adds the validation for the `VERSION` parameter.

Why not use something like `git describe --tags --always --dirty` to generate version ?
* The git command works in most cases if the repository already has a legit semver tag. If that is not the case then we need to add additional handling to create an actual semver tag.
* Instead of dealing with all the edge cases with above command, having a static non-release version gets the job done. Because it is really just a placeholder value for the release-test execution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
