### PR TITLE
add ability to skip fields for set output step

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -144,10 +144,32 @@ func SetResource(
 	out := "\n"
 	indent := strings.Repeat("\t", indentLevel)
 
+	// retrieve the operation config for the given operation
+	var operationConfig *ackgenconfig.OperationConfig
+	if val, ok := cfg.Operations[op.Name]; ok {
+		operationConfig = &val
+	}
+	var skipFields ackgenconfig.StringArray
+	if operationConfig != nil {
+		skipFields = operationConfig.SetOutputSkipFields
+	}
+
 	// Recursively descend down through the set of fields on the Output shape,
 	// creating temporary variables, populating those temporary variables'
 	// fields with further-nested fields as needed
 	for memberIndex, memberName := range outputShape.MemberNames() {
+		// skip the output field if specified in the operation config
+		skipField := false
+		for _, field := range skipFields {
+			if memberName == field {
+				skipField = true
+				break
+			}
+		}
+		if skipField {
+			continue
+		}
+
 		//TODO: (vijat@) should these field be renamed before looking them up in spec?
 		sourceAdaptedVarName := sourceVarName + "." + memberName
 

--- a/pkg/generate/config/operation.go
+++ b/pkg/generate/config/operation.go
@@ -45,6 +45,8 @@ type OperationConfig struct {
 	// An example of this is `Put...` or `Register...` API operations not being correctly classified as `Create` op type
 	// OperationType []string `json:"operation_type"`
 	OperationType StringArray `json:"operation_type"`
+	// Fields for which to skip generation of code for merging in API response
+	SetOutputSkipFields StringArray `json:"set_output_skip_fields"`
 }
 
 // IsIgnoredOperation returns true if Operation Name is configured to be ignored


### PR DESCRIPTION
Spec patching can be problematic for certain fields. For example, modifying an ElastiCache Replication Group's `spec.LogDeliveryConfigurations` from value `A` to value `B` causes the controller to infinitely loop. `desired` will have value `B` and `latest` will have value `A`. They will then switch and this continues indefinitely.

Since we cannot disable spec patching, the point of this PR is to add a workaround where service teams can choose not to merge in a particular field of the API response, so the user's desired state will not be overwritten by an incorrect/not up to date server value upon spec patching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
