### PR TITLE
fixing formatting in container image to be consistent with image

### DIFF
--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -106,7 +106,7 @@ func DefaultServiceConfig() ServiceConfig {
 			SuggestedNamespace: "ack-system",
 			ShortDescription:   "This is the placeholder short description for the default configuration",
 			IsCertified:        false,
-			ContainerImage:     "public.ecr.aws/aws-controllers-k8s/",
+			ContainerImage:     "public.ecr.aws/aws-controllers-k8s",
 			Support:            "Community",
 		},
 		[]Sample{},

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -7,7 +7,7 @@ metadata:
     capabilities: {{.Annotations.CapabilityLevel}}
     operatorframework.io/suggested-namespace: "ack-system"
     repository: {{.Annotations.Repository}}
-    containerImage: {{.Annotations.ContainerImage}}{{.ServiceIDClean}}-controller:v{{.Version}}
+    containerImage: {{.Annotations.ContainerImage}}/{{.ServiceIDClean}}-controller:v{{.Version}}
     description: {{.Annotations.ShortDescription}}
     createdAt: {{.CreatedAt}}
     support: {{.Annotations.Support}}


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
This PR aims to keep how `containerImage` tag is generated/built consistent and insync with how `image` tag in the cluster service version is generated. This makes readability of both sections of code/templates/sh's/etc the same and easier in the future if a change in the formate is needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
