### PR TITLE
Adds helm schema validation

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -27,6 +27,7 @@ var (
 		"helm/templates/cluster-role-binding.yaml.tpl",
 		"helm/Chart.yaml.tpl",
 		"helm/values.yaml.tpl",
+		"helm/values.schema.json",
 		"helm/templates/role-reader.yaml.tpl",
 		"helm/templates/role-writer.yaml.tpl",
 		"helm/templates/_controller-role-kind-patch.yaml.tpl",

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "image": {
+      "description": "Container Image",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["IfNotPresent", "Always", "Never"]
+        },
+        "pullSecrets": {
+          "type": "array"
+        }
+      },
+      "required": [
+          "repository",
+          "tag",
+          "pullPolicy"
+      ],
+      "type": "object"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullNameOverride": {
+      "type": "string"
+    },
+    "deployment": {
+      "description": "Deployment settings",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "containerPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "object"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        }
+      },
+      "required": [
+          "containerPort",
+          "nodeSelector"
+      ],
+      "type": "object"
+    },
+    "metrics": {
+      "description": "Metrics settings",
+      "properties": {
+        "service": {
+          "description": "Kubernetes service settings",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            }
+          },
+          "required": [
+              "create",
+              "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+          "service"
+      ],
+      "type": "object"
+    },
+    "resources": {
+      "description": "Kubernetes resources settings",
+      "properties": {
+        "requests": {
+          "description": "Kubernetes resource requests",
+          "properties": {
+            "memory": {
+              "oneOf": [
+                { "type": "number" },
+                { "type": "string" }
+              ]
+            },
+            "cpu": {
+              "oneOf": [
+                { "type": "number" },
+                { "type": "string" }
+              ]
+            }
+          },
+          "required": [
+              "memory",
+              "cpu"
+          ],
+          "type": "object"
+        },
+        "limits": {
+          "description": "Kubernetes resource limits",
+          "properties": {
+            "memory": {
+              "oneOf": [
+                { "type": "number" },
+                { "type": "string" }
+              ]
+            },
+            "cpu": {
+              "oneOf": [
+                { "type": "number" },
+                { "type": "string" }
+              ]
+            }
+          },
+          "required": [
+              "memory",
+              "cpu"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+          "requests",
+          "limits"
+      ],
+      "type": "object"
+    },
+    "aws": {
+      "description": "AWS API settings",
+      "properties": {
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "log": {
+      "description": "Logging settings",
+      "properties": {
+        "enable_development_logging": {
+          "type": "boolean"
+        },
+        "level": {
+          "type": "string",
+          "enum": ["debug", "info"]
+        }
+      },
+      "type": "object"
+    },
+    "installScope": {
+      "type": "string",
+      "enum": ["cluster", "namespace"]
+    },
+    "resourceTags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^.*=.*$"
+      }
+    },
+    "serviceAccount": {
+      "description": "ServiceAccount settings",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "deployment",
+    "metrics",
+    "resources",
+    "log",
+    "installScope",
+    "resourceTags",
+    "serviceAccount"
+  ],
+  "title": "Values",
+  "type": "object"
+}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -61,8 +61,7 @@
         }
       },
       "required": [
-          "containerPort",
-          "nodeSelector"
+          "containerPort"
       ],
       "type": "object"
     },
@@ -165,8 +164,7 @@
           "type": "boolean"
         },
         "level": {
-          "type": "string",
-          "enum": ["debug", "info"]
+          "type": "string"
         }
       },
       "type": "object"


### PR DESCRIPTION
Issue #, if available:
Closes https://github.com/aws-controllers-k8s/community/issues/899

Description of changes:
This adds a JSON schema to validate inputs to the helm chart, so that values of an incorrect type, regex or enumeration will fail quickly, rather than after the helm deployment runs.

Please let me know if I've missed any of the enum options.

Also worth noting that regarding the types, this will break functionality for anyone using `"true"`, `"false"`, `1`, `0` as a boolean or `"42"` as an integer, so let me know if you want those added as additional options to those fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
