### PR TITLE
Remove the last modification timestamp and the OS/Arch from `ack-generate-metadata.yaml` file.

### DIFF
--- a/pkg/metadata/generation_metadata.go
+++ b/pkg/metadata/generation_metadata.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/ghodss/yaml"
 
@@ -82,8 +81,6 @@ type generatorConfigInfo struct {
 
 // last modification information
 type lastModificationInfo struct {
-	// UTC Timestamp
-	Timestamp string `json:"timestamp"`
 	// Modification reason
 	Reason UpdateReason `json:"reason"`
 }
@@ -112,8 +109,7 @@ func CreateGenerationMetadata(
 		APIVersion:           apiVersion,
 		APIDirectoryChecksum: hash,
 		LastModification: lastModificationInfo{
-			Timestamp: time.Now().UTC().String(),
-			Reason:    modificationReason,
+			Reason: modificationReason,
 		},
 		AWSSDKGoVersion: awsSDKGo,
 		ACKGenerateInfo: ackGenerateInfo{

--- a/pkg/metadata/generation_metadata.go
+++ b/pkg/metadata/generation_metadata.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/ghodss/yaml"
 
@@ -116,7 +117,7 @@ func CreateGenerationMetadata(
 			Version:   version.Version,
 			BuildDate: version.BuildDate,
 			BuildHash: version.BuildHash,
-			GoVersion: version.GoVersion,
+			GoVersion: runtime.Version(),
 		},
 		GeneratorConfigInfo: generatorConfigInfo{
 			OriginalFileName: filepath.Base(generatorFileName),


### PR DESCRIPTION
Recently we introduced a new generate metadata file to all the apiVersions
directory (e.g [EC2 v1alpha1](https://github.com/aws-controllers-k8s/ec2-controller/blob/main/apis/v1alpha1/ack-generate-metadata.yaml)). However after few weeks we realized the 
`last_modification_info` and `ack_generate_info` were too verbose and
often caused merge conflicts since our contributors don't use the same
`OS`/`Arch` for compiling `ack-generate` binary.

This patch removes the last modification timestamp and the OS/Arch from
ack generate information.

Description of changes:
- Remove the `OS`/`Arch` from `pkg/metadata.ackGenerateInfo`
- Remove last update timestamp from `pkg/metadata.lastMoficationInfo`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
