### PR TITLE
use cleaned name for pluralized resources in cfg

### DIFF
--- a/pkg/model/op_test.go
+++ b/pkg/model/op_test.go
@@ -144,7 +144,7 @@ func TestGetOpTypeAndResourceNameFromOpID_PluralSingular(t *testing.T) {
 		},
 		{
 			"DescribeDhcpOptions",
-			model.OpTypeList,
+			model.OpTypeGet,
 			"DhcpOptions",
 		},
 		{

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -68,7 +68,7 @@ operations:
     output_wrapper_field_path: VpcEndpoint
 
 resources:
-  DhcpOptions:
+  DHCPOptions:
 
   SecurityGroup:
     renames:


### PR DESCRIPTION
Cleans up the `pkg/model:GetOpTypeAndResourceNameFromOpID()` function so
that resources with pluralized singular names can be referred to with
the "cleaned" Camel-cased name in the generator.yaml file. In addition,
corrects an error in said function where the operation returning a
singular pluralized resource -- e.g. DescribeDhcpOptions -- was
incorrectly being returned as OpTypeList instead of OpTypeGet.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
