### PR TITLE
Default priorityClassName to blank string

### DIFF
--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -27,7 +27,7 @@ deployment:
   affinity: {}
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
-  priorityClassName:
+  priorityClassName: ""
   
 metrics:
   service:


### PR DESCRIPTION
Issue #, if available:
Relates https://github.com/aws-controllers-k8s/code-generator/pull/249
Relates https://github.com/aws-controllers-k8s/code-generator/pull/252

Description of changes:
This fixes a bug I introduced in a previous PR (sorry!)
This must default to an empty string rather than null or you get:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
s3-chart:
- deployment.priorityClassName: Invalid type. Expected: string, given: null

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
