### PR TITLE
Update base images to ECR public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Base image to use for the final stage
-ARG base_image=amazonlinux:2
+ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2
 # Build the manager binary
-FROM golang:1.14.1 as builder
+FROM public.ecr.aws/bitnami/golang:1.15.15 as builder
 
 ARG service_alias
 # The tuple of controller image version information
@@ -12,9 +12,7 @@ ARG build_date
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
-# For building Go Module required
-# TODO(vijtrip2): After golang update to 1.15 or later, replace ',' with '|'
-ENV GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,7 +1,7 @@
 # Base image to use at runtime
-ARG base_image=amazonlinux:2
+ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2
 # Build the manager binary
-FROM golang:1.14.1 as builder
+FROM public.ecr.aws/bitnami/golang:1.15.15 as builder
 
 ARG service_alias
 # The tuple of controller image version information
@@ -12,8 +12,7 @@ ARG build_date
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
-# For building Go Module required
-ENV GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -74,6 +74,9 @@ if [[ $QUIET = "false" ]]; then
     echo " git commit: $SERVICE_CONTROLLER_GIT_COMMIT"
 fi
 
+# Log into ECR public to access base images
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
 # if local build
 # then use Dockerfile which allows references to local modules from service controller
 DOCKER_BUILD_CONTEXT="$ACK_DIR"


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/925

Description of changes:
Modify all base and builder images to use ECR public instead of DockerHub
- Requires AWS ECR Public login before any pulls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
