### PR TITLE
Add `UUID` to initialism

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -122,6 +122,7 @@ var (
 		// Need to prevent "security" from becoming "SecURIty"
 		{"Uri", "URI", "uri", regexp.MustCompile("(?!sec)uri(?!ty)|(Uri)", regexp.None)},
 		{"Url", "URL", "url", nil},
+		{"Uuid", "UUID", "uuid", nil},
 		{"Vlan", "VLAN", "vlan", nil},
 		{"Vpc", "VPC", "vpc", nil},
 		{"Vpn", "VPN", "vpn", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -66,6 +66,7 @@ func TestNames(t *testing.T) {
 		{"Vlan", "VLAN", "vlan", "vlan"},
 		{"Ecmp", "ECMP", "ecmp", "ecmp"},
 		{"Ena", "ENA", "ena", "ena"},
+		{"UUID", "UUID", "uuid", "uuid"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Generating `EventSourceMapping` resource in the lambda controller
produces a CRD FIeld with a json tag `uUID`. This commit makes sure
that `UUID` names stay intact during code generation.

Description of changes:
- Add `UUID` to initialisms

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
