### PR TITLE
fix(group): group redeclared issue fixed

### DIFF
--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -82,7 +82,7 @@ type {{ .CRD.Kind }}List struct {
 // Repository type metadata.
 var (
 	{{ .CRD.Kind }}Kind             = "{{ .CRD.Kind }}"
-	{{ .CRD.Kind }}GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .CRD.Kind }}Kind}.String()
+	{{ .CRD.Kind }}GroupKind        = schema.GroupKind{Group: CRDGroup, Kind: {{ .CRD.Kind }}Kind}.String()
 	{{ .CRD.Kind }}KindAPIVersion   = {{ .CRD.Kind }}Kind + "." + GroupVersion.String()
 	{{ .CRD.Kind }}GroupVersionKind = GroupVersion.WithKind({{ .CRD.Kind }}Kind)
 )

--- a/templates/crossplane/apis/groupversion_info.go.tpl
+++ b/templates/crossplane/apis/groupversion_info.go.tpl
@@ -11,13 +11,13 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "{{ .APIGroup }}"
-	Version = "{{ .APIVersion }}"
+	CRDGroup   = "{{ .APIGroup }}"
+	CRDVersion = "{{ .APIVersion }}"
 )
 
 var (
     // GroupVersion is the API Group Version used to register the objects
-    GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
+    GroupVersion = schema.GroupVersion{Group: CRDGroup, Version: CRDVersion}
 
     // SchemeBuilder is used to add go types to the GroupVersionKind scheme
     SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

Issue https://github.com/aws-controllers-k8s/community/issues/1108 https://github.com/crossplane/provider-aws/issues/1025

Description of changes:
changed const Group to CRDGroup to fits generated Group for IAM 

without this PR:
make generate failed with:
`panic: interface conversion: types.Type is nil, not *types.Named`
![image](https://user-images.githubusercontent.com/21083497/146688301-b9e37f14-4eea-4ebb-b56c-de1666254610.png)

https://github.com/haarchri/provider-aws/blob/error/group/apis/iam/v1alpha1/zz_groupversion_info.go#L28
https://github.com/haarchri/provider-aws/blob/error/group/apis/iam/v1alpha1/zz_service_linked_role.go#L144
https://github.com/haarchri/provider-aws/blob/error/group/apis/iam/v1alpha1/zz_types.go#L102

fixed issue with this PR:
code-generator works in crossplane for iam:

https://github.com/haarchri/provider-aws/blob/fix/group/apis/iam/v1alpha1/zz_groupversion_info.go#L28
https://github.com/haarchri/provider-aws/blob/fix/group/apis/iam/v1alpha1/zz_groupversion_info.go#L34
https://github.com/haarchri/provider-aws/blob/fix/group/apis/iam/v1alpha1/zz_service_linked_role.go#L144

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
