### PR TITLE
Use loadModelWithLatestAPIVersion to load models for crossplane

### DIFF
--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -35,9 +35,6 @@ var crossplaneCmd = &cobra.Command{
 }
 
 func init() {
-	crossplaneCmd.PersistentFlags().StringVar(
-		&optOutputPath, "provider-dir", ".", "the directory of the Crossplane provider",
-	)
 	rootCmd.AddCommand(crossplaneCmd)
 }
 

--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -25,11 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
-	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
 	cpgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/crossplane"
-	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
-	acksdk "github.com/aws-controllers-k8s/code-generator/pkg/sdk"
 )
 
 // crossplaneCmd is the command that generates Crossplane API types
@@ -39,11 +34,9 @@ var crossplaneCmd = &cobra.Command{
 	RunE:  generateCrossplane,
 }
 
-var providerDir string
-
 func init() {
 	crossplaneCmd.PersistentFlags().StringVar(
-		&providerDir, "provider-dir", ".", "the directory of the Crossplane provider",
+		&optOutputPath, "provider-dir", ".", "the directory of the Crossplane provider",
 	)
 	rootCmd.AddCommand(crossplaneCmd)
 }
@@ -58,34 +51,9 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 		return err
 	}
 	svcAlias := strings.ToLower(args[0])
-	cfgPath := filepath.Join(providerDir, "apis", svcAlias, optGenVersion, "generator-config.yaml")
-	_, err := os.Stat(cfgPath)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	if os.IsNotExist(err) {
-		cfgPath = ""
-	}
-	cfg, err := ackgenconfig.New(cfgPath, ackgenerate.DefaultConfig)
-	if err != nil {
-		return err
-	}
-	sdkHelper := acksdk.NewHelper(sdkDir, cfg)
-	sdkHelper.APIGroupSuffix = "aws.crossplane.io"
-	sdkAPI, err := sdkHelper.API(svcAlias)
-	if err != nil {
-		retryModelName, err := FallBackFindServiceID(sdkDir, svcAlias)
-		if err != nil {
-			return err
-		}
-		// Retry using path found by querying service ID
-		sdkAPI, err = sdkHelper.API(retryModelName)
-		if err != nil {
-			return fmt.Errorf("cannot get the API model for service %s", svcAlias)
-		}
-	}
-	m, err := ackmodel.New(
-		sdkAPI, svcAlias, optGenVersion, cfg,
+	optGeneratorConfigPath = filepath.Join(optOutputPath, "apis", svcAlias, optGenVersion, "generator-config.yaml")
+	m, err := loadModelWithLatestAPIVersion(
+		svcAlias,
 	)
 	if err != nil {
 		return err
@@ -106,7 +74,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 			fmt.Println(strings.TrimSpace(contents.String()))
 			continue
 		}
-		outPath := filepath.Join(providerDir, path)
+		outPath := filepath.Join(optOutputPath, path)
 		outDir := filepath.Dir(outPath)
 		if _, err := ensureDir(outDir); err != nil {
 			return err
@@ -115,8 +83,8 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	apiPath := filepath.Join(providerDir, "apis", svcAlias, optGenVersion)
-	controllerPath := filepath.Join(providerDir, "pkg", "controller", svcAlias)
+	apiPath := filepath.Join(optOutputPath, "apis", svcAlias, optGenVersion)
+	controllerPath := filepath.Join(optOutputPath, "pkg", "controller", svcAlias)
 	// TODO(muvaf): goimports don't allow to be included as a library. Make sure
 	// goimports binary exists.
 	if err := exec.Command("goimports", "-w", apiPath, controllerPath).Run(); err != nil {

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -116,7 +116,7 @@ func init() {
 		&optMetadataConfigPath, "metadata-config-path", "", "Path to file containing service metadata to use",
 	)
 	rootCmd.PersistentFlags().StringVarP(
-		&optOutputPath, "output", "o", "", "Path to directory to output generated files.",
+		&optOutputPath, "output", "o", "", "Path to directory to output generated files (if generating crossplane providers, this should be the root of the aws-crossplane directory)",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optAWSSDKGoVersion, "aws-sdk-go-version", "", "Version of github.com/aws/aws-sdk-go used to generate apis and controllers files",

--- a/templates/crossplane/README.md
+++ b/templates/crossplane/README.md
@@ -4,7 +4,7 @@ This folder includes the templates to generate AWS Crossplane Provider. Run the
 following to generate:
 
 ```console
-go run -tags codegen cmd/ack-generate/main.go crossplane apis ecr --provider-dir <directory for provider>
+go run -tags codegen cmd/ack-generate/main.go crossplane apis ecr --output <directory for provider>
 ```
 
 See [Contributing New Resource Using ACK](https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md)


### PR DESCRIPTION
This fixes an issue where the crossplane command would fail to find API
models for resources whose name differed between the model and API in
the SDK. Previous behavior was to continue using the svcAlias instead of
correctly using model_name from the configuration.

The changes here also have the added benefit of making the generateCrossplane function code more similar to other generation functions and utilize more of the common codebase.

Issue #, if available:
N/A

Description of changes:
Replace duplicated code in the generateCrossplane function with implementations in common.go and change variables to match the naming scheme used elsewhere.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
