### PR TITLE
Reference `output_wrapper_field_path` when generating CRD fields as part of the `Create*` request in `model.go`

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -110,23 +110,14 @@ func SetResource(
 	if op == nil {
 		return ""
 	}
-	outputShape := op.OutputRef.Shape
+	outputShape, _ := r.GetOutputShape(op)
 	if outputShape == nil {
 		return ""
 	}
 
-	var err error
-	// We might be in a "wrapper" shape. Unwrap it to find the real object
-	// representation for the CRD's createOp/DescribeOP.
-
 	// Use the wrapper field path if it's given in the ack-generate config file.
 	wrapperFieldPath := r.GetOutputWrapperFieldPath(op)
 	if wrapperFieldPath != nil {
-		outputShape, err = r.GetWrapperOutputShape(outputShape, *wrapperFieldPath)
-		if err != nil {
-			msg := fmt.Sprintf("Unable to unwrap the output shape: %v", err)
-			panic(msg)
-		}
 		sourceVarName += "." + *wrapperFieldPath
 	} else {
 		// If the wrapper field path is not specified in the config file and if

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2969,6 +2969,21 @@ func TestGetOutputShape_DynamoDB_Override(t *testing.T) {
 		outputShape.ShapeName)
 }
 
+func TestGetOutputShape_VPCEndpoint_Override(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "VpcEndpoint")
+	require.NotNil(crd)
+
+	outputShape, _ := crd.GetOutputShape(crd.Ops.Create)
+	assert.Equal(
+		"VpcEndpoint",
+		outputShape.ShapeName)
+}
+
 func TestSetResource_MQ_Broker_SetResourceIdentifiers(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -161,7 +161,10 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 		// Now process the fields that will go into the Status struct. We want
 		// fields that are in the Create operation's Output Shape but that are
 		// not in the Input Shape.
-		outputShape := createOp.OutputRef.Shape
+		outputShape, err := crd.GetOutputShape(createOp)
+		if err != nil {
+			return nil, err
+		}
 		if outputShape.UsedAsOutput && len(outputShape.MemberRefs) == 1 {
 			// We might be in a "wrapper" shape. Unwrap it to find the real object
 			// representation for the CRD's createOp. If there is a single member

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -19,7 +19,7 @@ ignore:
     - InternetGateway
     - KeyPair
     - LaunchTemplateVersion
-    # - LaunchTemplate
+    #- LaunchTemplate
     - LocalGatewayRouteTableVpcAssociation
     - LocalGatewayRoute
     - ManagedPrefixList
@@ -50,13 +50,17 @@ ignore:
     - TransitGatewayRoute
     - TransitGatewayVpcAttachment
     - TransitGateway
-    # - Volume
+    #- Volume
     - VpcEndpointConnectionNotification
     - VpcEndpointServiceConfiguration
-    - VpcEndpoint
-    # - Vpc
+    #- VpcEndpoint
+    #- Vpc
     - VpcCidrBlock
     - VpcPeeringConnection
     - VpnConnectionRoute
     - VpnConnection
     - VpnGateway
+
+operations:
+  CreateVpcEndpoint:
+    output_wrapper_field_path: VpcEndpoint


### PR DESCRIPTION
Issue #, if available:
* `model.go` **does not** take into account any `output_wrapper_field_path` overrides when processing Status fields for a CRD

Description of changes:
* Refactored `GetOutputShape` api:
  * always return an *output* shape
  * make `getWrapperOutputShape` private
  * updated tests
* Added `GetOutputShape` invocation to `model.go` so that overrides are checked before creating the CRD

Local Testing:
* *generator.yaml*
```
operations:
  CreateVpcEndpoint:
    output_wrapper_field_path: VpcEndpoint
```

* `make build-controller SERVICE=ec2` 
* **Result:** `VPCEndpointStatus` contains all unpacked fields. Assigning from aws sdk response (`vpc_endpoint/sdk.go`) includes `resp.VpcEndpoint` as prefix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
