### PR TITLE
unpack struct element/value fields of list/map

### DIFF
--- a/pkg/model/field_test.go
+++ b/pkg/model/field_test.go
@@ -33,7 +33,7 @@ func TestMemberFields(t *testing.T) {
 	require.NotNil(ltdField.ShapeRef)
 	require.Equal(ltdField.ShapeRef.Shape.Type, "structure")
 
-	assert.NotNil(ltdField.MemberFields)
+	require.NotNil(ltdField.MemberFields)
 
 	// HibernationOptions is a member of the LaunchTemplateData structure and
 	// is itself another structure field. Make sure that the Field definition
@@ -44,6 +44,63 @@ func TestMemberFields(t *testing.T) {
 	assert.NotNil(hoField.MemberFields)
 
 	hocField := hoField.MemberFields["Configured"]
-	assert.NotNil(hocField)
+	require.NotNil(hocField)
 	assert.Equal(hocField.Path, "LaunchTemplateData.HibernationOptions.Configured")
+}
+
+func TestMemberFields_Containers_ListOfStruct(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("DHCPOptions", crds)
+	require.NotNil(crd)
+
+	// The DHCPOptions resource has a DHCPConfigurations field that is of type
+	// []*NewDHCPConfiguration. Here, we test to make sure that the inference
+	// process deduced the DHCPOptions.DHCPConfigurations Field object's Values
+	// Field properly.
+	dhcpConfsField := crd.Fields["DHCPConfigurations"]
+	require.NotNil(dhcpConfsField)
+
+	require.NotNil(dhcpConfsField.MemberFields)
+	valuesField := dhcpConfsField.MemberFields["Values"]
+	require.NotNil(valuesField)
+	require.NotNil(valuesField.ShapeRef)
+	require.NotNil(valuesField.ShapeRef.Shape)
+	assert.Equal(valuesField.ShapeRef.Shape.Type, "list")
+	assert.Equal(valuesField.Path, "DHCPConfigurations.Values")
+}
+
+func TestMemberFields_Containers_MapOfStruct(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "sagemaker")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("TrialComponent", crds)
+	require.NotNil(crd)
+
+	// The TrialComponent resource has an InputArtifacts field that is of type
+	// map[string]*TrialComponentArtifact. TrialComponentArtifact is a struct
+	// with two member fields, Value and MediaType. Here, we test to make sure
+	// that the inference process deduced the TrialComponent.InputArtifacts
+	// Field object's Value Field properly.
+	inArtifactsField := crd.Fields["InputArtifacts"]
+	require.NotNil(inArtifactsField)
+
+	require.NotNil(inArtifactsField.MemberFields)
+	valueField := inArtifactsField.MemberFields["Value"]
+	require.NotNil(valueField)
+	require.NotNil(valueField.ShapeRef)
+	require.NotNil(valueField.ShapeRef.Shape)
+	assert.Equal(valueField.ShapeRef.Shape.Type, "string")
+	assert.Equal(valueField.Path, "InputArtifacts.Value")
 }

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -15,6 +15,7 @@ package model_test
 
 import (
 	"sort"
+	"strings"
 
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
@@ -30,7 +31,7 @@ func attrCamelNames(fields map[string]*ackmodel.Field) []string {
 
 func getCRDByName(name string, crds []*ackmodel.CRD) *ackmodel.CRD {
 	for _, c := range crds {
-		if c.Names.Original == name {
+		if strings.EqualFold(c.Names.Original, name) {
 			return c
 		}
 	}
@@ -39,7 +40,7 @@ func getCRDByName(name string, crds []*ackmodel.CRD) *ackmodel.CRD {
 
 func getTypeDefByName(name string, tdefs []*ackmodel.TypeDef) *ackmodel.TypeDef {
 	for _, td := range tdefs {
-		if td.Names.Original == name {
+		if strings.EqualFold(td.Names.Original, name) {
 			return td
 		}
 	}

--- a/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/sagemaker/0000-00-00/generator.yaml
@@ -65,7 +65,7 @@ ignore:
       - Project
       # TrainingJob
       - TransformJob
-      - TrialComponent
+      #- TrialComponent
       - Trial
       - UserProfile
       - Workforce


### PR DESCRIPTION
A previous commit added functionality to the API/resource inference
process to "unpack" a struct field's member fields into the
`pkg/model.Field.MemberFields` map. However, I had failed to account for
lists or maps of structs. This patch accounts for the list or map of
structs fields, stepping into the list field's element struct type and
adding a Field definition to the containing Field's `MemberFields` map
for each member field in the element struct type. Same for containing
shapes of type "map".

With this patch, we're now able to "access" via field path any nested
field (including its corresponding `FieldConfig` object) which means
that in following patches we can finally resolve the "different Go types
for nested fields" problem we've had in the code generator.

Related issue: aws-controllers-k8s/community#1065

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
