### PR TITLE
Refactor `setSDKReadMany` and `setResourceForScalar`

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -18,10 +18,11 @@ import (
 	"sort"
 	"strings"
 
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/names"
-	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
 // SetSDK returns the Go code that sets an SDK input shape's member fields from

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -18,13 +18,10 @@ import (
 	"sort"
 	"strings"
 
-	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
-	"github.com/gertd/go-pluralize"
-
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/names"
-	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
 // SetSDK returns the Go code that sets an SDK input shape's member fields from
@@ -760,9 +757,7 @@ func setSDKReadMany(
 	indent := strings.Repeat("\t", indentLevel)
 
 	resVarPath := ""
-	pluralize := pluralize.NewClient()
 	opConfig, override := cfg.OverrideValues(op.Name)
-	shapeIdentifiers := FindIdentifiersInShape(r, inputShape)
 	var err error
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if override {
@@ -787,24 +782,15 @@ func setSDKReadMany(
 		// Field renames are handled in GetSanitizedMemberPath
 		resVarPath, err = r.GetSanitizedMemberPath(memberName, op, sourceVarName)
 		if err != nil {
-			// if it's an identifier field check for singular/plural
-			if util.InStrings(memberName, shapeIdentifiers) {
-				var flipped string
-				if pluralize.IsPlural(memberName) {
-					flipped = pluralize.Singular(memberName)
-				} else {
-					flipped = pluralize.Plural(memberName)
-				}
-				// If there are multiple identifiers, then prioritize the
-				// 'Id' identifier.
-				if resVarPath == "" || (!strings.HasSuffix(resVarPath, "Id") ||
-					!strings.HasSuffix(resVarPath, "Ids")) {
-					resVarPath, err = r.GetSanitizedMemberPath(flipped, op, sourceVarName)
-					if err != nil {
-						panic(fmt.Sprintf(
-							"Unable to locate identifier field %s in "+
-								"%s Spec/Status in generate.code.setSDKReadMany", flipped, r.Kind))
-					}
+			// if memberName is an identifier field, then check for
+			// corresponding model identifier
+			crIdentifier, shapeIdentifier := FindPluralizedIdentifiersInShape(r, inputShape)
+			if strings.EqualFold(memberName, shapeIdentifier) {
+				resVarPath, err = r.GetSanitizedMemberPath(crIdentifier, op, sourceVarName)
+				if err != nil {
+					panic(fmt.Sprintf(
+						"Unable to locate identifier field %s in "+
+							"%s Spec/Status in generate.code.setSDKReadMany", crIdentifier, r.Kind))
 				}
 			} else {
 				// TODO(jaypipes): check generator config for exceptions?


### PR DESCRIPTION
Issue #, if available: [#922](https://github.com/aws-controllers-k8s/community/issues/922)

Description of changes:
* Refactor `setSDKReadMany`:
  * use *FindPluralizedIdentifiersInShape* helpers to simplify logic
* Refactor `setResourceForScalar`:
  * Remove unused params
  * Add `targetVar` param to be the variable's fully-qualified name (i.e. fieldPath+varName r.ko.Spec.CacheClusterID)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
