### PR TITLE
Rename ServiceID reference to ServiceIDClean

### DIFF
--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -23,7 +23,7 @@ spec:
       name: {{ ToLower .Plural }}.{{$.APIGroup}}
       version: {{$.APIVersion}}
       displayName: {{.Kind}}
-      description: {{.Kind}} represents the state of an AWS {{$.ServiceID}} {{.Kind}} resource.
+      description: {{.Kind}} represents the state of an AWS {{$.ServiceIDClean}} {{.Kind}} resource.
     {{- end}}
   description: '{{ .Description }}'
   displayName: {{ .DisplayName}}


### PR DESCRIPTION


Issue #, if available:
aws-controllers-k8s/community#1009

Description of changes:
ServiceID was removed in a recent commit. One reference was left in clusterserviceversion.yaml.tpl. This PR simply renames that reference to ServiceIDClean to prevent breakage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
