### PR TITLE
Export ToNames in template func map

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
+	names "github.com/aws-controllers-k8s/code-generator/pkg/names"
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
@@ -56,6 +57,9 @@ var (
 		"ToLower": strings.ToLower,
 		"Dereference": func(s *string) string {
 			return *s
+		},
+		"ToNames": func(s string) names.Names {
+			return names.New(s)
 		},
 		"ResourceExceptionCode": func(r *ackmodel.CRD, httpStatusCode int) string {
 			return r.ExceptionCode(httpStatusCode)


### PR DESCRIPTION
Description of changes:
Export `names.New` as `ToNames` in the template function map. This will allow for mapping from AWS SDK types to their respective CRD Spec and Status field names. For example, in the EKS controller, we want to create a `awssdk.ResourceVpcConfig` constructor that uses `svcapitypes.ResourceVPCConfig` as input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
