### PR TITLE
Replace `primary_identifier_field_name` with `is_primary_key`

### DIFF
--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -131,12 +131,6 @@ func FindPrimaryIdentifierFieldNames(
 ) (crField string, shapeField string) {
 	shape := op.InputRef.Shape
 
-	// Attempt to fetch the primary identifier override from the configuration
-	opConfig, ok := cfg.Operations[op.Name]
-	if ok {
-		shapeField = opConfig.PrimaryIdentifierFieldName
-	}
-
 	if shapeField == "" {
 		// For ReadOne, search for a direct identifier
 		if op == r.Ops.ReadOne {
@@ -151,8 +145,8 @@ func FindPrimaryIdentifierFieldNames(
 			default:
 				panic("Found multiple possible primary identifiers for " +
 					r.Names.Original + ". Set " +
-					"`primary_identifier_field_name` for the " + op.Name +
-					" operation in the generator config.")
+					"`is_primary_key` for the primary field in the " +
+					r.Names.Camel + " resource.")
 			}
 		} else {
 			// For ReadMany, search for pluralized identifiers
@@ -162,12 +156,12 @@ func FindPrimaryIdentifierFieldNames(
 		// Require override if still can't find any identifiers
 		if shapeField == "" {
 			panic("Could not find primary identifier for " + r.Names.Original +
-				". Set `primary_identifier_field_name` for the " + op.Name +
-				" operation in the generator config.")
+				". Set `is_primary_key` for the primary field in the " +
+				r.Names.Camel + " resource.")
 		}
 	}
 
-	if r.IsPrimaryARNField(shapeField) || shapeField == PrimaryIdentifierARNOverride {
+	if r.IsPrimaryARNField(shapeField) {
 		return "", PrimaryIdentifierARNOverride
 	}
 

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -898,7 +898,7 @@ func SetResourceIdentifiers(
 	var primaryCRField, primaryShapeField string
 	isPrimarySet := primaryField != nil
 	if isPrimarySet {
-		memberPath, _ := findFieldInCR(cfg, r, primaryField.Names.Camel)
+		memberPath, _ := findFieldInCR(cfg, r, primaryField.Names.Original)
 		targetVarPath := fmt.Sprintf("%s%s", targetVarName, memberPath)
 		primaryKeyOut += setResourceIdentifierPrimaryIdentifier(cfg, r,
 			primaryField,
@@ -962,7 +962,7 @@ func SetResourceIdentifiers(
 		}
 
 		memberPath, targetField := findFieldInCR(cfg, r, searchField)
-		if targetField == nil {
+		if targetField == nil || (isPrimarySet && targetField == primaryField) {
 			continue
 		}
 
@@ -975,13 +975,11 @@ func SetResourceIdentifiers(
 
 		targetVarPath := fmt.Sprintf("%s%s", targetVarName, memberPath)
 		if isPrimaryIdentifier {
-			if !isPrimarySet {
-				primaryKeyOut += setResourceIdentifierPrimaryIdentifier(cfg, r,
-					targetField,
-					targetVarPath,
-					sourceVarName,
-					indentLevel)
-			}
+			primaryKeyOut += setResourceIdentifierPrimaryIdentifier(cfg, r,
+				targetField,
+				targetVarPath,
+				sourceVarName,
+				indentLevel)
 		} else {
 			additionalKeyOut += setResourceIdentifierAdditionalKey(
 				cfg, r,

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -896,7 +896,8 @@ func SetResourceIdentifiers(
 	}
 
 	var primaryCRField, primaryShapeField string
-	if primaryField != nil {
+	isPrimarySet := primaryField != nil
+	if isPrimarySet {
 		memberPath, _ := findFieldInCR(cfg, r, primaryField.Names.Camel)
 		targetVarPath := fmt.Sprintf("%s%s", targetVarName, memberPath)
 		primaryKeyOut += setResourceIdentifierPrimaryIdentifier(cfg, r,
@@ -904,8 +905,6 @@ func SetResourceIdentifiers(
 			targetVarPath,
 			sourceVarName,
 			indentLevel)
-
-		primaryCRField = primaryField.Names.Camel
 	} else {
 		primaryCRField, primaryShapeField = FindPrimaryIdentifierFieldNames(cfg, r, op)
 		if primaryShapeField == PrimaryIdentifierARNOverride {
@@ -948,6 +947,11 @@ func SetResourceIdentifiers(
 			op.Name, memberName,
 		)
 
+		// Check to see if we've already set the field as the primary identifier
+		if isPrimarySet && renamedName == primaryField.Names.Camel {
+			continue
+		}
+
 		isPrimaryIdentifier := memberName == primaryShapeField
 
 		searchField := ""
@@ -970,10 +974,8 @@ func SetResourceIdentifiers(
 		}
 
 		targetVarPath := fmt.Sprintf("%s%s", targetVarName, memberPath)
-		// TODO(RedbackThomson): Clean up logic for `is_primary_key` already
-		// settings `primaryKeyOut`.
 		if isPrimaryIdentifier {
-			if primaryKeyOut == "" {
+			if !isPrimarySet {
 				primaryKeyOut += setResourceIdentifierPrimaryIdentifier(cfg, r,
 					targetField,
 					targetVarPath,

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -170,9 +170,9 @@ type FieldConfig struct {
 	// Required indicates whether this field is a required member or not.
 	// This field is used to configure '+kubebuilder:validation:Required' on API object's members.
 	IsRequired *bool `json:"is_required,omitempty"`
-	// IsName indicates the field represents the primary name/string identifier
-	// field for the resource.  This allows the generator config to override the
-	// default behaviour of considering a field called "Name" or
+	// IsPrimaryKey indicates the field represents the primary name/string
+	// identifier field for the resource.  This allows the generator config to
+	// override the default behaviour of considering a field called "Name" or
 	// "{Resource}Name" or "{Resource}Id" as the "name field" for the resource.
 	IsPrimaryKey bool `json:"is_primary_key"`
 	// IsOwnerAccountID indicates the field contains the AWS Account ID

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -170,11 +170,11 @@ type FieldConfig struct {
 	// Required indicates whether this field is a required member or not.
 	// This field is used to configure '+kubebuilder:validation:Required' on API object's members.
 	IsRequired *bool `json:"is_required,omitempty"`
-	// IsName indicates the field represents the name/string identifier field
-	// for the resource.  This allows the generator config to override the
+	// IsName indicates the field represents the primary name/string identifier
+	// field for the resource.  This allows the generator config to override the
 	// default behaviour of considering a field called "Name" or
 	// "{Resource}Name" or "{Resource}Id" as the "name field" for the resource.
-	IsName bool `json:"is_name"`
+	IsPrimaryKey bool `json:"is_primary_key"`
 	// IsOwnerAccountID indicates the field contains the AWS Account ID
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.

--- a/pkg/generate/config/operation.go
+++ b/pkg/generate/config/operation.go
@@ -18,7 +18,7 @@ import (
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 
-	"github.com/aws-controllers-k8s/code-generator/pkg/util"	
+	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
 // StringArray is a type that can be represented in JSON as *either* a string
@@ -45,10 +45,6 @@ type OperationConfig struct {
 	// An example of this is `Put...` or `Register...` API operations not being correctly classified as `Create` op type
 	// OperationType []string `json:"operation_type"`
 	OperationType StringArray `json:"operation_type"`
-	// PrimaryIdentifierFieldName provides the name of the field that should be
-	// interpreted as the "primary" identifier field. This field will be used as
-	// the primary field for resource adoption.
-	PrimaryIdentifierFieldName string `json:"primary_identifier_field_name,omitempty"`
 }
 
 // IsIgnoredOperation returns true if Operation Name is configured to be ignored

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -82,6 +82,9 @@ type ResourceConfig struct {
 	// Print contains instructions for the code generator to generate kubebuilder printcolumns
 	// marker comments.
 	Print *PrintConfig `json:"print,omitempty"`
+	// IsARNPrimaryKey determines whether the CRD uses the ARN as the primary
+	// identifier in the ReadOne operations.
+	IsARNPrimaryKey bool `json:"is_arn_primary_key"`
 }
 
 // HooksConfig instructs the code generator how to inject custom callback hooks

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-field-config.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-with-field-config.yaml
@@ -2,7 +2,7 @@ resources:
   Repository:
     fields:
       Name:
-        is_name: true
+        is_primary_key: true
     exceptions:
       errors:
         404:

--- a/pkg/testdata/models/apis/rds/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/rds/0000-00-00/generator.yaml
@@ -1,13 +1,15 @@
 ignore:
   shape_names:
     - DBSecurityGroupMembershipList
-operations:
-  DescribeDBInstances:
-    primary_identifier_field_name: DBInstanceIdentifier
-  DescribeDBSubnetGroups:
-    primary_identifier_field_name: DBSubnetGroupName
 resources:
+  DBInstance:
+    fields:
+      DBInstanceIdentifier:
+        is_primary_key: true
   DBSubnetGroup:
+    fields:
+      Name:
+        is_primary_key: true
     renames:
       operations:
         DescribeDBSubnetGroups:

--- a/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
@@ -22,9 +22,8 @@ resources:
   Endpoint:
     reconcile: 
       requeue_on_success_seconds: 10
-operations:
-  DescribeModelPackage:
-    primary_identifier_field_name: ARN
+  ModelPackage:
+    is_arn_primary_key: true
 ignore:
     resource_names:
       - Algorithm


### PR DESCRIPTION
Description of changes:
We have had quite a few issues with the logic of `SetResourceIdentifiers` struggling to find the correct identifier field name or matching it to the corresponding spec or status field. The current implementation solves the first of these issues by pointing directly to the identifier member in the input shape, but the logic to link this back to a spec or status field is still flawed. 
Rather than pointing to a member in the input shape and trying to infer the spec or status field, this new implementation directly denotes a field on a resource as the "primary key". The `SetResourceIdentifiers` logic can now directly find the target field and create the corresponding setter. The override logic for ARNs has now been moved to a `is_arn_primary_key` on the `ResourceConfig` object, since we cannot access the ARN as a `FieldConfig`.

This is a **backwards compatibility breaking change** as all existing `primary_identifier_field_name` configurations need to be refactored into `is_primary_key` fields on the respective resource's field. For example:
```yaml
operations:
  DescribeDBInstances:
    primary_identifier_field_name: DBInstanceIdentifier
  DescribeDBSubnetGroups:
    primary_identifier_field_name: DBSubnetGroupName
```

becomes:
```yaml
resources:
  DBInstance:
    fields:
      DBInstanceIdentifier:
        is_primary_key: true
  DBSubnetGroup:
    fields:
      Name:
        is_primary_key: true
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
