### PR TITLE
Use `ServiceMetadata` strings in Helm charts

### DIFF
--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
+	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
@@ -91,8 +92,14 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	metadata, err := ackmetadata.NewServiceMetadata(optMetadataConfigPath)
+	if err != nil {
+		return err
+	}
+
 	ts, err := ackgenerate.Release(
-		m, optTemplateDirs,
+		m, metadata, optTemplateDirs,
 		releaseVersion, optImageRepository, optServiceAccountName,
 	)
 	if err != nil {

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -18,6 +18,7 @@ import (
 	ttpl "text/template"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
+	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
@@ -49,6 +50,7 @@ var (
 // generating an ACK service controller release (Helm artifacts, etc)
 func Release(
 	m *ackmodel.Model,
+	metadata *ackmetadata.ServiceMetadata,
 	templateBasePaths []string,
 	// releaseVersion is the SemVer string describing the release that the Helm
 	// chart will install
@@ -70,6 +72,7 @@ func Release(
 	metaVars := m.MetaVars()
 	releaseVars := &templateReleaseVars{
 		metaVars,
+		metadata,
 		releaseVersion,
 		imageRepository,
 		serviceAccountName,
@@ -88,6 +91,7 @@ func Release(
 // outputs Go code for a release artifact
 type templateReleaseVars struct {
 	templateset.MetaVars
+	Metadata *ackmetadata.ServiceMetadata
 	// ReleaseVersion is the semver release tag (or Git SHA1 commit) that is
 	// used for the binary image artifacts and Helm release version
 	ReleaseVersion string

--- a/pkg/metadata/service_metadata.go
+++ b/pkg/metadata/service_metadata.go
@@ -104,17 +104,17 @@ func (m *ServiceMetadata) getVersionsByStatus(status APIStatus) []string {
 // path to a metadata file
 func NewServiceMetadata(
 	metadataPath string,
-) (ServiceMetadata, error) {
+) (*ServiceMetadata, error) {
 	if metadataPath == "" {
-		return ServiceMetadata{}, ErrNoServiceMetadataFile
+		return &ServiceMetadata{}, ErrNoServiceMetadataFile
 	}
 	content, err := ioutil.ReadFile(metadataPath)
 	if err != nil {
-		return ServiceMetadata{}, err
+		return &ServiceMetadata{}, err
 	}
 	gc := ServiceMetadata{}
 	if err = yaml.Unmarshal(content, &gc); err != nil {
-		return ServiceMetadata{}, err
+		return &ServiceMetadata{}, err
 	}
-	return gc, nil
+	return &gc, nil
 }

--- a/pkg/model/multiversion/manager.go
+++ b/pkg/model/multiversion/manager.go
@@ -37,7 +37,7 @@ var (
 // and APIInfos.
 type APIVersionManager struct {
 	gitRepo  *git.Repository
-	metadata ackmetadata.ServiceMetadata
+	metadata *ackmetadata.ServiceMetadata
 
 	hubVersion    string
 	spokeVersions []string

--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: {{ .ServiceIDClean }}-chart
-description: A Helm chart for the ACK service controller for {{ .ServiceIDClean }}
+description: A Helm chart for the ACK service controller for {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}
 home: https://github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: ACK Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
-  - name: {{ .ServiceIDClean }} Admins
+  - name: {{ .Metadata.Service.ShortName }} Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/{{ .ServiceIDClean }}-maintainer
 keywords:
   - aws


### PR DESCRIPTION
Description of changes:
Use the fields in the service metadata file (`metadata.yaml`) to produce nicer descriptions in the Helm chart. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
