### PR TITLE
Allow OperatorType to be a list such that one API can map to multiple operations

### DIFF
--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -14,7 +14,6 @@
 package model
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -387,7 +386,6 @@ func (a *SDKAPI) SDKAPIInterfaceTypeName() string {
 
 // Override the operation type and/or resource name if specified in config
 func getOpTypeAndResourceName(opID string, cfg *ackgenconfig.Config) ([]OpType, string) {
-	var unmarshaledOpTypes ackgenconfig.StringArray
 	opType, resName := GetOpTypeAndResourceNameFromOpID(opID)
 	opTypes := []OpType{opType}
 
@@ -399,12 +397,9 @@ func getOpTypeAndResourceName(opID string, cfg *ackgenconfig.Config) ([]OpType, 
 			resName = operationConfig.ResourceName
 		}
 
-		if b, err := json.Marshal(operationConfig.OperationType); err == nil {
-			json.Unmarshal(b, &unmarshaledOpTypes)
-			for _, operationType := range unmarshaledOpTypes {
-				opType = OpTypeFromString(operationType)
-				opTypes = append(opTypes, opType)
-			}
+		for _, operationType := range operationConfig.OperationType {
+			opType = OpTypeFromString(operationType)
+			opTypes = append(opTypes, opType)
 		}
 	}
 	return opTypes, resName


### PR DESCRIPTION
Allow OperatorType to be a list such that one API can map to multiple operations. 
This is required in certain cases where the same API call maps to both Create and Update operations such as `RegisterScalableTarget` and `PutScalingPolicy`

[Link to ApplicationAutoscaling PR with the related change](https://github.com/aws-controllers-k8s/applicationautoscaling-controller/pull/27)
Note: This change will require all other services to update their generator configs as well. 

Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/867

### Description of changes:
The `getOpTypeAndResourceName` method handles each of the following cases same as before in addition to the new case 5- 
1.  the cfg itself is nil
2.  cfg is not nil but opId is not in the cfg
3.  cfg is not nil, the opID is in the cfg but the opType is not specified
  ```
  operations:
    DescribeScalableTargets:
    primary_identifier_field_name: ResourceID
  ```
4. One API -> one operations
```
operations:
  PutScalingPolicy:
    operation_type: 
    - Create
  ```
5. One API -> multiple operations
```
operations:
  PutScalingPolicy:
    operation_type: 
    - Create
    - Update
  ```
### Testing
- I tested by generating the controller code for both applicationAutoscaling and the SageMaker repos. 
- The unit tests pass as is. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
