### PR TITLE
Shorten metric service name

### DIFF
--- a/templates/helm/templates/metrics-service.yaml
+++ b/templates/helm/templates/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "app.fullname" . }}-metrics
+  name: {{ .Chart.Name | trimSuffix "-chart" | trunc 44 }}-controller-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/956

Description of changes:
* Previous metric service name for applicationautoscaling-controller was going over 63 characters and failing k8s validation
* Other resources are not at risk because they use template from helpers.tpl which restricts the name to 63 chars
* The issue occurred for this service because we were adding a suffix('-metrics')
* It is important to distinguish metrics service because in future controller can have other kinds of service as well.
* With the proposed solution, the metrics service name looks like `applicationautoscaling-controller-metrics` and is also truncated to never cross 63 chars(max 44 chars from service name + '-controller-metrics')

Tested locally that this works accurately and helm test passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
