### PR TITLE
return nil if observed is nil from a successful delete

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -157,7 +157,7 @@ func (rm *resourceManager) Delete(
 	if observed != nil {
 		return rm.onSuccess(observed)
 	}
-	return rm.onSuccess(r)
+	return nil, nil
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -154,10 +154,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return nil, nil
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -266,6 +263,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if ackcompare.IsNil(r) {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -286,6 +286,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if ackcompare.IsNil(r) {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/931

Description of changes:
Solution 2 in the issue linked above. If `rm.Delete` does not return an error, and observed is also nil, return `nil, nil` to the caller instead of the resource passed to the method.

Testing:
`make test`
Manually using sagemaker controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
