### PR TITLE
Return `OpTypeList` for singular plurals

### DIFF
--- a/pkg/model/op.go
+++ b/pkg/model/op.go
@@ -111,7 +111,7 @@ func GetOpTypeAndResourceNameFromOpID(
 		resName := strings.TrimPrefix(opID, "Describe")
 		if pluralize.IsPlural(resName) {
 			if resourceExistsInConfig(resName, cfg) {
-				return OpTypeGet, resName
+				return OpTypeList, resName
 			}
 			return OpTypeList, pluralize.Singular(resName)
 		}

--- a/pkg/model/op_test.go
+++ b/pkg/model/op_test.go
@@ -144,7 +144,7 @@ func TestGetOpTypeAndResourceNameFromOpID_PluralSingular(t *testing.T) {
 		},
 		{
 			"DescribeDhcpOptions",
-			model.OpTypeGet,
+			model.OpTypeList,
 			"DhcpOptions",
 		},
 		{


### PR DESCRIPTION
Issue #, if available: N/A, [heuristic](https://github.com/aws-controllers-k8s/code-generator/blob/89b0a106fea6268609fd666270518145099646f7/pkg/model/op.go#L110-L118) is returning `ReadOne` operation for `DescribeDhcpOptions` when it is a `ReadMany` call

Description of changes:
* returns `OpTypeList` instead of `OpTypeGet` for "singular plural" in `"Describe"` processing
* removes duplicate code
* updates comments on singular-plural description to be clearer and present in all affected areas

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
