### PR TITLE
changing CSV template to use categories

### DIFF
--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    category: "Cloud Provider"
+    categories: "Cloud Provider"
     alm-examples: '[]'
     capabilities: {{.Annotations.CapabilityLevel}}
     operatorframework.io/suggested-namespace: "ack-system"


### PR DESCRIPTION
Issue #, if available:
NA

Description of changes:
The community operator repo's tests expects `categories` instead of `category` even if an operator is only going to be listed in OperatorHub under one category.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Adam D. Cornett <adc@redhat.com>