### PR TITLE
Fix installation of controller-gen in prowjobs

### DIFF
--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -26,6 +26,8 @@ if ! is_installed controller-gen || ! k8s_controller_gen_version_equals "$CONTRO
     # GOBIN and GOPATH are not always set, so default to GOPATH from `go env`
     __GOPATH=$(go env GOPATH)
     __install_dir=${GOBIN:-$__GOPATH/bin}
+    # If __install_dir does not exist, create it
+    [[ -d $__install_dir ]] || mkdir -p "$__install_dir"
     __install_path="$__install_dir/controller-gen"
     __work_dir=$(mktemp -d /tmp/controller-gen-XXX)
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Fix installation of controller-gen in prowjobs
* Installing controller-gen in prowjobs fail because $GOPATH/bin directory is not present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
