### PR TITLE
Use loadModel instead of loadModelWithLatestAPIVersion for crossplane

### DIFF
--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -49,9 +49,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 	}
 	svcAlias := strings.ToLower(args[0])
 	optGeneratorConfigPath = filepath.Join(optOutputPath, "apis", svcAlias, optGenVersion, "generator-config.yaml")
-	m, err := loadModelWithLatestAPIVersion(
-		svcAlias,
-	)
+	m, err := loadModel(svcAlias, optGenVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
getLatestAPIVersion doesn't seem to work correctly with crossplane, and
opgGenVersion is already used to find the configuration path for
resources, so just use that instead.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
