### PR TITLE
Prevent generated types from colliding with Resources

### DIFF
--- a/templates/crossplane/apis/type_def.go.tpl
+++ b/templates/crossplane/apis/type_def.go.tpl
@@ -1,4 +1,5 @@
 {{- define "type_def" -}}
+// +kubebuilder:skipversion
 type {{ .Names.Camel }} struct {
 {{- range $attrName, $attr := .Attrs }}
 	{{- if $attr.Shape }}


### PR DESCRIPTION
Signed-off-by: Aaron Eaton <aaron@upbound.io>

Issue #, if available: https://github.com/crossplane/provider-aws/issues/876

Description of changes:

It is possible to have a name collision between a Crossplane Managed Resource and a generated type based on a resource's fields. A good example of this is the SecurityGroup type, which is both a [Managed Resource](https://github.com/crossplane/provider-aws/blob/fd376a39bfebaef2fcc5d1c8fb9177f7e4652bd8/apis/ec2/v1beta1/securitygroup_types.go#L240) and a [generated type](https://github.com/crossplane/provider-aws/blob/76bc036fa0b1cfc5438777cf324922b3634b05e1/apis/ec2/v1alpha1/zz_types.go#L2428).

Whichever type is declared  in the highest apiVersion will become the "storage version" for the given type.

For SecurityGroup, this has no impact, because the Managed Resource is version `v1beta1` and the generated type is only in lower versions.

But for the proposed [Route](https://github.com/crossplane/provider-aws/pull/859) resource, the Managed Resources is `v1alpha1` and a generated type exists in `v1beta1`, resulting in `v1beta1` becoming the storage version. Because the storage version is generated, it lacks crossplane required fields `status` and `synced`.

Marking all generated types with `// +kubebuilder:skipversion` will prevent them from becoming the storage version for a Managed Resource of the same name.