### PR TITLE
Update ACK runtime to `v0.16.2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.16.1"
+VERSION ?= "v0.16.2"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.16.1
+	github.com/aws-controllers-k8s/runtime v0.16.2
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.16.1 h1:up+vn3J8mqjaHgleOSCU7wGqj7t8RCvF+V4EhdMEtSY=
-github.com/aws-controllers-k8s/runtime v0.16.1/go.mod h1:DHwPczqO/nK4L1kqWlmng5GuIQuX5MSSWbTQMuL4LnM=
+github.com/aws-controllers-k8s/runtime v0.16.2 h1:JWitWBy3OoWCvBLKsBAoaUkKkPyfOHaQItgRlCO41IM=
+github.com/aws-controllers-k8s/runtime v0.16.2/go.mod h1:DHwPczqO/nK4L1kqWlmng5GuIQuX5MSSWbTQMuL4LnM=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1133

Description of changes:
* ACK runtime update v0.16.1 => v0.16.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
