### PR TITLE
Non root controller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Base image to use for the final stage
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 # Build the manager binary
+# TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
+# supports golang 1.17
 FROM public.ecr.aws/bitnami/golang:1.17.5 as builder
 
 ARG service_alias
@@ -46,4 +48,6 @@ ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
+# Make this image non-root by default
+USER 1000
 ENTRYPOINT ["/bin/controller"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,8 @@
 # Base image to use at runtime
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 # Build the manager binary
+# TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
+# supports golang 1.17
 FROM public.ecr.aws/bitnami/golang:1.17.5 as builder
 
 ARG service_alias
@@ -58,4 +60,5 @@ ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
+USER 1000
 ENTRYPOINT ["/bin/controller"]

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -57,7 +57,6 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
-          runAsUser: 1000
           capabilities:
             drop:
               - ALL

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
-          runAsUser: 1000
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
Description of changes:

#### Before
* OpenShift enforces `nonRoot` security posture by running container images using random UID and does not allow specifying `runAsUser` field in deployment spec.
* Before this change, ACK generated artifacts enforced `nonRoot` security posture using `SecurityContext`'s `runAsUser` and `runAsNonRoot` field, while the container image ran as `root` by default

-----

#### Now

* With this change, ACK controller images now run by default with `non-root` User(1000)
* Removed `runAsUser` field from deployment templates. This change keeps the existing functionality because K8s pod inherit UserId from Image metadata and ACK controller still runs with non-root user(1000) [Tested and Validated]
* Removing `runAsUser` unblock OpenShift installation and allows OpenShift to run container using random UserId
* Keeping `runAsNonRoot` field, keeps the validation in place that ACK controller does not run as `root`. This validation helps security posture for both OpenShift and helm/kustomize installation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
