### PR TITLE
update olm script to remove AdoptedResource from the bundle that is generated

### DIFF
--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -128,8 +128,8 @@ kustomize edit set image controller="$AWS_SERVICE_DOCKER_IMG"
 popd 1>/dev/null
 
 # remove crd/common from bases to prevent inclusion of AdoptedResource CRD from being generated in the bundle directory
-sed -i '' '/bases:/d' $tmp_kustomize_config_dir/crd/kustomization.yaml
-sed -i '' '/- common/d' $tmp_kustomize_config_dir/crd/kustomization.yaml
+sed -i.orig '/^bases:$/d' $tmp_kustomize_config_dir/crd/kustomization.yaml
+sed -i.orig '/- common$/d' $tmp_kustomize_config_dir/crd/kustomization.yaml
 
 # prepare bundle generate arguments
 opsdk_gen_bundle_args="--version $BUNDLE_VERSION --package ack-$SERVICE-controller --kustomize-dir $SERVICE_CONTROLLER_SOURCE_PATH/config/manifests --overwrite "


### PR DESCRIPTION
Issue #, if available:
aws-controllers-k8s/community#1006
This does not close this issue, this is just one piece needed. The runtime also needs to be update.

Description of changes:
This PR updates the `olm` scripts in a way that the `AdpotedResource` is no longer generated in the bundle that gets produced on disk. Since the OLM script works off a `temp` directory, this does not update/affect any of the artifacts on disk in the repo. The bundle that this generates has been tested against an OpenShift cluster vai OLM install. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
