### PR TITLE
add ENA to initialism list w/ preventions

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -91,6 +91,8 @@ var (
 		{"Ecr", "ECR", "ecr", nil},
 		{"Efs", "EFS", "efs", nil},
 		{"Eks", "EKS", "eks", nil},
+		// Prevent "Enable" and "Enabling" from becoming "ENAble"
+		{"Ena", "ENA", "ena", regexp.MustCompile("Ena(?!bl)", regexp.None)},
 		{"Ecmp", "ECMP", "ecmp", nil},
 		{"Fpga", "FPGA", "fpga", nil},
 		{"Gpu", "GPU", "gpu", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -65,6 +65,7 @@ func TestNames(t *testing.T) {
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance"},
 		{"Vlan", "VLAN", "vlan", "vlan"},
 		{"Ecmp", "ECMP", "ecmp", "ecmp"},
+		{"Ena", "ENA", "ena", "ena"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/ec2-controller/pull/17

Description of changes:
 - Add `ENA` to initialism list and prevent `"Enable" -> "ENAble" and "Enabling" -> "ENAbling" `


Grep to find other `Ena` words in aws models:

```
$ grep -r 'Ena[a-zA-Z]*' -o .  | sort | uniq | grep -v "Enabl"
./ec2/2016-11-15/api-2.json:EnaSupport
./ec2/2016-11-15/docs-2.json:EnaSupport
./ec2/2016-11-15/examples-1.json:EnaSupport
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
