### PR TITLE
Expose `CompareStruct` to templates

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -107,6 +107,9 @@ var (
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeCompareStruct": func(r *ackmodel.CRD, shape *awssdkmodel.Shape, deltaVarName string, sourceVarName string, targetVarName string, fieldPath string, indentLevel int) string {
+			return code.CompareStruct(r.Config(), r, nil, shape, deltaVarName, sourceVarName, targetVarName, fieldPath, indentLevel)
+		},
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -157,7 +157,7 @@ func CompareResource(
 		case "structure":
 			// Recurse through all the struct's fields and subfields, building
 			// nested conditionals and calls to `delta.Add()`...
-			out += compareStruct(
+			out += CompareStruct(
 				cfg, r,
 				compareConfig,
 				memberShape,
@@ -501,10 +501,10 @@ func compareSlice(
 	return out
 }
 
-// compareStruct outputs Go code that compares two struct values from two
+// CompareStruct outputs Go code that compares two struct values from two
 // resource fields and, if there is a difference, adds the difference to a
 // variable representing an `ackcompare.Delta`.
-func compareStruct(
+func CompareStruct(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 	// struct informing code generator how to compare the field values
@@ -586,7 +586,7 @@ func compareStruct(
 		case "structure":
 			// Recurse through all the struct's fields and subfields, building
 			// nested conditionals and calls to `delta.Add()`...
-			out += compareStruct(
+			out += CompareStruct(
 				cfg, r,
 				compareConfig,
 				memberShape,


### PR DESCRIPTION
Description of changes:
Exports and exposes the `CompareStruct` method, so that hooks can create their own delta comparison code. This PR will also require https://github.com/aws-controllers-k8s/code-generator/pull/229 as the delta code could require importing `reflect`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
