### PR TITLE
Export `GroupVersionResource` and `GroupKind` variables

### DIFF
--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -18,7 +18,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("{{ ToLower .CRD.Plural }}")
+	GroupKind = metav1.GroupKind{
 		Group: "{{ .APIGroup }}",
 		Kind:  "{{ .CRD.Kind }}",
 	}
@@ -32,7 +33,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/998

Description of changes:
`GroupVersionResource` is used by dynamic clients to specify the CRD to be CRUD'd.
`GroupKind` is sometimes used in place where the version is not necessarily specified. I chose to export this mainly because it could be used down the line by other dynamic clients.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
