### PR TITLE
Allow override resource identifier to ARN

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -845,22 +845,14 @@ func SetResourceIdentifiers(
 	primaryKeyConditionalOut += fmt.Sprintf("%s\treturn ackerrors.MissingNameIdentifier\n", indent)
 	primaryKeyConditionalOut += fmt.Sprintf("%s}\n", indent)
 
-	arnOut := ""
+	arnOut := "\n"
 	// if r.ko.Status.ACKResourceMetadata == nil {
 	//  r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	// }
 	// r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
+	arnOut += ackResourceMetadataGuardConstructor(fmt.Sprintf("%s.Status", targetVarName), indentLevel)
 	arnOut += fmt.Sprintf(
-		"\n%sif %s.Status.ACKResourceMetadata == nil {",
-		indent, targetVarName,
-	)
-	arnOut += fmt.Sprintf(
-		"\n\t%s%s.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}",
-		indent, targetVarName,
-	)
-	arnOut += fmt.Sprintf("\n%s}", indent)
-	arnOut += fmt.Sprintf(
-		"\n%s%s.Status.ACKResourceMetadata.ARN = %s.ARN\n",
+		"%s%s.Status.ACKResourceMetadata.ARN = %s.ARN\n",
 		indent, targetVarName, sourceVarName,
 	)
 
@@ -959,6 +951,7 @@ func SetResourceIdentifiers(
 			// throwing an error accessible to the user
 			additionalKeyOut += fmt.Sprintf("%s%s, %sok := %s\n", indent, fieldIndexName, fieldIndexName, sourceAdaptedVarName)
 			additionalKeyOut += fmt.Sprintf("%sif %sok {\n", indent, fieldIndexName)
+
 			additionalKeyOut += fmt.Sprintf("%s\t%s%s.%s = &%s\n", indent, targetVarName, memberPath, cleanMemberName, fieldIndexName)
 			additionalKeyOut += fmt.Sprintf("%s}\n", indent)
 

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -801,6 +801,19 @@ func SetResourceGetAttributes(
 // 	  r.ko.Spec.ServiceNamespace = f1
 // }
 // ```
+// An example of code that uses the ARN:
+//
+// ```
+// if r.ko.Status.ACKResourceMetadata == nil {
+// 	r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+// }
+// r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
+//
+// f0, f0ok := identifier.AdditionalKeys["modelPackageName"]
+// if f0ok {
+// 	r.ko.Spec.ModelPackageName = &f0
+// }
+// ```
 func SetResourceIdentifiers(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -3092,3 +3092,29 @@ func TestSetResource_APIGWV2_ApiMapping_SetResourceIdentifiers(t *testing.T) {
 		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
 	)
 }
+
+func TestSetResource_SageMaker_ModelPackage_SetResourceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "sagemaker")
+
+	crd := testutil.GetCRDByName(t, g, "ModelPackage")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
+
+	f0, f0ok := identifier.AdditionalKeys["modelPackageName"]
+	if f0ok {
+		r.ko.Spec.ModelPackageName = &f0
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetResourceIdentifiers(crd.Config(), crd, "identifier", "r.ko", 1),
+	)
+}

--- a/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
@@ -22,6 +22,9 @@ resources:
   Endpoint:
     reconcile: 
       requeue_on_success_seconds: 10
+operations:
+  DescribeModelPackage:
+    primary_identifier_field_name: ARN
 ignore:
     resource_names:
       - Algorithm
@@ -50,7 +53,7 @@ ignore:
       - Model
       - ModelBiasJobDefinition
       - ModelExplainabilityJobDefinition
-      - ModelPackage
+      # - ModelPackage
       # ModelPackageGroup
       - ModelQualityJobDefinition
       - MonitoringSchedule


### PR DESCRIPTION
Closes https://github.com/aws-controllers-k8s/community/issues/909

Description of changes:
The SageMaker `ModelPackage` (in some cases) needs to be described using the resource ARN, even though the spec has a `ModelPackageName` and the `DescribeModelPackage` input shape has a `ModelPackageName` field. This pull requests allows the service teams to set the `primary_identifier_field_name` as `"ARN"`, to override the default generator logic in order to set the `ACKResourceMetadata.ARN` field to be `identifier.ARN`. 

Also refactored the identifier code to use the new `FindIdentifiersInShape` common method and to use the `setResourceForScalar` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
