### PR TITLE
Refactor identifier and path logic to `crd.go`

### DIFF
--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -77,39 +77,6 @@ func FindARNIdentifiersInShape(
 	return identifiers
 }
 
-// FindIdentifiersInCRD returns the identifier fields of a given CRD which
-// can be singular or plural. Note, these fields will be the *original* field
-// names from the API model shape, not renamed field names.
-func FindIdentifiersInCRD(
-	r *model.CRD) []string {
-	var identifiers []string
-	if r == nil {
-		return identifiers
-	}
-	identifierLookup := []string{
-		"Id",
-		"Ids",
-		r.Names.Original + "Id",
-		r.Names.Original + "Ids",
-		"Name",
-		"Names",
-		r.Names.Original + "Name",
-		r.Names.Original + "Names",
-	}
-
-	for _, id := range identifierLookup {
-		_, found := r.SpecFields[id]
-		if !found {
-			_, found = r.StatusFields[id]
-		}
-		if found {
-			identifiers = append(identifiers, id)
-		}
-	}
-
-	return identifiers
-}
-
 // FindPluralizedIdentifiersInShape returns the name of a Spec OR Status field
 // that has a matching pluralized field in the given shape and the name of
 // the corresponding shape field name. This method will returns the original
@@ -122,7 +89,7 @@ func FindPluralizedIdentifiersInShape(
 	shape *awssdkmodel.Shape,
 ) (crField string, shapeField string) {
 	shapeIdentifiers := FindIdentifiersInShape(r, shape)
-	crIdentifiers := FindIdentifiersInCRD(r)
+	crIdentifiers := r.GetIdentifiers()
 	if len(shapeIdentifiers) == 0 || len(crIdentifiers) == 0 {
 		return "", ""
 	}

--- a/pkg/generate/code/common_test.go
+++ b/pkg/generate/code/common_test.go
@@ -58,7 +58,7 @@ func TestFindIdentifiersInCRD_S3_Bucket_ReadMany_Empty(t *testing.T) {
 	assert.Len(actualIdentifiers, 0)
 }
 
-func TestFindIdentifiersInCRD_EC2_VPC_StatusField(t *testing.T) {
+func TestGetIdentifiers_EC2_VPC_StatusField(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -68,7 +68,7 @@ func TestFindIdentifiersInCRD_EC2_VPC_StatusField(t *testing.T) {
 	require.NotNil(crd)
 
 	expIdentifier := "VpcId"
-	actualIdentifiers := code.FindIdentifiersInCRD(crd)
+	actualIdentifiers := crd.GetIdentifiers()
 	assert.Len(actualIdentifiers, 1)
 	assert.Equal(
 		strings.TrimSpace(expIdentifier),
@@ -76,7 +76,7 @@ func TestFindIdentifiersInCRD_EC2_VPC_StatusField(t *testing.T) {
 	)
 }
 
-func TestFindIdentifiersInCRD_S3_Bucket_SpecField(t *testing.T) {
+func TestGetIdentifiers_S3_Bucket_SpecField(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -86,7 +86,7 @@ func TestFindIdentifiersInCRD_S3_Bucket_SpecField(t *testing.T) {
 	require.NotNil(crd)
 
 	expIdentifier := "Name"
-	actualIdentifiers := code.FindIdentifiersInCRD(crd)
+	actualIdentifiers := crd.GetIdentifiers()
 	assert.Len(actualIdentifiers, 1)
 	assert.Equal(
 		strings.TrimSpace(expIdentifier),
@@ -94,7 +94,7 @@ func TestFindIdentifiersInCRD_S3_Bucket_SpecField(t *testing.T) {
 	)
 }
 
-func TestFindIdentifiersInCRD_APIGatewayV2_API_Multiple(t *testing.T) {
+func TestGetIdentifiers_APIGatewayV2_API_Multiple(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -103,7 +103,7 @@ func TestFindIdentifiersInCRD_APIGatewayV2_API_Multiple(t *testing.T) {
 	require.NotNil(crd)
 
 	expIdentifiers := []string{"ApiId", "Name"}
-	actualIdentifiers := code.FindIdentifiersInCRD(crd)
+	actualIdentifiers := crd.GetIdentifiers()
 	assert.Len(actualIdentifiers, 2)
 	assert.True(ackcompare.SliceStringEqual(expIdentifiers, actualIdentifiers))
 }

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -784,8 +784,8 @@ func setSDKReadMany(
 			}
 		}
 
-		// Field renames are handled in getSanitizedMemberPath
-		resVarPath, err = getSanitizedMemberPath(memberName, r, op, sourceVarName)
+		// Field renames are handled in GetSanitizedMemberPath
+		resVarPath, err = r.GetSanitizedMemberPath(memberName, op, sourceVarName)
 		if err != nil {
 			// if it's an identifier field check for singular/plural
 			if util.InStrings(memberName, shapeIdentifiers) {
@@ -799,7 +799,7 @@ func setSDKReadMany(
 				// 'Id' identifier.
 				if resVarPath == "" || (!strings.HasSuffix(resVarPath, "Id") ||
 					!strings.HasSuffix(resVarPath, "Ids")) {
-					resVarPath, err = getSanitizedMemberPath(flipped, r, op, sourceVarName)
+					resVarPath, err = r.GetSanitizedMemberPath(flipped, op, sourceVarName)
 					if err != nil {
 						panic(fmt.Sprintf(
 							"Unable to locate identifier field %s in "+

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -657,6 +657,38 @@ func (r *CRD) GetAllRenames(op OpType) (map[string]string, error) {
 	return renames, nil
 }
 
+// GetIdentifiers returns the identifier fields of a given CRD which
+// can be singular or plural. Note, these fields will be the *original* field
+// names from the API model shape, not renamed field names.
+func (r *CRD) GetIdentifiers() []string {
+	var identifiers []string
+	if r == nil {
+		return identifiers
+	}
+	identifierLookup := []string{
+		"Id",
+		"Ids",
+		r.Names.Original + "Id",
+		r.Names.Original + "Ids",
+		"Name",
+		"Names",
+		r.Names.Original + "Name",
+		r.Names.Original + "Names",
+	}
+
+	for _, id := range identifierLookup {
+		_, found := r.SpecFields[id]
+		if !found {
+			_, found = r.StatusFields[id]
+		}
+		if found {
+			identifiers = append(identifiers, id)
+		}
+	}
+
+	return identifiers
+}
+
 // GetSanitizedMemberPath takes a shape member field, checks for renames, checks
 // for existence in Spec and Status, then constructs and returns the var path.
 // Returns error if memberName is not present in either Spec or Status.


### PR DESCRIPTION
Issue #, if available: [#922](https://github.com/aws-controllers-k8s/community/issues/922)

Description of changes:
* Moving 2 helper funcs to become *methods* of CRD Struct for clearer encapsulation:
  * `GetSanitizedMemberPath`
  * `GetIdentifiers`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
