### PR TITLE
Use sts GetCallerIdentity to find AWS AccountId

### DIFF
--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -44,6 +44,11 @@ func main() {
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()
+	if err := ackCfg.PopulateAccountIdIfMissing(); err != nil {
+		setupLog.Error(
+			err, "Error while finding AWS AccountId using sts GetCallerIdentity",
+		)
+	}
 
 	if err := ackCfg.Validate(); err != nil {
 		setupLog.Error(


### PR DESCRIPTION
Description of changes: 
* Use sts `GetCallerIdentity` to find AWS AccountId when `aws-account-id` flag and `AWS_ACCOUNT_ID` env variable is missing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
