### PR TITLE
Make CRD version configurable

### DIFF
--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -50,7 +50,10 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 	}
 	svcAlias := strings.ToLower(args[0])
 	if optGeneratorConfigPath == "" {
-		optGeneratorConfigPath = filepath.Join(optOutputPath, "apis", svcAlias, optGenVersion, "generator-config.yaml")
+		// default generator configuration file path is now: apis/<service>/<generator-config.yaml>
+		// as this configuration is per API group (per service), and
+		// resources can exist in multiple versions.
+		optGeneratorConfigPath = filepath.Join(optOutputPath, "apis", svcAlias, "generator-config.yaml")
 	}
 	m, err := loadModel(svcAlias, optGenVersion, "aws.crossplane.io", cpgenerate.DefaultConfig)
 	if err != nil {

--- a/pkg/generate/config/resource.go
+++ b/pkg/generate/config/resource.go
@@ -75,10 +75,12 @@ type ResourceConfig struct {
 	// All ShortNames must be distinct from any other ShortNames installed into the cluster,
 	// otherwise the CRD will fail to install.
 	ShortNames []string `json:"shortNames,omitempty"`
-	// APIVersion represents the API version of the generated CRD.
+	// APIVersions represents the API versions defined for the generated CRD.
 	// Default version to be used is the one specified via the "--version"
-	// command-line argument.
-	APIVersion *string `json:"api_version,omitempty"`
+	// command-line argument, if none is specified here.
+	// For the Crossplane pipeline, the generation target is the version
+	// marked as the storage version.
+	APIVersions []APIVersion `json:"api_versions,omitempty"`
 	// IsAdoptable determines whether the CRD should be accepted by the adoption reconciler.
 	// If set to false, the user will be given an error if they attempt to adopt a resource
 	// with this type.

--- a/pkg/generate/config/version.go
+++ b/pkg/generate/config/version.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+// APIVersion represents an API version of the generated CRD.
+type APIVersion struct {
+	// Name of the API version, e.g. v1beta1
+	Name string `json:"name"`
+	// Served whether this version is enabled or not
+	Served *bool `json:"served,omitempty"`
+	// Storage whether this version is the storage version.
+	// One and only one version can be set as the storage version.
+	Storage *bool `json:"storage,omitempty"`
+}

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -135,9 +135,13 @@ func Crossplane(
 	)
 
 	metaVars := m.MetaVars()
-	detectedCRDVersions := make(map[string]struct{})
+	detectedCRDVersions := make(map[string]bool)
 	for _, crd := range crds {
-		detectedCRDVersions[crd.GetAPIVersion(metaVars.APIVersion)] = struct{}{}
+		v, err := crd.GetStorageVersion(metaVars.APIVersion)
+		if err != nil {
+			return nil, err
+		}
+		detectedCRDVersions[v] = true
 	}
 
 	// First add all the CRDs and API types
@@ -161,14 +165,19 @@ func Crossplane(
 		}
 	}
 	for _, crd := range crds {
+		v, err := crd.GetStorageVersion(metaVars.APIVersion)
+		if err != nil {
+			return nil, err
+		}
 		crdFileName := filepath.Join(
-			"apis", metaVars.ServicePackageName, crd.GetAPIVersion(metaVars.APIVersion),
+			"apis", metaVars.ServicePackageName, v,
 			"zz_"+strcase.ToSnake(crd.Kind)+".go",
 		)
 		crdVars := &templateCRDVars{
 			metaVars,
 			crd,
 		}
+		crdVars.APIVersion = v
 		if err = ts.Add(crdFileName, crdTemplatePath, crdVars); err != nil {
 			return nil, err
 		}
@@ -184,7 +193,9 @@ func Crossplane(
 			metaVars,
 			crd,
 		}
-		crdVars.APIVersion = crd.GetAPIVersion(metaVars.APIVersion)
+		if crdVars.APIVersion, err = crd.GetStorageVersion(metaVars.APIVersion); err != nil {
+			return nil, err
+		}
 		if err = ts.Add(outPath, controllerTmplPath, crdVars); err != nil {
 			return nil, err
 		}
@@ -196,7 +207,9 @@ func Crossplane(
 			metaVars,
 			crd,
 		}
-		crdVars.APIVersion = crd.GetAPIVersion(metaVars.APIVersion)
+		if crdVars.APIVersion, err = crd.GetStorageVersion(metaVars.APIVersion); err != nil {
+			return nil, err
+		}
 		if err = ts.Add(outPath, conversionsTmplPath, crdVars); err != nil {
 			return nil, err
 		}

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -96,14 +96,21 @@ func (r *CRD) Config() *ackgenconfig.Config {
 	return r.cfg
 }
 
-// GetAPIVersion returns the configured API version for the CRD, or
+// GetStorageVersion returns the configured storage API version for the CRD, or
 // the specified default version.
-func (r *CRD) GetAPIVersion(defaultVersion string) string {
+func (r *CRD) GetStorageVersion(defaultVersion string) (string, error) {
 	// if not configured
-	if r.cfg == nil || r.cfg.Resources[r.Names.Original].APIVersion == nil {
-		return defaultVersion
+	if r.cfg == nil || len(r.cfg.Resources[r.Names.Original].APIVersions) == 0 {
+		return defaultVersion, nil
 	}
-	return *r.cfg.Resources[r.Names.Original].APIVersion
+
+	for _, v := range r.cfg.Resources[r.Names.Original].APIVersions {
+		if v.Storage != nil && *v.Storage {
+			return v.Name, nil
+		}
+	}
+	return "", fmt.Errorf("exactly one configured version must be marked as the storage version for the %q CRD",
+		r.Names.Original)
 }
 
 // SDKAPIPackageName returns the aws-sdk-go package name used for this


### PR DESCRIPTION
- Fixes #1089
- Adds config.ResourceConfig.APIVersion to be able to
  override the generated version for a CRD

Issue #, if available: [#1089](https://github.com/aws-controllers-k8s/community/issues/1089)

Description of changes:
This PR proposes a new configuration field named `APIVersion` (JSON-serialized name `api_version`) in `config.ResourceConfig` that allows overriding versions of specific CRDs generated by the Crossplane codegen pipeline. If a specific version string is not configured for a CRD-type, the default version specified with the `--version` command-line argument is used for backwards-compatibility. An [example configuration](https://github.com/crossplane/provider-aws/blob/master/apis/cloudfront/v1alpha1/generator-config.yaml) overriding the version for the CloudFront Distribution resource is as follows:
```
resources:
  "Distribution":
    api_versions:
    - name: "v1beta1"
      storage: true
ignore:
  resource_names:
    - FieldLevelEncryptionProfile
    - Invalidation
    - KeyGroup
    - OriginRequestPolicy
    - PublicKey
    - StreamingDistribution
    - RealtimeLogConfig
    - MonitoringSubscription
    - FieldLevelEncryptionConfig
  field_paths:
    - DistributionConfig.CallerReference
    - Origins.Quantity
    - OriginAccessIdentityConfig.CallerReference
```


**This PR now introduces a backward-incompatible behavior change in the Crossplane pipeline:**
Because the generator configuration is per API group (service) and because we may now have resources belonging to different API versions in a single group, this PR changes the default path of the `generator-config.yaml` file from:
`apis/<API group>/<API version>/generator-config.yaml`
to
`apis/<API group>/generator-config.yaml`


An example invocation `ack-generate crossplane cloudfront --output <output path> --generator-config-path generator-config.yaml` using the above configuration yields the following file structure:
```console
❯ tree
.
├── apis
│   └── cloudfront
│       ├── v1alpha1
│       │   ├── zz_cache_policy.go
│       │   ├── zz_cloud_front_origin_access_identity.go                                                                                [0/941]
│       │   ├── zz_doc.go
│       │   ├── zz_enums.go
│       │   ├── zz_function.go
│       │   ├── zz_groupversion_info.go
│       │   ├── zz_response_headers_policy.go
│       │   └── zz_types.go
│       └── v1beta1
│           ├── zz_distribution.go
│           ├── zz_doc.go
│           ├── zz_enums.go
│           ├── zz_groupversion_info.go
│           └── zz_types.go
├── generator-config.yaml
├── go.mod
├── go.sum
└── pkg
    └── controller
        └── cloudfront
            ├── cachepolicy
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── cloudfrontoriginaccessidentity
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── distribution
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── function
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            └── responseheaderspolicy
                ├── zz_controller.go
                └── zz_conversions.go

12 directories, 26 files
```

Without the `resources` configuration block, all resources are under `v1alpha1` version as expected:
```console
❯ tree .
.
├── apis                                                                                                                               [0/1036]
│   └── cloudfront
│       └── v1alpha1
│           ├── zz_cache_policy.go
│           ├── zz_cloud_front_origin_access_identity.go
│           ├── zz_distribution.go
│           ├── zz_doc.go
│           ├── zz_enums.go
│           ├── zz_function.go
│           ├── zz_groupversion_info.go
│           ├── zz_response_headers_policy.go
│           └── zz_types.go
├── generator-config.yaml
├── go.mod
├── go.sum
└── pkg
    └── controller
        └── cloudfront
            ├── cachepolicy
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── cloudfrontoriginaccessidentity
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── distribution
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            ├── function
            │   ├── zz_controller.go
            │   └── zz_conversions.go
            └── responseheaderspolicy
                ├── zz_controller.go
                └── zz_conversions.go

11 directories, 22 files
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
