### PR TITLE
Support nested paths in field config specifically list type members

### DIFF
--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -246,7 +246,9 @@ func (a *SDKAPI) GetOutputShapeRef(
 }
 
 // getMemberByPath returns a ShapeRef given a root Shape and a dot-notation
-// object search path
+// object search path. Given the explicit type check for list type members 
+// both ".." and "." notations work currently. 
+// TODO: Add support for other types such as map.
 func getMemberByPath(
 	shape *awssdkmodel.Shape,
 	path string,
@@ -254,6 +256,9 @@ func getMemberByPath(
 	elements := strings.Split(path, ".")
 	last := len(elements) - 1
 	for x, elem := range elements {
+		if elem == "" {
+			continue
+		}
 		if shape == nil {
 			return nil, false
 		}
@@ -264,7 +269,13 @@ func getMemberByPath(
 		if x == last {
 			return shapeRef, true
 		}
-		shape = shapeRef.Shape
+		elemType := shapeRef.Shape.Type
+		switch elemType {
+		case "list":
+			shape = shapeRef.Shape.MemberRef.Shape
+		default:
+			shape = shapeRef.Shape
+		}
 	}
 	return nil, false
 }

--- a/pkg/model/sdk_helper_test.go
+++ b/pkg/model/sdk_helper_test.go
@@ -134,6 +134,13 @@ func TestGetOutputShapeRef(t *testing.T) {
 			true,
 		},
 		{
+			// list type nested path search
+			"ListAliases",
+			"Aliases..RevisionId",
+			&stringshape,
+			true,
+		},
+		{
 			// no such op
 			"GetNonexisting",
 			"Foo",


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/932

Description of changes:
`getMemberByPath` checks the shape type as it loops through members to ensure lists are handled correctly. Currently I have simply ignored the empty element created by the splitting of the string on the single dot instead of handling the double dot notation explicitly. Open to comments. 
Also added a Unit Test for the same. 

Testing
1. Generated code for ApplicationAutoscaling and ensured CreationTime field now works as expected. Linked changes [in this PR](https://github.com/aws-controllers-k8s/applicationautoscaling-controller/pull/39).
2. Ensured that the SageMaker Controller can be generated using new changes with no diff as expected. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
