### PR TITLE
import ACK runtime pkg/condition in sdk.go

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
@@ -27,6 +28,7 @@ var (
 	_ = &svcapitypes.{{ .CRD.Names.Camel }}{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource


### PR DESCRIPTION
Adds the `pkg/condition` package from ACK runtime into
`pkg/resource/{RESOURCE}/sdk.go` file. This makes the various common ACK
runtime condition functions like `SetSynced` available to hook code that
may be injected into sdk.go code paths.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
