### PR TITLE
Remove code setting a resource ARN from its spec primary identifier

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -194,8 +194,6 @@ func SetSDK(
 		if r.IsPrimaryARNField(memberName) {
 			// if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
 			//     res.SetTopicArn(string(*ko.Status.ACKResourceMetadata.ARN))
-			// } else {
-			//     res.SetTopicArn(rm.ARNFromName(*ko.Spec.Name))
 			// }
 			out += fmt.Sprintf(
 				"%sif %s.Status.ACKResourceMetadata != nil && %s.Status.ACKResourceMetadata.ARN != nil {\n",
@@ -204,14 +202,6 @@ func SetSDK(
 			out += fmt.Sprintf(
 				"%s\t%s.Set%s(string(*%s.Status.ACKResourceMetadata.ARN))\n",
 				indent, targetVarName, memberName, sourceVarName,
-			)
-			out += fmt.Sprintf(
-				"%s} else {\n", indent,
-			)
-			nameField := *r.SpecIdentifierField()
-			out += fmt.Sprintf(
-				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
-				indent, targetVarName, memberName, sourceVarName, nameField,
 			)
 			out += fmt.Sprintf(
 				"%s}\n", indent,


### PR DESCRIPTION
Originally, this code was added to be able to make `ReadOne` calls when
a resource was not created yet and its ARN is not known, by trying to
build the ARN from the primary identifier field.

Currently `ReadOne` calls uses `requiredFieldsMissingFromReadOneInput`
to know whether a resource was created or not - if a required field is
missing, the `sdkFind` function will return a `ackerr.NotFound`

This also fixes code generation for lambda `CodeSigningConfig` resource
which was panicking because `CodeSIgningConfig` doesn't have a spec
identifier field.

Tested with dynamodb and ECR.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
