### PR TITLE
always use single dot fieldpath notation

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1145,16 +1145,14 @@ func setSDKForSlice(
 	//
 	//  f0elem.SetMyField(*f0iter)
 	containerFieldName := ""
-	sourceAttributePath := sourceFieldPath
 	if targetShape.MemberRef.Shape.Type == "structure" {
 		containerFieldName = targetFieldName
-		sourceAttributePath = sourceFieldPath + "."
 	}
 	out += setSDKForContainer(
 		cfg, r,
 		containerFieldName,
 		elemVarName,
-		sourceAttributePath,
+		sourceFieldPath,
 		iterVarName,
 		&targetShape.MemberRef,
 		indentLevel+1,
@@ -1218,7 +1216,7 @@ func setSDKForMap(
 		cfg, r,
 		containerFieldName,
 		valVarName,
-		sourceFieldPath+".",
+		sourceFieldPath,
 		valIterVarName,
 		&targetShape.ValueRef,
 		indentLevel+1,

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -111,24 +111,6 @@ func (f *Field) IsReference() bool {
 	return trimmedGoType == "*ackv1alpha1.AWSResourceReferenceWrapper"
 }
 
-// ParentFieldPath takes a field path and returns the field path of the
-// containing "parent" field. For example, if the field path
-// `Users..Credentials.Login` is passed in, this function returns
-// `Users..Credentials`. If `Users..Password` is supplied, this function
-// returns `Users`, etc.
-func ParentFieldPath(path string) string {
-	parts := strings.Split(path, ".")
-	// Pop the last element of the supplied field path
-	parts = parts[0 : len(parts)-1]
-	// If the parent field's type is a list or map, there will be two dots ".."
-	// in the supplied field path. We don't want the returned field path to end
-	// in a dot, since that would be invalid, so we trim it off here
-	if parts[len(parts)-1] == "" {
-		parts = parts[0 : len(parts)-1]
-	}
-	return strings.Join(parts, ".")
-}
-
 // NewReferenceField returns a pointer to a new Field object.
 // The go-type of field is either slice of '*AWSResourceReferenceWrapper' or
 // '*AWSResourceReferenceWrapper' depending on whether 'shapeRef' parameter

--- a/pkg/model/field_test.go
+++ b/pkg/model/field_test.go
@@ -6,37 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
 )
-
-func TestParentFieldPath(t *testing.T) {
-	assert := assert.New(t)
-	testCases := []struct {
-		subject string
-		want    string
-	}{
-		{
-			"Repository.Name",
-			"Repository",
-		},
-		{
-			"Users..Password",
-			"Users",
-		},
-		{
-			"User.Credentials..Password",
-			"User.Credentials",
-		},
-	}
-
-	for _, tc := range testCases {
-		result := model.ParentFieldPath(
-			tc.subject,
-		)
-		assert.Equal(tc.want, result)
-	}
-}
 
 func TestMemberFields(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/model/model_mq_test.go
+++ b/pkg/model/model_mq_test.go
@@ -35,7 +35,7 @@ func TestMQ_Broker(t *testing.T) {
 	// (which is a `[]*User` type) is findable in the CRD's Fields collection
 	// by the path `Spec.Users..Password` and that the FieldConfig associated
 	// with this Field is marked as a SecretKeyReference.
-	passFieldPath := "Users..Password"
+	passFieldPath := "Users.Password"
 	passField, found := crd.Fields[passFieldPath]
 	require.True(found)
 	require.NotNil(passField.FieldConfig)

--- a/pkg/testdata/models/apis/mq/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/mq/0000-00-00/generator.yaml
@@ -10,5 +10,5 @@ resources:
       sdk_delete_pre_build_request:
         template_path: sdk_delete_pre_build_request.go.tpl
     fields:
-      Users..Password:
+      Users.Password:
         is_secret: true


### PR DESCRIPTION
This patch completes earlier work that was done in the `pkg/fieldpath`
package that only uses a single dot notation to refer to a *field* with
type *list* or *map* within a field path.

We previously were using a double dot in field paths in `generator.yaml`
config files to refer to fields of type list or map. This was erroneous,
since referring to the *field* (not the *value* of the field) only
requires a single dot in order for the fieldpath to "locate" a field
within a path.

In this PR, we simplify and DRY up the inference code in
`pkg/model/model.go`'s processing of "nested fields" so that the field
path added for all Field objects uses this single-dot notation only.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
