### PR TITLE
Fix type of tolerations in helm chart

### DIFF
--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -51,7 +51,7 @@
           "type": "object"
         },
         "tolerations": {
-          "type": "object"
+          "type": "array"
         },
         "affinity": {
           "type": "object"

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -21,7 +21,7 @@ deployment:
     kubernetes.io/os: linux
   # Which tolerations to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: {}
+  tolerations: []
   # What affinity to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
At the moment, the helm chart treats the deployment's tolerations as an object (similarly to nodeSelector). In the Deployment manifest however tolerations are an array (in contrast to nodeSelector). This PR makes the deployment's tolerations of type array instead of object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
