### PR TITLE
Add `sdk_file_import` hook

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -56,6 +56,7 @@ code paths:
 * sdk_get_attributes_post_set_output
 * sdk_create_post_set_output
 * sdk_update_post_set_output
+* sdk_file_import
 * sdk_file_end
 * delta_pre_compare
 * delta_post_compare
@@ -93,6 +94,10 @@ The "post_set_output" hooks are called AFTER the the information from the API ca
 is merged with the copy of the original Kubernetes object. These hooks will
 have access to the updated Kubernetes object `ko`, the response of the API call
 (and the original Kubernetes CR object if its sdkUpdate)
+
+The "sdk_file_import" is a generic hook point that occurs outside the scope of
+any specific AWSResourceManager method and can be used to place packages into
+the import block of the sdk.go file
 
 The "sdk_file_end" is a generic hook point that occurs outside the scope of any
 specific AWSResourceManager method and can be used to place commonly-generated

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -6,6 +6,9 @@ import (
 	"context"
 	"strings"
 
+	{{- if $hookCode := Hook .CRD "sdk_file_import" }}
+	{{ $hookCode }}
+	{{- end }}
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"


### PR DESCRIPTION
Description of changes:
Add a hook to allow importing arbitrary packages into the `sdk.go` file. This will be used by the s3 controller to import `reflect`, for its custom diff logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
