### PR TITLE
collect Field structs for members of structures

### DIFF
--- a/pkg/model/field_test.go
+++ b/pkg/model/field_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
 
 func TestParentFieldPath(t *testing.T) {
@@ -34,4 +36,43 @@ func TestParentFieldPath(t *testing.T) {
 		)
 		assert.Equal(tc.want, result)
 	}
+}
+
+func TestMemberFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("LaunchTemplate", crds)
+	require.NotNil(crd)
+
+	specFields := crd.SpecFields
+
+	// LaunchTemplate.Spec.LaunchTemplateData field is itself a struct field
+	// with a number of member fields. We are checking here to ensure that the
+	// LaunchTemplate.Spec.LaunchTemplateData Field definition properly
+	// gathered the member field information.
+	ltdField := specFields["LaunchTemplateData"]
+	require.NotNil(ltdField)
+	require.Equal(ltdField.Path, "LaunchTemplateData")
+	require.NotNil(ltdField.ShapeRef)
+	require.Equal(ltdField.ShapeRef.Shape.Type, "structure")
+
+	assert.NotNil(ltdField.MemberFields)
+
+	// HibernationOptions is a member of the LaunchTemplateData structure and
+	// is itself another structure field. Make sure that the Field definition
+	// for this nested structure member field exists.
+	hoField := ltdField.MemberFields["HibernationOptions"]
+	assert.NotNil(hoField)
+	assert.Equal(hoField.Path, "LaunchTemplateData.HibernationOptions")
+	assert.NotNil(hoField.MemberFields)
+
+	hocField := hoField.MemberFields["Configured"]
+	assert.NotNil(hocField)
+	assert.Equal(hocField.Path, "LaunchTemplateData.HibernationOptions.Configured")
 }


### PR DESCRIPTION
When inferring the structure of a CRD and its fields, we create a
`pkg/model.Field` struct for each *top-level* field in the CRD's Spec or
Status. The `pkg/model.GetCRDs()` function ends up calling
`pkg/model.CRD:AddSpecField()` and `pkg/model.CRD:AddStatusField()` for
those field definitions that the API inference stage of the generation
pipeline discovers in the aws-sdk-go API model.

Because we were creating `pkg/model.Field` objects for only the
top-level fields in Spec and Status and the `pkg/model.Field` object is
what was tied to a `pkg/generate/config.FieldConfig` object, this meant
that only the top-level field definitions were able to be *configured*
via the generator.yaml file. This is a problem for more complex APIs
like EC2 which have resources with top-level fields that are structures
themselves. We were not able to configure nested fields properly because
we were not actually constructing a `pkg/model.Field` object for these
nested fields.

This PR enhances the API inference process inside the code generator to
detect when a new `pkg/model.Field` refers to an
`aws-sdk-go/private/model.Shape` that is of type "structure" and recurse
through that Shape's MemberRefs collection, building a map of
`pkg/model.Field` objects for each member field along with a fieldpath
that allows these nested struct member fields to later be "found" by the
code generator.

Issue: aws-controllers-k8s/community#1100

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
