### PR TITLE
Add hook into SetIdentifier for custom code before ReadOne is called from AdoptedResource.

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -61,6 +61,7 @@ code paths:
 * delta_post_compare
 * late_initialize_pre_read_one
 * late_initialize_post_read_one
+* set_identifiers_pre_read_one
 
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -80,6 +80,9 @@ func (r *resource) SetStatus(desired acktypes.AWSResource) {
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
 {{- GoCodeSetResourceIdentifiers .CRD "identifier" "r.ko" 1}}
+{{- if $hookCode := Hook .CRD "set_identifiers_pre_read_one" }}
+{{ $hookCode }}
+{{- end }}
 	return nil
 }
 


### PR DESCRIPTION
Issue #, if available:
This is currently required as a temporary fix to be able to use AdoptedResource feature for ScalableTarget in the ApplicationAutoscaling Service but is a useful hook to have. 

Description of changes:
Adds a hook into SetIdentifier for custom code before ReadOne is called from AdoptedResource.

Sample Usage:
as seen in [this PR ](https://github.com/aws-controllers-k8s/applicationautoscaling-controller/pull/42)
```
set_identifiers_pre_read_one:
       code: r.customSetIdentifierCode(identifier)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
