### PR TITLE
Added node selector for helm chart

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -77,3 +77,4 @@ spec:
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
+      nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -15,6 +15,8 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  nodeSelector:
+    kubernetes.io/os: linux
 
 metrics:
   service:


### PR DESCRIPTION
Issue #, if available:

Description of changes: Added nodSelector label to allow options in case cluster has window and linux nodes. Set default value to linux node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
