### PR TITLE
adding back required `install-kustomize.sh` file

### DIFF
--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-kustomize.sh
+#
+# Installs the latest version kustomize if not installed.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kustomize
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+if ! is_installed kustomize ; then
+    __kustomize_url="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+    echo -n "installing kustomize from $__kustomize_url ... "
+    curl --silent "$__kustomize_url" | bash 1>/dev/null
+    chmod +x kustomize
+    sudo mv kustomize /usr/local/bin/kustomize
+    echo "ok."
+fi


### PR DESCRIPTION
Issue #, if available:
fixes aws-controllers-k8s/community#963

Description of changes:
The `install-kustomize.sh` was previously in the `community` repo and should live in the `code-generator` repo so that the `olm` scripts can execute properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
