### PR TITLE
Allow separate service ID and alias

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -87,9 +87,9 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("please specify the service alias for the AWS service API to generate")
 	}
-	svcPackage := strings.ToLower(args[0])
+	svcAlias := strings.ToLower(args[0])
 	if optOutputPath == "" {
-		optOutputPath = filepath.Join(optServicesDir, svcPackage)
+		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 	ctx, cancel := contextWithSigterm(context.Background())
 	defer cancel()
@@ -97,7 +97,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if optModelName == "" {
-		optModelName = svcPackage
+		optModelName = svcAlias
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(optModelName)
@@ -108,11 +108,11 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return fmt.Errorf("service %s not found", svcPackage)
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
 	model, err := ackmodel.New(
-		sdkAPI, svcPackage, optGenVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
+		sdkAPI, svcAlias, optGenVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -52,9 +52,9 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("please specify the service alias for the AWS service API to generate")
 	}
-	svcPackage := strings.ToLower(args[0])
+	svcAlias := strings.ToLower(args[0])
 	if optOutputPath == "" {
-		optOutputPath = filepath.Join(optServicesDir, svcPackage)
+		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 
 	ctx, cancel := contextWithSigterm(context.Background())
@@ -63,7 +63,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if optModelName == "" {
-		optModelName = svcPackage
+		optModelName = svcAlias
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(optModelName)
@@ -74,7 +74,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return fmt.Errorf("service %s not found", svcPackage)
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
 	latestAPIVersion, err = getLatestAPIVersion()
@@ -82,7 +82,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	m, err := ackmodel.New(
-		sdkAPI, svcPackage, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
+		sdkAPI, svcAlias, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -54,9 +54,9 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	svcPackage := strings.ToLower(args[0])
+	svcAlias := strings.ToLower(args[0])
 	if optModelName == "" {
-		optModelName = svcPackage
+		optModelName = svcAlias
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkHelper.APIGroupSuffix = "aws.crossplane.io"
@@ -68,10 +68,10 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return fmt.Errorf("service %s not found", svcPackage)
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
-	cfgPath := filepath.Join(providerDir, "apis", svcPackage, optGenVersion, "generator-config.yaml")
+	cfgPath := filepath.Join(providerDir, "apis", svcAlias, optGenVersion, "generator-config.yaml")
 	_, err = os.Stat(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -80,7 +80,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 		cfgPath = ""
 	}
 	m, err := ackmodel.New(
-		sdkAPI, svcPackage, optGenVersion, cfgPath, cpgenerate.DefaultConfig,
+		sdkAPI, svcAlias, optGenVersion, cfgPath, cpgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err
@@ -110,8 +110,8 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	apiPath := filepath.Join(providerDir, "apis", svcPackage, optGenVersion)
-	controllerPath := filepath.Join(providerDir, "pkg", "controller", svcPackage)
+	apiPath := filepath.Join(providerDir, "apis", svcAlias, optGenVersion)
+	controllerPath := filepath.Join(providerDir, "pkg", "controller", svcAlias)
 	// TODO(muvaf): goimports don't allow to be included as a library. Make sure
 	// goimports binary exists.
 	if err := exec.Command("goimports", "-w", apiPath, controllerPath).Run(); err != nil {

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -73,9 +73,9 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 				"for the AWS service API to generate",
 		)
 	}
-	svcPackage := strings.ToLower(args[0])
+	svcAlias := strings.ToLower(args[0])
 	if optOutputPath == "" {
-		optOutputPath = filepath.Join(optServicesDir, svcPackage)
+		optOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 
 	version := args[1]
@@ -87,7 +87,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if optModelName == "" {
-		optModelName = svcPackage
+		optModelName = svcAlias
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(optModelName)
@@ -98,7 +98,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return fmt.Errorf("service %s not found", svcPackage)
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
 
@@ -107,14 +107,14 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	m, err := ackmodel.New(
-		sdkAPI, svcPackage, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
+		sdkAPI, svcAlias, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err
 	}
 
 	if optOLMConfigPath == "" {
-		optOLMConfigPath = strings.Join([]string{svcPackage, olmConfigFileSuffix}, "-")
+		optOLMConfigPath = strings.Join([]string{svcAlias, olmConfigFileSuffix}, "-")
 	}
 
 	// read the configuration from file

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -58,12 +58,12 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		return fmt.Errorf("please specify the service alias and the release version to generate release artifacts for")
 	}
-	svcPackage := strings.ToLower(args[0])
+	svcAlias := strings.ToLower(args[0])
 	if optReleaseOutputPath == "" {
-		optReleaseOutputPath = filepath.Join(optServicesDir, svcPackage)
+		optReleaseOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 	if optImageRepository == "" {
-		optImageRepository = fmt.Sprintf("public.ecr.aws/aws-controllers-k8s/%s-controller", svcPackage)
+		optImageRepository = fmt.Sprintf("public.ecr.aws/aws-controllers-k8s/%s-controller", svcAlias)
 	}
 	// TODO(jaypipes): We could do some git-fu here to verify that the release
 	// version supplied hasn't been used (as a Git tag) before...
@@ -75,7 +75,7 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if optModelName == "" {
-		optModelName = svcPackage
+		optModelName = svcAlias
 	}
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(optModelName)
@@ -86,11 +86,11 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return fmt.Errorf("service %s not found", svcPackage)
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
 	m, err := ackmodel.New(
-		sdkAPI, svcPackage, "", optGeneratorConfigPath, ackgenerate.DefaultConfig,
+		sdkAPI, svcAlias, "", optGeneratorConfigPath, ackgenerate.DefaultConfig,
 	)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -34,6 +34,7 @@ var (
 	optCacheDir            string
 	optRefreshCache        bool
 	optAWSSDKGoVersion     string
+	optModelName           string
 	defaultTemplateDirs    []string
 	optTemplateDirs        []string
 	defaultServicesDir     string
@@ -120,6 +121,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optAWSSDKGoVersion, "aws-sdk-go-version", "", "Version of github.com/aws/aws-sdk-go used to generate apis and controllers files",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&optModelName, "model-name", "", "the name of the service model package",
 	)
 }
 

--- a/pkg/generate/templateset/vars.go
+++ b/pkg/generate/templateset/vars.go
@@ -21,9 +21,6 @@ type MetaVars struct {
 	// alias does not match the ServiceID. e.g. The AWS Step Functions API has
 	// a ServiceID of "SFN" and a service alias of "states"...
 	ServiceAlias string
-	// ServiceID is the exact string that appears in the AWS service API's
-	// api-2.json descriptor file under `metadata.serviceId`
-	ServiceID string
 	// ServiceIDClean is the ServiceID lowercased and stripped of any
 	// non-alphanumeric characters
 	ServiceIDClean string
@@ -34,6 +31,9 @@ type MetaVars struct {
 	// for custom resources, e.g. "sns.services.k8s.aws" or
 	// "sfn.services.k8s.aws"
 	APIGroup string
+	// AWSSDKModelServiceID is the exact string that appears in the AWS service API's
+	// api-2.json descriptor file under `metadata.serviceId`
+	AWSSDKModelServiceID string
 	// SDKAPIInterfaceTypeName is the name of the interface type used by the
 	// aws-sdk-go services/$SERVICE/api.go file
 	SDKAPIInterfaceTypeName string

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -34,13 +34,14 @@ var (
 // Model contains the ACK model for the generator to process and apply
 // templates against.
 type Model struct {
-	SDKAPI       *SDKAPI
-	serviceAlias string
-	apiVersion   string
-	crds         []*CRD
-	typeDefs     []*TypeDef
-	typeImports  map[string]string
-	typeRenames  map[string]string
+	SDKAPI         *SDKAPI
+	servicePackage string
+	serviceAlias   string
+	apiVersion     string
+	crds           []*CRD
+	typeDefs       []*TypeDef
+	typeImports    map[string]string
+	typeRenames    map[string]string
 	// Instructions to the code generator how to handle the API and its
 	// resources
 	cfg *ackgenconfig.Config
@@ -51,10 +52,10 @@ type Model struct {
 func (m *Model) MetaVars() templateset.MetaVars {
 	return templateset.MetaVars{
 		ServiceAlias:            m.serviceAlias,
-		ServiceID:               m.SDKAPI.ServiceID(),
-		ServiceIDClean:          m.SDKAPI.ServiceIDClean(),
-		APIGroup:                m.SDKAPI.APIGroup(),
+		ServiceIDClean:          m.ServiceIDClean(),
+		APIGroup:                m.APIGroup(),
 		APIVersion:              m.apiVersion,
+		AWSSDKModelServiceID:    m.SDKAPI.AWSSDKModelServiceID(),
 		SDKAPIInterfaceTypeName: m.SDKAPI.SDKAPIInterfaceTypeName(),
 		CRDNames:                m.crdNames(),
 	}
@@ -688,11 +689,29 @@ func (m *Model) GetConfig() *ackgenconfig.Config {
 	return m.cfg
 }
 
+// APIGroup returns the normalized Kubernetes APIGroup for the AWS service API,
+// e.g. "sns.services.k8s.aws"
+func (m *Model) APIGroup() string {
+	serviceID := m.servicePackage
+	suffix := "services.k8s.aws"
+	if m.SDKAPI.apiGroupSuffix != "" {
+		suffix = m.SDKAPI.apiGroupSuffix
+	}
+	return fmt.Sprintf("%s.%s", serviceID, suffix)
+}
+
+// ServiceIDClean returns a lowercased, whitespace-stripped ServiceID
+func (m *Model) ServiceIDClean() string {
+	serviceID := strings.ToLower(m.servicePackage)
+	return strings.Replace(serviceID, " ", "", -1)
+}
+
 // New returns a new Model struct for a supplied API model.
 // Optionally, pass a file path to a generator config file that can be used to
 // instruct the code generator how to handle the API properly
 func New(
 	SDKAPI *SDKAPI,
+	servicePackage string,
 	apiVersion string,
 	configPath string,
 	defaultConfig ackgenconfig.Config,
@@ -702,12 +721,11 @@ func New(
 		return nil, err
 	}
 	m := &Model{
-		SDKAPI: SDKAPI,
-		// TODO(jaypipes): Handle cases where service alias and service ID
-		// don't match (Step Functions)
-		serviceAlias: SDKAPI.ServiceID(),
-		apiVersion:   apiVersion,
-		cfg:          &cfg,
+		SDKAPI:         SDKAPI,
+		servicePackage: servicePackage,
+		serviceAlias:   SDKAPI.AWSSDKModelServiceID(),
+		apiVersion:     apiVersion,
+		cfg:            &cfg,
 	}
 	m.ApplyShapeIgnoreRules()
 	return m, nil

--- a/pkg/model/multiversion/manager.go
+++ b/pkg/model/multiversion/manager.go
@@ -51,6 +51,7 @@ func NewAPIVersionManager(
 	sdkCacheDir string,
 	metadataPath string,
 	serviceAlias string,
+	serviceModelName string,
 	hubVersion string,
 	apisInfo map[string]ackmetadata.APIInfo,
 	defaultConfig ackgenconfig.Config,
@@ -94,13 +95,14 @@ func NewAPIVersionManager(
 			return nil, err
 		}
 
-		SDKAPI, err := SDKAPIHelper.API(serviceAlias)
+		SDKAPI, err := SDKAPIHelper.API(serviceModelName)
 		if err != nil {
 			return nil, err
 		}
 
 		i, err := ackmodel.New(
 			SDKAPI,
+			serviceAlias,
 			version.APIVersion,
 			apiInfo.GeneratorConfigPath,
 			defaultConfig,

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -246,8 +246,8 @@ func (a *SDKAPI) GetOutputShapeRef(
 }
 
 // getMemberByPath returns a ShapeRef given a root Shape and a dot-notation
-// object search path. Given the explicit type check for list type members 
-// both ".." and "." notations work currently. 
+// object search path. Given the explicit type check for list type members
+// both ".." and "." notations work currently.
 // TODO: Add support for other types such as map.
 func getMemberByPath(
 	shape *awssdkmodel.Shape,
@@ -353,19 +353,15 @@ func (a *SDKAPI) HasConflictingTypeName(typeName string, cfg *ackgenconfig.Confi
 		util.InStrings(cleanTypeName, crdListResourceNames)
 }
 
-// ServiceID returns the exact `metadata.serviceId` attribute for the AWS
-// service APi's api-2.json file
-func (a *SDKAPI) ServiceID() string {
+// AWSSDKModelServiceID returns the exact `metadata.serviceId` attribute for the AWS
+// service APi's api-2.json file.
+// This MAY NOT MATCH the AWS SDK Go package used by the service. For example:
+// AWS SDK Go uses `opensearchservice` whereas the service ID is `opensearch`
+func (a *SDKAPI) AWSSDKModelServiceID() string {
 	if a == nil || a.API == nil {
 		return ""
 	}
 	return awssdkmodel.ServiceID(a.API)
-}
-
-// ServiceIDClean returns a lowercased, whitespace-stripped ServiceID
-func (a *SDKAPI) ServiceIDClean() string {
-	serviceID := strings.ToLower(a.ServiceID())
-	return strings.Replace(serviceID, " ", "", -1)
 }
 
 func (a *SDKAPI) GetServiceFullName() string {
@@ -373,17 +369,6 @@ func (a *SDKAPI) GetServiceFullName() string {
 		return ""
 	}
 	return a.API.Metadata.ServiceFullName
-}
-
-// APIGroup returns the normalized Kubernetes APIGroup for the AWS service API,
-// e.g. "sns.services.k8s.aws"
-func (a *SDKAPI) APIGroup() string {
-	serviceID := a.ServiceIDClean()
-	suffix := "services.k8s.aws"
-	if a.apiGroupSuffix != "" {
-		suffix = a.apiGroupSuffix
-	}
-	return fmt.Sprintf("%s.%s", serviceID, suffix)
 }
 
 // SDKAPIInterfaceTypeName returns the name of the aws-sdk-go primary API

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -29,6 +29,8 @@ import (
 type TestingModelOptions struct {
 	// The CR API Version. Defaults to v1alpha1
 	APIVersion string
+	// Override for the model name for the service
+	ServiceModelName string
 	// The generator config file. Defaults to generator.yaml
 	GeneratorConfigFile string
 	// The AWS Service's API version. Defaults to 00-00-0000
@@ -36,9 +38,12 @@ type TestingModelOptions struct {
 }
 
 // SetDefaults sets the empty fields to a default value.
-func (o *TestingModelOptions) SetDefaults() {
+func (o *TestingModelOptions) SetDefaults(serviceAlias string) {
 	if o.APIVersion == "" {
 		o.APIVersion = "v1alpha1"
+	}
+	if o.ServiceModelName == "" {
+		o.ServiceModelName = serviceAlias
 	}
 	if o.GeneratorConfigFile == "" {
 		o.GeneratorConfigFile = "generator.yaml"
@@ -71,10 +76,10 @@ func NewModelForServiceWithOptions(t *testing.T, serviceAlias string, options *T
 			break
 		}
 	}
-	options.SetDefaults()
+	options.SetDefaults(serviceAlias)
 	sdkHelper := model.NewSDKHelper(path)
 	sdkHelper.WithAPIVersion(options.ServiceAPIVersion)
-	sdkAPI, err := sdkHelper.API(serviceAlias)
+	sdkAPI, err := sdkHelper.API(options.ServiceModelName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +87,7 @@ func NewModelForServiceWithOptions(t *testing.T, serviceAlias string, options *T
 	if _, err := os.Stat(generatorConfigPath); os.IsNotExist(err) {
 		generatorConfigPath = ""
 	}
-	m, err := ackmodel.New(sdkAPI, options.APIVersion, generatorConfigPath, ackgenerate.DefaultConfig)
+	m, err := ackmodel.New(sdkAPI, serviceAlias, options.APIVersion, generatorConfigPath, ackgenerate.DefaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -30,6 +30,7 @@ ACK_GENERATE_CACHE_DIR=${ACK_GENERATE_CACHE_DIR:-"$HOME/.cache/aws-controllers-k
 # typically at $GOPATH/src/github.com/aws-controllers-k8s/code-generator
 DEFAULT_ACK_GENERATE_BIN_PATH="$ROOT_DIR/../../aws-controllers-k8s/code-generator/bin/ack-generate"
 ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
+ACK_GENERATE_MODEL_NAME=${ACK_GENERATE_MODEL_NAME:-""}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
 ACK_METADATA_CONFIG_PATH=${ACK_METADATA_CONFIG_PATH:-""}
@@ -184,6 +185,9 @@ helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
 ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --aws-sdk-go-version $AWS_SDK_GO_VERSION"
 if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
     ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
+fi
+if [ -n "$ACK_GENERATE_MODEL_NAME" ]; then
+    ag_args="$ag_args --model-name $ACK_GENERATE_MODEL_NAME"
 fi
 if [ -n "$ACK_GENERATE_OUTPUT_PATH" ]; then
     ag_args="$ag_args --output $ACK_GENERATE_OUTPUT_PATH"

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -23,6 +23,7 @@ ACK_GENERATE_CACHE_DIR=${ACK_GENERATE_CACHE_DIR:-"$HOME/.cache/aws-controllers-k
 # typically at $GOPATH/src/github.com/aws-controllers-k8s/code-generator
 DEFAULT_ACK_GENERATE_BIN_PATH="$ROOT_DIR/bin/ack-generate"
 ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
+ACK_GENERATE_MODEL_NAME=${ACK_GENERATE_MODEL_NAME:-""}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
 ACK_METADATA_CONFIG_PATH=${ACK_METADATA_CONFIG_PATH:-""}
@@ -49,6 +50,12 @@ Environment variables:
                             previously generated, the latest generated API
                             version is used. If the service controller has yet
                             to be generated, 'v1alpha1' is used.
+  ACK_GENERATE_MODEL_NAME:  Overrides the name of the AWS SDK model for the
+                            current service. If not specified, the name of the
+                            service will be used. Most services do not require
+                            overriding this value, but some services models
+                            do not match the name of the service as defined in
+                            the AWS SDK Go (eg. opensearchservice).
   ACK_GENERATE_CONFIG_PATH: Specify a path to the generator config YAML file to
                             instruct the code generator for the service.
                             Default: generator.yaml
@@ -157,6 +164,11 @@ fi
 apis_args="apis $ag_args"
 if [ -n "$ACK_GENERATE_API_VERSION" ]; then
     apis_args="$apis_args --version $ACK_GENERATE_API_VERSION"
+fi
+
+if [ -n "$ACK_GENERATE_MODEL_NAME" ]; then
+    ag_args="$ag_args --model-name $ACK_GENERATE_MODEL_NAME"
+    apis_args="$apis_args --model-name $ACK_GENERATE_MODEL_NAME"
 fi
 
 if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/994

Description of changes:
This pull request supports including an optional `--model-name` command line argument for any `ack-generate` generator verb. The generator will use this argument to override the service name when looking up the API files in `aws-sdk-go/models/apis`. 

Currently we reference the `metadata.serviceId` field from the `api-2.json` file as the `ServiceIDClean` variable. `ServiceIDClean` is used in all code generator templates as the import path for `aws-sdk-go` and when referencing the controller name (eg. `{{ .ServiceIDClean}}-controller`). This pull request will redirect `ServiceIDClean` to use the service alias provided when calling `ack-generate`, instead. Therefore, all subsequent ACK repositories should be named according to the AWS SDK Go package name, rather than the API file's definition of `serviceId`. 

`ServiceID` has been removed from the template variables, instead replaced by `AWSSDKModelServiceID` if it is needed. `ServiceIDClean` now refers to the name of the AWS SDK Go package name.

For services that need to use the `--model-name` command line argument, such as `opensearchservice` and `elbv2`, developers should use the `ACK_GENERATE_MODEL_NAME` environment variable when calling `make build-controller`. Changes to the CI/CD system will need to be made to accommodate this customisation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
