### PR TITLE
Only return MetaObject from AWSResource.MetaObject() call

### DIFF
--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -46,7 +46,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/937

Description of changes:
* For implementation of AWSResource.MetaObject, we were returning the complete resource.
* This change only returns 'ObjectMeta' from AWSResource which is the implementation of 'metav1.Object' inside resource struct
* returning only the relevant members helps in metadata comparison correctly with `ackcompare.MetaV1ObjectEqual`

---------------

* Unit tests successful
* Successful local kind e2e test for newly generated dynamodb controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
