### PR TITLE
Load service model name from generator

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -96,7 +96,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModel(svcAlias)
+	m, err := loadModelWithLatestAPIVersion(svcAlias)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -24,7 +24,6 @@ import (
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
-	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
@@ -97,25 +96,11 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
-	sdkAPI, err := sdkHelper.API(svcAlias)
-	if err != nil {
-		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
-		if err != nil {
-			return err
-		}
-		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
-		if err != nil {
-			return fmt.Errorf("service %s not found", svcAlias)
-		}
-	}
-	model, err := ackmodel.New(
-		sdkAPI, optGenVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
-	)
+	m, err := loadModel(svcAlias)
 	if err != nil {
 		return err
 	}
-	ts, err := ackgenerate.APIs(model, optTemplateDirs)
+	ts, err := ackgenerate.APIs(m, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/common.go
+++ b/cmd/ack-generate/command/common.go
@@ -239,11 +239,12 @@ func loadModel(svcAlias string, apiVersion string) (*ackmodel.Model, error) {
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(modelName)
 	if err != nil {
-		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
+		retryModelName, err := FallBackFindServiceID(sdkDir, svcAlias)
 		if err != nil {
 			return nil, err
 		}
-		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
+		// Retry using path found by querying service ID
+		sdkAPI, err = sdkHelper.API(retryModelName)
 		if err != nil {
 			return nil, fmt.Errorf("service %s not found", svcAlias)
 		}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -28,7 +28,6 @@ import (
 	k8sversion "k8s.io/apimachinery/pkg/version"
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
-	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
 var (
@@ -62,25 +61,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
-	sdkAPI, err := sdkHelper.API(svcAlias)
-	if err != nil {
-		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
-		if err != nil {
-			return err
-		}
-		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
-		if err != nil {
-			return fmt.Errorf("service %s not found", svcAlias)
-		}
-	}
-	latestAPIVersion, err = getLatestAPIVersion()
-	if err != nil {
-		return err
-	}
-	m, err := ackmodel.New(
-		sdkAPI, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
-	)
+	m, err := loadModel(svcAlias)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -21,11 +21,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
-	k8sversion "k8s.io/apimachinery/pkg/version"
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 )
@@ -61,7 +59,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModel(svcAlias)
+	m, err := loadModelWithLatestAPIVersion(svcAlias)
 	if err != nil {
 		return err
 	}
@@ -90,26 +88,6 @@ func generateController(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
-}
-
-// getLatestAPIVersion looks in a target output directory to determine what the
-// latest Kubernetes API version for CRDs exposed by the generated service
-// controller.
-func getLatestAPIVersion() (string, error) {
-	apisPath := filepath.Join(optOutputPath, "apis")
-	versions := []string{}
-	subdirs, err := ioutil.ReadDir(apisPath)
-	if err != nil {
-		return "", err
-	}
-
-	for _, subdir := range subdirs {
-		versions = append(versions, subdir.Name())
-	}
-	sort.Slice(versions, func(i, j int) bool {
-		return k8sversion.CompareKubeAwareVersionStrings(versions[i], versions[j]) < 0
-	})
-	return versions[len(versions)-1], nil
 }
 
 // FallBackFindServiceID reads through aws-sdk-go/models/apis/*/*/api-2.json

--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -84,7 +84,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 		}
 	}
 	m, err := ackmodel.New(
-		sdkAPI, optGenVersion, cfg,
+		sdkAPI, svcAlias, optGenVersion, cfg,
 	)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -23,9 +23,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 
-	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	olmgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/olm"
-	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
 const (
@@ -86,26 +84,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
-	sdkAPI, err := sdkHelper.API(svcAlias)
-	if err != nil {
-		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
-		if err != nil {
-			return err
-		}
-		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
-		if err != nil {
-			return fmt.Errorf("service %s not found", svcAlias)
-		}
-	}
-
-	latestAPIVersion, err = getLatestAPIVersion()
-	if err != nil {
-		return err
-	}
-	m, err := ackmodel.New(
-		sdkAPI, latestAPIVersion, optGeneratorConfigPath, ackgenerate.DefaultConfig,
-	)
+	m, err := loadModel(svcAlias)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -84,7 +84,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModel(svcAlias)
+	m, err := loadModelWithLatestAPIVersion(svcAlias)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -73,7 +73,7 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModel(svcAlias)
+	m, err := loadModel(svcAlias, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -24,7 +24,6 @@ import (
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
-	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
 var (
@@ -74,21 +73,7 @@ func generateRelease(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
-	sdkAPI, err := sdkHelper.API(svcAlias)
-	if err != nil {
-		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
-		if err != nil {
-			return err
-		}
-		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
-		if err != nil {
-			return fmt.Errorf("service %s not found", svcAlias)
-		}
-	}
-	m, err := ackmodel.New(
-		sdkAPI, "", optGeneratorConfigPath, ackgenerate.DefaultConfig,
-	)
+	m, err := loadModel(svcAlias)
 	if err != nil {
 		return err
 	}

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// SetManyOutput function fails with NotFound error.
 	// Default is "return nil, ackerr.NotFound"
 	SetManyOutputNotFoundErrReturn string `json:"set_many_output_notfound_err_return,omitempty"`
+	// ModelName lets you specify the path used to identify the AWS service API
+	// in the aws-sdk-go's models/apis/ directory
+	ModelName string `json:"model_name,omitempty"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -40,7 +40,10 @@ type Config struct {
 	// Default is "return nil, ackerr.NotFound"
 	SetManyOutputNotFoundErrReturn string `json:"set_many_output_notfound_err_return,omitempty"`
 	// ModelName lets you specify the path used to identify the AWS service API
-	// in the aws-sdk-go's models/apis/ directory
+	// in the aws-sdk-go's models/apis/ directory. This field is optional and
+	// only needed for services such as the opensearchservice service where the
+	// model name is `opensearch` and the service package is called
+	// `opensearchservice`.
 	ModelName string `json:"model_name,omitempty"`
 }
 

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -145,7 +145,7 @@ func Crossplane(
 	for _, path := range apisGenericTemplatesPaths {
 		outPath := filepath.Join(
 			"apis",
-			metaVars.ServiceIDClean,
+			metaVars.ServiceAlias,
 			metaVars.APIVersion,
 			"zz_"+strings.TrimSuffix(filepath.Base(path), ".tpl"),
 		)
@@ -155,7 +155,7 @@ func Crossplane(
 	}
 	for _, crd := range crds {
 		crdFileName := filepath.Join(
-			"apis", metaVars.ServiceIDClean, metaVars.APIVersion,
+			"apis", metaVars.ServiceAlias, metaVars.APIVersion,
 			"zz_"+strcase.ToSnake(crd.Kind)+".go",
 		)
 		crdVars := &templateCRDVars{
@@ -170,7 +170,7 @@ func Crossplane(
 	// Next add the controller package for each CRD
 	for _, crd := range crds {
 		outPath := filepath.Join(
-			"pkg", "controller", metaVars.ServiceIDClean, crd.Names.Lower,
+			"pkg", "controller", metaVars.ServiceAlias, crd.Names.Lower,
 			"zz_controller.go",
 		)
 		crdVars := &templateCRDVars{
@@ -181,7 +181,7 @@ func Crossplane(
 			return nil, err
 		}
 		outPath = filepath.Join(
-			"pkg", "controller", metaVars.ServiceIDClean, crd.Names.Lower,
+			"pkg", "controller", metaVars.ServiceAlias, crd.Names.Lower,
 			"zz_conversions.go",
 		)
 		crdVars = &templateCRDVars{

--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -79,7 +79,7 @@ func BundleAssets(
 
 	csvBaseOutPath := fmt.Sprintf(
 		"config/manifests/bases/ack-%s-controller.clusterserviceversion.yaml",
-		m.MetaVars().ServiceIDClean)
+		m.MetaVars().ServiceAlias)
 	if err := ts.Add(csvBaseOutPath, "config/manifests/bases/clusterserviceversion.yaml.tpl", olmVars); err != nil {
 		return nil, err
 	}

--- a/pkg/generate/templateset/vars.go
+++ b/pkg/generate/templateset/vars.go
@@ -27,6 +27,11 @@ type MetaVars struct {
 	// ServiceIDClean is the ServiceID lowercased and stripped of any
 	// non-alphanumeric characters
 	ServiceIDClean string
+	// ServiceModelName contains the exact string used to identify the AWS
+	// service API in the aws-sdk-go's models/apis/ directory. Note that some
+	// APIs this name does not match the ServiceID. e.g. The AWS Step Functions
+	// API has a ServiceID of "SFN" and a service model name of "states"...
+	ServiceModelName string
 	// APIVersion contains the version of the Kubernetes API resources, e.g.
 	// "v1alpha1"
 	APIVersion string

--- a/pkg/generate/templateset/vars.go
+++ b/pkg/generate/templateset/vars.go
@@ -17,16 +17,12 @@ package templateset
 // that describe the service alias, its package name, etc
 type MetaVars struct {
 	// ServiceAlias contains the exact string used to identify the AWS service
-	// API in the aws-sdk-go's models/apis/ directory. Note that some APIs this
-	// alias does not match the ServiceID. e.g. The AWS Step Functions API has
-	// a ServiceID of "SFN" and a service alias of "states"...
+	// API in the aws-sdk-go `service/` directory. It is also used as the
+	// identifier for the ACK controller's name and packages.
 	ServiceAlias string
 	// ServiceID is the exact string that appears in the AWS service API's
 	// api-2.json descriptor file under `metadata.serviceId`
 	ServiceID string
-	// ServiceIDClean is the ServiceID lowercased and stripped of any
-	// non-alphanumeric characters
-	ServiceIDClean string
 	// ServiceModelName contains the exact string used to identify the AWS
 	// service API in the aws-sdk-go's models/apis/ directory. Note that some
 	// APIs this name does not match the ServiceID. e.g. The AWS Step Functions

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -53,6 +53,7 @@ func (m *Model) MetaVars() templateset.MetaVars {
 		ServiceAlias:            m.serviceAlias,
 		ServiceID:               m.SDKAPI.ServiceID(),
 		ServiceIDClean:          m.SDKAPI.ServiceIDClean(),
+		ServiceModelName:        m.cfg.ModelName,
 		APIGroup:                m.SDKAPI.APIGroup(),
 		APIVersion:              m.apiVersion,
 		SDKAPIInterfaceTypeName: m.SDKAPI.SDKAPIInterfaceTypeName(),
@@ -697,13 +698,8 @@ func (m *Model) GetConfig() *ackgenconfig.Config {
 func New(
 	SDKAPI *SDKAPI,
 	apiVersion string,
-	configPath string,
-	defaultConfig ackgenconfig.Config,
+	cfg ackgenconfig.Config,
 ) (*Model, error) {
-	cfg, err := ackgenconfig.New(configPath, defaultConfig)
-	if err != nil {
-		return nil, err
-	}
 	m := &Model{
 		SDKAPI: SDKAPI,
 		// TODO(jaypipes): Handle cases where service alias and service ID

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -52,9 +52,8 @@ func (m *Model) MetaVars() templateset.MetaVars {
 	return templateset.MetaVars{
 		ServiceAlias:            m.serviceAlias,
 		ServiceID:               m.SDKAPI.ServiceID(),
-		ServiceIDClean:          m.SDKAPI.ServiceIDClean(),
 		ServiceModelName:        m.cfg.ModelName,
-		APIGroup:                m.SDKAPI.APIGroup(),
+		APIGroup:                m.APIGroup(),
 		APIVersion:              m.apiVersion,
 		SDKAPIInterfaceTypeName: m.SDKAPI.SDKAPIInterfaceTypeName(),
 		CRDNames:                m.crdNames(),
@@ -692,19 +691,29 @@ func (m *Model) GetConfig() *ackgenconfig.Config {
 	return m.cfg
 }
 
+// APIGroup returns the normalized Kubernetes APIGroup for the AWS service API,
+// e.g. "sns.services.k8s.aws"
+func (m *Model) APIGroup() string {
+	serviceAlias := m.serviceAlias
+	suffix := "services.k8s.aws"
+	if m.SDKAPI.apiGroupSuffix != "" {
+		suffix = m.SDKAPI.apiGroupSuffix
+	}
+	return fmt.Sprintf("%s.%s", serviceAlias, suffix)
+}
+
 // New returns a new Model struct for a supplied API model.
 // Optionally, pass a file path to a generator config file that can be used to
 // instruct the code generator how to handle the API properly
 func New(
 	SDKAPI *SDKAPI,
+	serviceAlias string,
 	apiVersion string,
 	cfg ackgenconfig.Config,
 ) (*Model, error) {
 	m := &Model{
-		SDKAPI: SDKAPI,
-		// TODO(jaypipes): Handle cases where service alias and service ID
-		// don't match (Step Functions)
-		serviceAlias: SDKAPI.ServiceID(),
+		SDKAPI:       SDKAPI,
+		serviceAlias: serviceAlias,
 		apiVersion:   apiVersion,
 		cfg:          &cfg,
 	}

--- a/pkg/model/multiversion/manager.go
+++ b/pkg/model/multiversion/manager.go
@@ -106,6 +106,7 @@ func NewAPIVersionManager(
 
 		i, err := ackmodel.New(
 			SDKAPI,
+			serviceAlias,
 			version.APIVersion,
 			cfg,
 		)

--- a/pkg/model/multiversion/manager.go
+++ b/pkg/model/multiversion/manager.go
@@ -94,6 +94,11 @@ func NewAPIVersionManager(
 			return nil, err
 		}
 
+		cfg, err := ackgenconfig.New(apiInfo.GeneratorConfigPath, defaultConfig)
+		if err != nil {
+			return nil, err
+		}
+
 		SDKAPI, err := SDKAPIHelper.API(serviceAlias)
 		if err != nil {
 			return nil, err
@@ -102,8 +107,7 @@ func NewAPIVersionManager(
 		i, err := ackmodel.New(
 			SDKAPI,
 			version.APIVersion,
-			apiInfo.GeneratorConfigPath,
-			defaultConfig,
+			cfg,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create model for API version %s: %v", version.APIVersion, err)

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -93,8 +93,8 @@ func (h *SDKHelper) WithAPIVersion(apiVersion string) {
 }
 
 // API returns the aws-sdk-go API model for a supplied service alias
-func (h *SDKHelper) API(serviceAlias string) (*SDKAPI, error) {
-	modelPath, _, err := h.ModelAndDocsPath(serviceAlias)
+func (h *SDKHelper) API(serviceModelName string) (*SDKAPI, error) {
+	modelPath, _, err := h.ModelAndDocsPath(serviceModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -120,17 +120,17 @@ func (h *SDKHelper) API(serviceAlias string) (*SDKAPI, error) {
 // ModelAndDocsPath returns two string paths to the supplied service alias'
 // model and doc JSON files
 func (h *SDKHelper) ModelAndDocsPath(
-	serviceAlias string,
+	serviceModelName string,
 ) (string, string, error) {
 	if h.apiVersion == "" {
-		apiVersion, err := h.FirstAPIVersion(serviceAlias)
+		apiVersion, err := h.FirstAPIVersion(serviceModelName)
 		if err != nil {
 			return "", "", err
 		}
 		h.apiVersion = apiVersion
 	}
 	versionPath := filepath.Join(
-		h.basePath, "models", "apis", serviceAlias, h.apiVersion,
+		h.basePath, "models", "apis", serviceModelName, h.apiVersion,
 	)
 	modelPath := filepath.Join(versionPath, "api-2.json")
 	docsPath := filepath.Join(versionPath, "docs-2.json")
@@ -246,8 +246,8 @@ func (a *SDKAPI) GetOutputShapeRef(
 }
 
 // getMemberByPath returns a ShapeRef given a root Shape and a dot-notation
-// object search path. Given the explicit type check for list type members 
-// both ".." and "." notations work currently. 
+// object search path. Given the explicit type check for list type members
+// both ".." and "." notations work currently.
 // TODO: Add support for other types such as map.
 func getMemberByPath(
 	shape *awssdkmodel.Shape,

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -375,17 +375,6 @@ func (a *SDKAPI) GetServiceFullName() string {
 	return a.API.Metadata.ServiceFullName
 }
 
-// APIGroup returns the normalized Kubernetes APIGroup for the AWS service API,
-// e.g. "sns.services.k8s.aws"
-func (a *SDKAPI) APIGroup() string {
-	serviceID := a.ServiceIDClean()
-	suffix := "services.k8s.aws"
-	if a.apiGroupSuffix != "" {
-		suffix = a.apiGroupSuffix
-	}
-	return fmt.Sprintf("%s.%s", serviceID, suffix)
-}
-
 // SDKAPIInterfaceTypeName returns the name of the aws-sdk-go primary API
 // interface type name.
 func (a *SDKAPI) SDKAPIInterfaceTypeName() string {

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -92,7 +92,7 @@ func (h *SDKHelper) WithAPIVersion(apiVersion string) {
 	h.apiVersion = apiVersion
 }
 
-// API returns the aws-sdk-go API model for a supplied service alias
+// API returns the aws-sdk-go API model for a supplied service model name.
 func (h *SDKHelper) API(serviceModelName string) (*SDKAPI, error) {
 	modelPath, _, err := h.ModelAndDocsPath(serviceModelName)
 	if err != nil {
@@ -117,8 +117,8 @@ func (h *SDKHelper) API(serviceModelName string) (*SDKAPI, error) {
 	return nil, ErrServiceNotFound
 }
 
-// ModelAndDocsPath returns two string paths to the supplied service alias'
-// model and doc JSON files
+// ModelAndDocsPath returns two string paths to the supplied service's API and
+// doc JSON files
 func (h *SDKHelper) ModelAndDocsPath(
 	serviceModelName string,
 ) (string, string, error) {

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -87,7 +87,7 @@ func NewModelForServiceWithOptions(t *testing.T, serviceAlias string, options *T
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := ackmodel.New(sdkAPI, options.APIVersion, cfg)
+	m, err := ackmodel.New(sdkAPI, serviceAlias, options.APIVersion, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
@@ -82,7 +83,11 @@ func NewModelForServiceWithOptions(t *testing.T, serviceAlias string, options *T
 	if _, err := os.Stat(generatorConfigPath); os.IsNotExist(err) {
 		generatorConfigPath = ""
 	}
-	m, err := ackmodel.New(sdkAPI, options.APIVersion, generatorConfigPath, ackgenerate.DefaultConfig)
+	cfg, err := ackgenconfig.New(generatorConfigPath, ackgenerate.DefaultConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := ackmodel.New(sdkAPI, options.APIVersion, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -14,19 +14,19 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	ctrlrtmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	svcresource "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/resource"
-	svctypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
+	svcresource "github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller/pkg/resource"
+	svctypes "github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller/apis/{{ .APIVersion }}"
 	{{/* TODO(a-hilaly): import apis/* packages to register webhooks */}}
-	{{ $serviceIDClean := .ServiceIDClean }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $serviceIDClean }}-controller/pkg/resource/{{ $crdName }}"
+	{{ $serviceIDClean := .ServiceAlias }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $serviceIDClean }}-controller/pkg/resource/{{ $crdName }}"
 	{{end}}
 )
 
 var (
 	awsServiceAPIGroup = "{{ .APIGroup }}"
-	awsServiceAlias	= "{{ .ServiceIDClean }}"
+	awsServiceAlias	= "{{ .ServiceAlias }}"
 	awsServiceEndpointsID = svcsdk.EndpointsID
 	scheme			 = runtime.NewScheme()
 	setupLog		   = ctrlrt.Log.WithName("setup")

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ack-{{ .ServiceIDClean }}-controller
+  name: ack-{{ .ServiceAlias }}-controller
   namespace: ack-system
   labels:
     control-plane: controller

--- a/templates/config/controller/kustomization_def.yaml.tpl
+++ b/templates/config/controller/kustomization_def.yaml.tpl
@@ -6,6 +6,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ack-{{ .ServiceIDClean }}-controller
+  newName: ack-{{ .ServiceAlias }}-controller
   newTag: latest
 {{end}}

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ack-{{ .ServiceIDClean }}-metrics-service
+  name: ack-{{ .ServiceAlias }}-metrics-service
   namespace: ack-system
 spec:
   selector:

--- a/templates/config/controller/user-env.yaml.tpl
+++ b/templates/config/controller/user-env.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ack-{{.ServiceIDClean}}-controller
+  name: ack-{{.ServiceAlias}}-controller
   namespace: {{.Annotations.SuggestedNamespace}}
 spec:
   template:

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -7,12 +7,12 @@ metadata:
     capabilities: {{.Annotations.CapabilityLevel}}
     operatorframework.io/suggested-namespace: "ack-system"
     repository: {{.Annotations.Repository}}
-    containerImage: {{.Annotations.ContainerImage}}/{{.ServiceIDClean}}-controller:v{{.Version}}
+    containerImage: {{.Annotations.ContainerImage}}/{{.ServiceAlias}}-controller:v{{.Version}}
     description: {{.Annotations.ShortDescription}}
     createdAt: {{.CreatedAt}}
     support: {{.Annotations.Support}}
     certified: {{.Annotations.IsCertified}}
-  name: ack-{{.ServiceIDClean }}-controller.v0.0.0
+  name: ack-{{.ServiceAlias }}-controller.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -23,7 +23,7 @@ spec:
       name: {{ ToLower .Plural }}.{{$.APIGroup}}
       version: {{$.APIVersion}}
       displayName: {{.Kind}}
-      description: {{.Kind}} represents the state of an AWS {{$.ServiceID}} {{.Kind}} resource.
+      description: {{.Kind}} represents the state of an AWS {{$.ServiceAlias}} {{.Kind}} resource.
     {{- end}}
   description: '{{ .Description }}'
   displayName: {{ .DisplayName}}
@@ -42,7 +42,7 @@ spec:
     type: {{ .Type }}
   {{- end}}
   keywords:
-  - {{.ServiceIDClean}}
+  - {{.ServiceAlias}}
   {{- range .Common.Keywords}}
   - {{ . }}
   {{- end}}

--- a/templates/config/overlays/namespaced/kustomization.yaml.tpl
+++ b/templates/config/overlays/namespaced/kustomization.yaml.tpl
@@ -6,10 +6,10 @@ patches:
     group: rbac.authorization.k8s.io
     version: v1
     kind: ClusterRole
-    name: ack-{{ .ServiceIDClean }}-controller
+    name: ack-{{ .ServiceAlias }}-controller
 - path: role-binding.json
   target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: ClusterRoleBinding
-    name: ack-{{ .ServiceIDClean }}-controller-rolebinding
+    name: ack-{{ .ServiceAlias }}-controller-rolebinding

--- a/templates/config/rbac/cluster-role-binding.yaml.tpl
+++ b/templates/config/rbac/cluster-role-binding.yaml.tpl
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-{{ .ServiceIDClean }}-controller-rolebinding
+  name: ack-{{ .ServiceAlias }}-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-{{ .ServiceIDClean }}-controller
+  name: ack-{{ .ServiceAlias }}-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/templates/config/rbac/role-reader.yaml.tpl
+++ b/templates/config/rbac/role-reader.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-reader
+  name: ack-{{ .ServiceAlias }}-reader
   namespace: default
 rules:
 - apiGroups:

--- a/templates/config/rbac/role-writer.yaml.tpl
+++ b/templates/config/rbac/role-writer.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-writer
+  name: ack-{{ .ServiceAlias }}-writer
   namespace: default
 rules:
 - apiGroups:

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -11,16 +11,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}/{{ .ServiceIDClean }}iface"
-	svcapi "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}/{{ .ServiceAlias }}iface"
+	svcapi "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 
-	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceIDClean }}/{{ .APIVersion}}"
+	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceAlias }}/{{ .APIVersion}}"
 	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 )
 

--- a/templates/crossplane/pkg/conversions.go.tpl
+++ b/templates/crossplane/pkg/conversions.go.tpl
@@ -11,9 +11,9 @@ import (
 {{ end }}
 {{- end }}
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 
-	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceIDClean }}/{{ .APIVersion}}"
+	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceAlias }}/{{ .APIVersion}}"
 )
 
 // NOTE(muvaf): We return pointers in case the function needs to start with an

--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,18 +1,18 @@
 apiVersion: v1
-name: {{ .ServiceIDClean }}-chart
+name: {{ .ServiceAlias }}-chart
 description: A Helm chart for the ACK service controller for {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}
-home: https://github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
+home: https://github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
-  - https://github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller
+  - https://github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller
 maintainers:
   - name: ACK Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
   - name: {{ .Metadata.Service.ShortName }} Admins
-    url: https://github.com/orgs/aws-controllers-k8s/teams/{{ .ServiceIDClean }}-maintainer
+    url: https://github.com/orgs/aws-controllers-k8s/teams/{{ .ServiceAlias }}-maintainer
 keywords:
   - aws
   - kubernetes
-  - {{ .ServiceIDClean }}
+  - {{ .ServiceAlias }}

--- a/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
+++ b/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-controller
+  name: ack-{{ .ServiceAlias }}-controller
 {{ "{{ else }}" }}
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-controller
+  name: ack-{{ .ServiceAlias }}-controller
   namespace: {{ "{{ .Release.Namespace }}" }}
 {{ "{{ end }}" }}

--- a/templates/helm/templates/cluster-role-binding.yaml.tpl
+++ b/templates/helm/templates/cluster-role-binding.yaml.tpl
@@ -14,7 +14,7 @@ roleRef:
   kind: Role
 {{ "{{ end }}" }}
   apiGroup: rbac.authorization.k8s.io
-  name: ack-{{ .ServiceIDClean }}-controller
+  name: ack-{{ .ServiceAlias }}-controller
 subjects:
 - kind: ServiceAccount
   name: {{ "{{ include \"service-account.name\" . }}" }}

--- a/templates/helm/templates/role-reader.yaml.tpl
+++ b/templates/helm/templates/role-reader.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-reader
+  name: ack-{{ .ServiceAlias }}-reader
   namespace: {{ "{{ .Release.Namespace }}" }}
 rules:
 - apiGroups:

--- a/templates/helm/templates/role-writer.yaml.tpl
+++ b/templates/helm/templates/role-writer.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServiceIDClean }}-writer
+  name: ack-{{ .ServiceAlias }}-writer
   namespace: {{ "{{ .Release.Namespace }}" }}
 rules:
 - apiGroups:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -1,4 +1,4 @@
-# Default values for ack-{{ .ServiceIDClean }}-controller.
+# Default values for ack-{{ .ServiceAlias }}-controller.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -10,7 +10,7 @@ import (
 	k8sapirt "k8s.io/apimachinery/pkg/runtime"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller/apis/{{ .APIVersion }}"
 )
 
 const (

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -20,8 +20,8 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}/{{ .ServiceIDClean }}iface"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}/{{ .ServiceAlias }}iface"
 )
 
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }},verbs=get;list;watch;create;update;patch;delete
@@ -163,7 +163,7 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:{{ .ServiceIDClean }}:%s:%s:%s",
+		"arn:aws:{{ .ServiceAlias }}:%s:%s:%s",
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 
-	svcresource "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/pkg/resource"
+	svcresource "github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller/pkg/resource"
 )
 
 // resourceManagerFactory produces resourceManager objects. It implements the

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceIDClean }}-controller/apis/{{ .APIVersion}}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServiceAlias }}-controller/apis/{{ .APIVersion}}"
 )
 
 // Hack to avoid import errors during build...

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -12,11 +12,11 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceIDClean }}"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{.ServiceIDClean }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{.ServiceAlias }}-controller/apis/{{ .APIVersion }}"
 )
 
 // Hack to avoid import errors during build...


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#994

Description of changes:
This pull request supports including an optional `model_name` field in the `generator.yaml` file. The generator will use this argument to override the service name when looking up the API files in aws-sdk-go/models/apis.

Currently `ServiceIDClean` is used in all code generator templates as the import path for aws-sdk-go and when referencing the controller name (eg. `{{ .ServiceIDClean}}-controller`). This pull request will remove `ServiceIDClean` and instead use the service alias (as `ServiceAlias`) when referencing the controller and the aws-sdk-go packages. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
