### PR TITLE
Added caution note regarding `endpoint_url`

### DIFF
--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -38,7 +38,12 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
-  endpoint_url: ""
+
+  # The following endpoint_url is for the AWS services such as s3, dynamodb, vpc, etc. 
+  # It can be easily confused with the EKS endpoint. Adding EKS endpoint url here results in issue 1015. 
+  # It has been intentionally commented out. 
+
+#  endpoint_url: ""
 
 # log level for the controller
 log:


### PR DESCRIPTION
Issue #, if available: 1015

Description of changes:
  Commented out endpoint_url. 
  The endpoint_url is for the AWS services such as s3, dynamodb, vpc, etc. See the [AWS SDK documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) for more information.
  It can be easily confused with the EKS endpoint. Adding EKS endpoint url here results in issue 1015.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
