### PR TITLE
use correct import name of service-controller repo

### DIFF
--- a/templates/pkg/resource/references_read_referenced_resource.go.tpl
+++ b/templates/pkg/resource/references_read_referenced_resource.go.tpl
@@ -12,7 +12,7 @@ Where field is of type 'Field' from aws-controllers-k8s/code-generator/pkg/model
 				Namespace: namespace,
 				Name: *arr.Name,
 			}
-			obj := acksvcv1alpha1.{{ .FieldConfig.References.Resource }}{}
+			obj := svcapitypes.{{ .FieldConfig.References.Resource }}{}
 			err := apiReader.Get(ctx, namespacedName, &obj)
 			if err != nil {
 				return err


### PR DESCRIPTION
Description of changes:
* template separate from `references.go.tpl` was using outdated import name
* Used the correct name now

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
