### PR TITLE
add ecmp to initialisms

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -91,6 +91,7 @@ var (
 		{"Ecr", "ECR", "ecr", nil},
 		{"Efs", "EFS", "efs", nil},
 		{"Eks", "EKS", "eks", nil},
+		{"Ecmp", "ECMP", "ecmp", nil},
 		{"Fpga", "FPGA", "fpga", nil},
 		{"Gpu", "GPU", "gpu", nil},
 		{"Html", "HTML", "html", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -64,6 +64,7 @@ func TestNames(t *testing.T) {
 		{"Iops", "IOPS", "iops", "iops"},
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance"},
 		{"Vlan", "VLAN", "vlan", "vlan"},
+		{"Ecmp", "ECMP", "ecmp", "ecmp"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/ec2-controller/pull/17

Description of changes:
 - Add ECMP as an initialism. Currently used in ec2.TransitGateway
 - Regenerated TGW in EC2 controller and tested w/ `make kind-test` ✅

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
