### PR TITLE
Add plural names support to `GetOpTypeAndResourceNameFromOpID`

### DIFF
--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -397,7 +397,7 @@ func (a *SDKAPI) SDKAPIInterfaceTypeName() string {
 
 // Override the operation type and/or resource name if specified in config
 func getOpTypeAndResourceName(opID string, cfg *ackgenconfig.Config) ([]OpType, string) {
-	opType, resName := GetOpTypeAndResourceNameFromOpID(opID)
+	opType, resName := GetOpTypeAndResourceNameFromOpID(opID, cfg)
 	opTypes := []OpType{opType}
 
 	if cfg == nil {

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -1,6 +1,7 @@
 ignore:
   field_paths:
     - CreateVpcInput.DryRun
+    - CreateDhcpOptionsInput.DryRun
   resource_names:
     - AccountAttribute
     - CapacityReservation
@@ -10,6 +11,7 @@ ignore:
     - CustomerGateway
     - DefaultSubnet
     - DefaultVpc
+    #- DhcpOptions
     - EgressOnlyInternetGateway
     - Fleet
     - FpgaImage
@@ -64,3 +66,6 @@ ignore:
 operations:
   CreateVpcEndpoint:
     output_wrapper_field_path: VpcEndpoint
+
+resources:
+  DhcpOptions:


### PR DESCRIPTION
Issue #, if available: [#999](https://github.com/aws-controllers-k8s/community/issues/999)

Description of changes:
* Heuristic to guess resource name will not singularize the resource, if defined in generator resource config. This is to support resources like EC2's DhcpOptions where there is no singular form of the resource.
* unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
