### PR TITLE
Add `Dereference` template function

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -53,6 +53,9 @@ var (
 	controllerCopyPaths = []string{}
 	controllerFuncMap   = ttpl.FuncMap{
 		"ToLower": strings.ToLower,
+		"Dereference": func(s *string) string {
+			return *s
+		},
 		"ResourceExceptionCode": func(r *ackmodel.CRD, httpStatusCode int) string {
 			return r.ExceptionCode(httpStatusCode)
 		},


### PR DESCRIPTION
Description of changes:
This PR adds a Go template function for de-referencing strings. Go templates do not, out of the box, support string de-referencing when doing string comparison. When comparing a string pointer to a pointer it gives a fatal type mismatch error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
