### PR TITLE
Generate resource `IsSynced` functions

### DIFF
--- a/pkg/fieldpath/path.go
+++ b/pkg/fieldpath/path.go
@@ -118,6 +118,11 @@ func (p *Path) Empty() bool {
 	return len(p.parts) == 0
 }
 
+// Size returns the Path number of parts
+func (p *Path) Size() int {
+	return len(p.parts)
+}
+
 // ShapeRef returns an aws-sdk-go ShapeRef within the supplied ShapeRef that
 // matches the Path. Returns nil if no matching ShapeRef could be found.
 //

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -120,6 +120,9 @@ var (
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeIsSynced": func(r *ackmodel.CRD, resVarName string, indentLevel int) string {
+			return code.ResourceIsSynced(r.Config(), r, resVarName, indentLevel)
+		},
 		"GoCodeCompareStruct": func(r *ackmodel.CRD, shape *awssdkmodel.Shape, deltaVarName string, sourceVarName string, targetVarName string, fieldPath string, indentLevel int) string {
 			return code.CompareStruct(r.Config(), r, nil, shape, deltaVarName, sourceVarName, targetVarName, fieldPath, indentLevel)
 		},

--- a/pkg/generate/code/synced.go
+++ b/pkg/generate/code/synced.go
@@ -1,0 +1,204 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/fieldpath"
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/generate/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+)
+
+// ResourceIsSynced returns the Go code that verifies whether a resource is synced or
+// not. This code is generated using ack-generate configuration.
+// See ack-generate/pkg/config.SyncedConfiguration.
+//
+//  Sample output:
+//
+//  	candidates0 := []string{"AVAILABLE", "ACTIVE"}
+//  	if !ackutil.InStrings(*r.ko.Status.TableStatus, candidates0) {
+//  		return false, nil
+//  	}
+//  	if r.ko.Spec.ProvisionedThroughput == nil {
+//  		return false, nil
+//  	}
+//  	if r.ko.Spec.ProvisionedThroughput.ReadCapacityUnits == nil {
+//  		return false, nil
+//  	}
+//  	candidates1 := []int{0, 10}
+//  	if !ackutil.InStrings(*r.ko.Spec.ProvisionedThroughput.ReadCapacityUnits, candidates1) {
+//  		return false, nil
+//  	}
+//  	candidates2 := []int{0}
+//  	if !ackutil.InStrings(*r.ko.Status.ItemCount, candidates2) {
+//  		return false, nil
+//  	}
+func ResourceIsSynced(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String
+	resVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := "\n"
+	resConfig, ok := cfg.ResourceConfig(r.Names.Original)
+	if !ok || resConfig.Synced == nil || len(resConfig.Synced.When) == 0 {
+		return out
+	}
+
+	for _, condition := range resConfig.Synced.When {
+		if condition.Path == nil || *condition.Path == "" {
+			panic("Received an empty sync condition path. 'SyncCondition.Path' must be provided.")
+		}
+		if len(condition.In) == 0 {
+			panic("'SyncCondition.In' must be provided.")
+		}
+		fp := fieldpath.FromString(*condition.Path)
+		field, err := getTopLevelField(r, *condition.Path)
+		if err != nil {
+			msg := fmt.Sprintf("cannot find top level field of path '%s': %v", *condition.Path, err)
+			panic(msg)
+		}
+		candidatesVarName := fmt.Sprintf("%sCandidates", field.Names.CamelLower)
+		if fp.Size() == 2 {
+			out += scalarFieldEqual(resVarName, candidatesVarName, field.ShapeRef.GoTypeElem(), condition)
+		} else {
+			out += fieldPathSafeEqual(resVarName, candidatesVarName, field, condition)
+		}
+	}
+
+	return out
+}
+
+func getTopLevelField(r *model.CRD, fieldPath string) (*model.Field, error) {
+	fp := fieldpath.FromString(fieldPath)
+	if fp.Size() < 2 {
+		return nil, fmt.Errorf("fieldPath must contain at least two elements, received: %s", fieldPath)
+	}
+
+	head := fp.PopFront()
+	fieldName := fp.PopFront()
+	switch head {
+	case "Spec":
+		field, ok := r.Fields[fieldName]
+		if !ok {
+			return nil, fmt.Errorf("field not found in Spec: %v", fieldName)
+		}
+		return field, nil
+	case "Status":
+		field, ok := r.Fields[fieldName]
+		if !ok {
+			return nil, fmt.Errorf("field not found in Status: %v", fieldName)
+		}
+		return field, nil
+	default:
+		return nil, fmt.Errorf("fieldPath must start with 'Spec' or 'Status', received: %v", head)
+	}
+}
+
+// scalarFieldEqual returns Go code that compares a scalar field to a given set of values.
+func scalarFieldEqual(resVarName string, candidatesVarName string, goType string, condition ackgenconfig.SyncedCondition) string {
+	out := ""
+	fieldPath := fmt.Sprintf("%s.%s", resVarName, *condition.Path)
+
+	valuesSlice := ""
+	switch goType {
+	case "string":
+		// []string{"AVAILABLE", "ACTIVE"}
+		valuesSlice = fmt.Sprintf("[]string{\"%s\"}", strings.Join(condition.In, "\", \""))
+	case "int64", "PositiveLongObject", "Long":
+		// []int64{1, 2}
+		valuesSlice = fmt.Sprintf("[]int{%s}", strings.Join(condition.In, ", "))
+	case "bool":
+		// []bool{false}
+		valuesSlice = fmt.Sprintf("[]bool{%s}", condition.In)
+	default:
+		panic("not supported type " + goType)
+	}
+
+	// candidates1 := []string{"AVAILABLE", "ACTIVE"}
+	out += fmt.Sprintf(
+		"\t%s := %v\n",
+		candidatesVarName,
+		valuesSlice,
+	)
+	// 	if !ackutil.InStrings(*r.ko.Status.State, candidates1) {
+	out += fmt.Sprintf(
+		"\tif !ackutil.InStrings(*%s, %s) {\n",
+		fieldPath,
+		candidatesVarName,
+	)
+
+	// return false, nil
+	out += "\t\treturn false, nil\n"
+	// }
+	out += "\t}\n"
+	return out
+}
+
+// fieldPathSafeEqual returns go code that safely compares a resource field to value
+func fieldPathSafeEqual(
+	resVarName string,
+	candidatesVarName string,
+	field *model.Field,
+	condition ackgenconfig.SyncedCondition,
+) string {
+	out := ""
+	rootPath := fmt.Sprintf("%s.%s", resVarName, strings.Split(*condition.Path, ".")[0])
+	knownShapesPath := strings.Join(strings.Split(*condition.Path, ".")[1:], ".")
+
+	fp := fieldpath.FromString(knownShapesPath)
+	shapes := fp.IterShapeRefs(field.ShapeRef)
+
+	subFieldPath := rootPath
+	for index, shape := range shapes {
+		if index == len(shapes)-1 {
+			// Some aws-sdk-go scalar shapes don't contain the real name of a shape
+			// In this case we use the full path given in condition.Path
+			subFieldPath = fmt.Sprintf("%s.%s", resVarName, *condition.Path)
+		} else {
+			subFieldPath += "." + shape.Shape.ShapeName
+		}
+		// if r.ko.Spec.ProvisionedThroughput == nil
+		out += fmt.Sprintf("\tif %s == nil {\n", subFieldPath)
+		// return false, nil
+		out += "\t\treturn false, nil\n"
+		// }
+		out += "\t}\n"
+	}
+	out += scalarFieldEqual(resVarName, candidatesVarName, shapes[len(shapes)-1].GoTypeElem(), condition)
+	return out
+}
+
+func fieldPathContainsMapOrArray(fieldPath string, shapeRef *awssdkmodel.ShapeRef) bool {
+	c := fieldpath.FromString(fieldPath)
+	sr := c.ShapeRef(shapeRef)
+
+	if sr == nil {
+		return false
+	}
+	if sr.ShapeName == "map" || sr.ShapeName == "list" {
+		return true
+	}
+	if sr.ShapeName == "structure" {
+		fieldName := c.PopFront()
+		return fieldPathContainsMapOrArray(c.Copy().At(1), sr.Shape.MemberRefs[fieldName])
+	}
+	return false
+}

--- a/pkg/generate/code/synced_test.go
+++ b/pkg/generate/code/synced_test.go
@@ -1,0 +1,92 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestSyncedLambdaFunction(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambda")
+
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	stateCandidates := []string{"AVAILABLE", "ACTIVE"}
+	if !ackutil.InStrings(*r.ko.Status.State, stateCandidates) {
+		return false, nil
+	}
+	lastUpdateStatusCandidates := []string{"AVAILABLE", "ACTIVE"}
+	if !ackutil.InStrings(*r.ko.Status.LastUpdateStatus, lastUpdateStatusCandidates) {
+		return false, nil
+	}
+	codeSizeCandidates := []int{1, 2}
+	if !ackutil.InStrings(*r.ko.Status.CodeSize, codeSizeCandidates) {
+		return false, nil
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.ResourceIsSynced(
+			crd.Config(), crd, "r.ko", 1,
+		),
+	)
+}
+
+func TestSyncedDynamodbTable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "dynamodb")
+
+	crd := testutil.GetCRDByName(t, g, "Table")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	tableStatusCandidates := []string{"AVAILABLE", "ACTIVE"}
+	if !ackutil.InStrings(*r.ko.Status.TableStatus, tableStatusCandidates) {
+		return false, nil
+	}
+	if r.ko.Spec.ProvisionedThroughput == nil {
+		return false, nil
+	}
+	if r.ko.Spec.ProvisionedThroughput.ReadCapacityUnits == nil {
+		return false, nil
+	}
+	provisionedThroughputCandidates := []int{0, 10}
+	if !ackutil.InStrings(*r.ko.Spec.ProvisionedThroughput.ReadCapacityUnits, provisionedThroughputCandidates) {
+		return false, nil
+	}
+	itemCountCandidates := []int{0}
+	if !ackutil.InStrings(*r.ko.Status.ItemCount, itemCountCandidates) {
+		return false, nil
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.ResourceIsSynced(
+			crd.Config(), crd, "r.ko", 1,
+		),
+	)
+}

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -33,6 +33,9 @@ type ResourceConfig struct {
 	// the code generator about a custom callback hooks that should be injected
 	// into the resource's manager or SDK binding code.
 	Hooks map[string]*HooksConfig `json:"hooks"`
+	// Synced contains instructions for the code generator to generate Go code
+	// that verifies whether a resource is synced or not.
+	Synced *SyncedConfig `json:"synced"`
 	// Renames identifies fields in Operations that should be renamed.
 	Renames *RenamesConfig `json:"renames,omitempty"`
 	// ListOperation contains instructions for the code generator to generate
@@ -85,6 +88,23 @@ type ResourceConfig struct {
 	// IsARNPrimaryKey determines whether the CRD uses the ARN as the primary
 	// identifier in the ReadOne operations.
 	IsARNPrimaryKey bool `json:"is_arn_primary_key"`
+}
+
+// SyncedConfig instructs the code generator on how to generate functions that checks
+// whether a resource was synced or not.
+type SyncedConfig struct {
+	// When is a list of conditions that should be satisfied in order to tell whether a
+	// a resource was synced or not.
+	When []SyncedCondition `json:"when"`
+}
+
+// SyncedCondition represent one of the unique condition that should be fullfiled in
+// order to assert whether a resource is synced.
+type SyncedCondition struct {
+	// Path of the field. e.g Status.Processing
+	Path *string `json:"path"`
+	// In contains a list of possible values `Path` should be equal to.
+	In []string `json:"in"`
 }
 
 // HooksConfig instructs the code generator how to inject custom callback hooks

--- a/pkg/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
@@ -4,6 +4,19 @@ resources:
       errors:
         404:
           code: ResourceNotFoundException
+    synced:
+      when:
+        - path: Status.TableStatus
+          in:
+            - AVAILABLE
+            - ACTIVE
+        - path: Spec.ProvisionedThroughput.ReadCapacityUnits
+          in:
+            - 0
+            - 10
+        - path: Status.ItemCount
+          in:
+            - 0
 operations:
   DescribeBackup:
     # DescribeBackupOutput is an unsual shape because it contains information for

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator.yaml
@@ -11,3 +11,17 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
+    synced:
+      when:
+        - path: Status.State
+          in:
+            - AVAILABLE
+            - ACTIVE
+        - path: Status.LastUpdateStatus
+          in:
+            - AVAILABLE
+            - ACTIVE
+        - path: Status.CodeSize
+          in:
+            - 1
+            - 2

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -16,12 +16,17 @@ import (
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}/{{ .ServicePackageName }}iface"
+)
+
+var (
+	_ = ackutil.InStrings
 )
 
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }},verbs=get;list;watch;create;update;patch;delete
@@ -232,6 +237,17 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
 {{ GoCodeLateInitializeFromReadOne .CRD "observed" "latest" 1 }}
+}
+
+// IsSynced returns true if the resource is synced.
+func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResource) (bool, error) {
+	r := rm.concreteResource(res)
+	if r.ko == nil {
+		// Should never happen... if it does, it's buggy code.
+		panic("resource manager's IsSynced() method received resource with nil CR object")
+	}
+{{ GoCodeIsSynced .CRD "r.ko" 1}}
+	return true, nil
 }
 
 // newResourceManager returns a new struct implementing


### PR DESCRIPTION
Issue: Generate ACK.ResourceSynced handlers #1064

Currently all the controllers contains custom code that checks whether
a resource is synced or not. This code is mostly used by generic hooks
that sets the `ACK.ResourceSynced` to its correct value. [Generic example
hook](https://github.com/aws-controllers-k8s/rds-controller/blob/main/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl)

This patch adds a new configuration option that will allow controller
maintainers to generate `resource.IsSynced`functions based on some
conditional.

configuration example:

```yaml
resources:
  Function:
    synced:
      when:
        - path: Status.State
          is: AVAILABLE
        - path: Status.State
          in:
            - AVAILABLE
            - ACTIVE
```

generated code example:

```go
// IsSynced returns true if the supplied resource is synced.
func (r *resource) IsSynced() bool {

	if *r.ko.Status.State != "AVAILABLE" {
		return false
	}
	candidates1 := []string{"AVAILABLE", "ACTIVE"}
	if !ackutil.InStrings(*r.ko.Status.State, candidates1) {
		return false
	}

	return true
}

```

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
