### PR TITLE
Prepend 'https://proxy.golang.org' to GOPROXY in Dockerfile for building controller image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ARG build_date
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 # For building Go Module required
-ENV GOPROXY=direct
+# TODO(vijtrip2): After golang update to 1.15 or later, replace ',' with '|'
+ENV GOPROXY=https://proxy.golang.org,direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux


### PR DESCRIPTION
Description of changes:

* Prepend 'https://proxy.golang.org' to GOPROXY in Dockerfile for building controller image.
* This GoPROXY helps fix the building of controller image during e2e tests. Tested by locally running `make kind-test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
