### PR TITLE
update conditions on error for delete operation

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -146,7 +146,14 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -153,7 +153,11 @@ func (rm *resourceManager) Delete(
 		}
 		return rm.onError(r, err)
 	}
-	return rm.onSuccess(observed)
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -212,7 +212,7 @@ func (rm *resourceManager) updateConditions (
 		}
 	}
 
-	if !r.IsBeingDeleted() && (rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound) {
+	if rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type:   ackv1alpha1.ConditionTypeTerminal,

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -224,7 +224,7 @@ func (rm *resourceManager) updateConditions (
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Code() + ": " + awsErr.Message()
+			errorMessage = awsErr.Message()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -247,7 +247,7 @@ func (rm *resourceManager) updateConditions (
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Code() + ": " + awsErr.Message()
+				errorMessage = awsErr.Message()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -212,7 +212,7 @@ func (rm *resourceManager) updateConditions (
 		}
 	}
 
-	if rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	if !r.IsBeingDeleted() && (rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type:   ackv1alpha1.ConditionTypeTerminal,
@@ -224,7 +224,7 @@ func (rm *resourceManager) updateConditions (
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Code() + ": " + awsErr.Message()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -247,7 +247,7 @@ func (rm *resourceManager) updateConditions (
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Code() + ": " + awsErr.Message()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {


### PR DESCRIPTION
Description of changes:
- Update conditions on delete in case of error. Right now the errors from delete are not reflected to the user
  - I have added a check to treat all errors as recoverable if the resource is being deleted as I am not sure what is the user experience if the resource hits a terminal condition after its deleted. Please advise

Testing:
Manually introduced an error from sdkDelete and verified it gets updated in conditions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
