### PR TITLE
support custom fields of list/scalar/map types

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -352,5 +352,22 @@ type FieldConfig struct {
 	LateInitialize *LateInitializeConfig `json:"late_initialize,omitempty"`
 	// References instructs the code generator how to refer this field from
 	// other custom resource
-	References     *ReferencesConfig     `json:"references,omitempty"`
+	References *ReferencesConfig `json:"references,omitempty"`
+	// Type *overrides* the inferred Go type of the field. This is required for
+	// custom fields that are not inferred either as a Create Input/Output
+	// shape or via the SourceFieldConfig attribute.
+	//
+	// As an example, assume you have a Role resource where you want to add a
+	// custom spec field called Policies that is a slice of string pointers.
+	// The generator.yaml file might look like this:
+	//
+	// resources:
+	//   Role:
+	//     fields:
+	//       Policies:
+	//         type: []*string
+	//
+	// TODO(jaypipes,crtbry): Figure out if we can roll the CustomShape stuff
+	// into this type override...
+	Type *string `json:"type,omitempty"`
 }

--- a/pkg/model/field_test.go
+++ b/pkg/model/field_test.go
@@ -104,3 +104,41 @@ func TestMemberFields_Containers_MapOfStruct(t *testing.T) {
 	assert.Equal(valueField.ShapeRef.Shape.Type, "string")
 	assert.Equal(valueField.Path, "InputArtifacts.Value")
 }
+
+func TestCustomFieldType(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "iam")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("Role", crds)
+	require.NotNil(crd)
+
+	// The Role resource has a custom field called Policies that is of type
+	// []*string. This field is custom because it is not inferred via either
+	// the Create Input/Output shape or the SourceFieldConfig attribute in the
+	// generator.yaml file but rather via a `type` attribute of the
+	// FieldConfig, which overrides the Go type of the custom field.
+	policiesField := crd.Fields["Policies"]
+	require.NotNil(policiesField)
+
+	assert.Equal("[]*string", policiesField.GoType)
+	require.NotNil(policiesField.ShapeRef)
+
+	// A map and a scalar custom field are also added in the testdata
+	// generator.yaml file.
+	logConfigField := crd.Fields["LoggingConfig"]
+	require.NotNil(logConfigField)
+
+	assert.Equal("map[string]*bool", logConfigField.GoType)
+	require.NotNil(logConfigField.ShapeRef)
+
+	myIntField := crd.Fields["MyCustomInteger"]
+	require.NotNil(myIntField)
+
+	assert.Equal("*int64", myIntField.GoType)
+	require.NotNil(myIntField.ShapeRef)
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -183,6 +183,13 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 					)
 					panic(msg)
 				}
+			} else if fieldConfig.Type != nil {
+				// We have a custom field that has a type override and has not
+				// been inferred via the normal Create Input shape or via the
+				// SourceFieldConfig. Manually construct the field and its
+				// shape reference here.
+				typeOverride := *fieldConfig.Type
+				memberShapeRef = m.SDKAPI.GetShapeRefFromType(typeOverride)
 			} else {
 				// Spec field is not well defined
 				continue

--- a/pkg/testdata/models/apis/iam/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/iam/0000-00-00/generator.yaml
@@ -35,3 +35,11 @@ resources:
         set:
           # The input and output shapes are different...
           - from: PermissionsBoundary.PermissionsBoundaryArn
+      # Test the custom field creation inference for simple scalar, list or map
+      # fields
+      Policies:
+        type: "[]*string"
+      LoggingConfig:
+        type: "map[string]*bool"
+      MyCustomInteger:
+        type: "*int64"


### PR DESCRIPTION
Adds functionality for the generator.yaml file to contain a
`FieldConfig.Type` attribute that is the Go type override string for a
field. If the Go type of the field cannot be inferred via the Create
Input/Output shape *or* via the `FieldConfig.From` (SourceFieldConfig)
value, we can look at this new `FieldConfig.Type` value and construct a
`aws-sdk-go/private/model/api:ShapeRef` object manually.

Thus, with this patch, we can do something like this (example from the
iam-controller's generator.yaml file, which is what I tested this patch
on):

```yaml
resources:
  Role:
    fields:
      Policies:
        type: "[]*string"
```

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
