### PR TITLE
updating containerImage format in clusterserviceversion

### DIFF
--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -106,7 +106,7 @@ func DefaultServiceConfig() ServiceConfig {
 			SuggestedNamespace: "ack-system",
 			ShortDescription:   "This is the placeholder short description for the default configuration",
 			IsCertified:        false,
-			ContainerImage:     "public.ecr.aws/aws-controllers-k8s/controller",
+			ContainerImage:     "public.ecr.aws/aws-controllers-k8s/",
 			Support:            "Community",
 		},
 		[]Sample{},

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -7,7 +7,7 @@ metadata:
     capabilities: {{.Annotations.CapabilityLevel}}
     operatorframework.io/suggested-namespace: "ack-system"
     repository: {{.Annotations.Repository}}
-    containerImage: {{.Annotations.ContainerImage}}:{{.ServiceIDClean}}-v{{.Version}}
+    containerImage: {{.Annotations.ContainerImage}}{{.ServiceIDClean}}-controller:v{{.Version}}
     description: {{.Annotations.ShortDescription}}
     createdAt: {{.CreatedAt}}
     support: {{.Annotations.Support}}


### PR DESCRIPTION
Issue #, if available:
fixes aws-controllers-k8s/community#967

Description of changes:
Updating the default `containerImage` and updating the clusterserviceversion template to follow the new image repository formate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
