### PR TITLE
making ack-user-config and ack-user-secrets required in the deployment template

### DIFF
--- a/templates/config/controller/user-env.yaml.tpl
+++ b/templates/config/controller/user-env.yaml.tpl
@@ -11,7 +11,7 @@ spec:
         envFrom:
           - configMapRef:
               name: ack-user-config
-              optional: true
+              optional: false
           - secretRef:
               name: ack-user-secrets
-              optional: true
+              optional: false


### PR DESCRIPTION
Issue #, if available:
Fixes: aws-controllers-k8s/community#1052

Description of changes:
Update to make `ack-user-config` and `ack-user-secrets` in the deployment be required for OpenShift. Thus making the operator installation fail false with clearer errors for the cluster admin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Adam D. Cornett <adc@redhat.com>