### PR TITLE
remove account-id from helm values and deployment

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -61,8 +61,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: AWS_ACCOUNT_ID
-          value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -38,7 +38,6 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
-  account_id: ""
   endpoint_url: ""
 
 # log level for the controller


### PR DESCRIPTION
Description of changes:
Removing `account-id` from helm files as they no longer supported in the latest runtime

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
