### PR TITLE
Optionally log into ECR public

### DIFF
--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -74,8 +74,10 @@ if [[ $QUIET = "false" ]]; then
     echo " git commit: $SERVICE_CONTROLLER_GIT_COMMIT"
 fi
 
-# Log into ECR public to access base images
-aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+if ! is_public_ecr_logged_in; then
+  # Log into ECR public to access base images
+  aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+fi
 
 # if local build
 # then use Dockerfile which allows references to local modules from service controller

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -109,3 +109,18 @@ k8s_controller_gen_version_equals() {
         return 1
     fi;
 }
+
+# is_public_ecr_logged_in returns 0 if the Docker client is authenticated
+# with ECR public and therefore can pull and push to ECR public, otherwise
+# returns 1
+#
+# Usage:
+#
+# if ! is_public_ecr_logged_in; then
+#   aws ecr-public get-login-password --region us-east-1 \
+#   | docker login --username AWS --password-stdin public.ecr.aws
+# fi
+is_public_ecr_logged_in() {
+    local public_ecr_url="public.ecr.aws"
+    jq -e --arg url $public_ecr_url '.auths | has($url)' ~/.docker/config.json > /dev/null;
+}


### PR DESCRIPTION
Description of changes:
Created a new helper method to determine whether the user is currently logged into the ECR public Docker registry. Only if they are not already logged in do we attempt to log in. This will allow the test infrastructure to log in once at the beginning (with a separate role) and ensure that login is stored even after we assume another role.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
