### PR TITLE
remove --aws-account-id flag from deployment

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -26,8 +26,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --enable-development-logging

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --aws-endpoint-url


### PR DESCRIPTION
ACK runtime v0.15.0 removed support for the `--aws-account-id`
controller flag but our deployment templates were still adding this flag
to the controller entrypoint args, which causes tests to fail with:

```
unknown flag: --aws-account-id
```

Related: #213

See: https://github.com/aws-controllers-k8s/runtime/commit/60801010475969b411d192574c9a47b5acc81bb9

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
