### PR TITLE
Add Helm NOTES.txt

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -28,6 +28,7 @@ var (
 		"helm/Chart.yaml.tpl",
 		"helm/values.yaml.tpl",
 		"helm/values.schema.json",
+		"helm/templates/NOTES.txt.tpl",
 		"helm/templates/role-reader.yaml.tpl",
 		"helm/templates/role-writer.yaml.tpl",
 		"helm/templates/_controller-role-kind-patch.yaml.tpl",

--- a/templates/helm/templates/NOTES.txt.tpl
+++ b/templates/helm/templates/NOTES.txt.tpl
@@ -1,4 +1,7 @@
-{{ "{{ .Chart.Name }}" }} has been installed. Check its status by running:
+{{ "{{ .Chart.Name }}" }} has been installed.
+This chart deploys "{{ .ImageRepository }}:{{ .ReleaseVersion }}".
+
+Check its status by running:
   kubectl --namespace {{ "{{ .Release.Namespace }}" }} get pods -l "app.kubernetes.io/instance={{ "{{ .Release.Name }}" }}"
 
 You are now able to create {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})

--- a/templates/helm/templates/NOTES.txt.tpl
+++ b/templates/helm/templates/NOTES.txt.tpl
@@ -4,8 +4,7 @@ This chart deploys "{{ .ImageRepository }}:{{ .ReleaseVersion }}".
 Check its status by running:
   kubectl --namespace {{ "{{ .Release.Namespace }}" }} get pods -l "app.kubernetes.io/instance={{ "{{ .Release.Name }}" }}"
 
-You are now able to create {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
-resources in your cluster!
+You are now able to create {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }}) resources!
 
 The controller is running in "{{ "{{ .Values.installScope }}" }}" mode.
 The controller is configured to run in the region: "{{ "{{ .Values.aws.region }}" }}"

--- a/templates/helm/templates/NOTES.txt.tpl
+++ b/templates/helm/templates/NOTES.txt.tpl
@@ -1,0 +1,14 @@
+{{ "{{ .Chart.Name }}" }} has been installed. Check its status by running:
+  kubectl --namespace {{ "{{ .Release.Namespace }}" }} get pods -l "app.kubernetes.io/instance={{ "{{ .Release.Name }}" }}"
+
+You are now able to create {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
+resources in your cluster!
+
+The controller is running in "{{ "{{ .Values.installScope }}" }}" mode.
+The controller is configured to run in the region: "{{ "{{ .Values.aws.region }}" }}"
+
+Visit https://aws-controllers-k8s.github.io/community/reference/ for an API 
+reference of all the resources that can be created using this controller.
+
+For more information on the AWS Controller for Kubernetes (ACK) project, visit:
+https://aws-controllers-k8s.github.io/community/


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1135

Description of changes:
Adds a cute, descriptive NOTES.txt file for our Helm chart - shown to users when they install the chart.

Example after running `helm install --generate-name s3-chart`:
```
s3-chart has been installed.
This chart deploys "public.ecr.aws/aws-controllers-k8s/s3-controller:v0.0.10".

Check its status by running:
  kubectl --namespace default get pods -l "app.kubernetes.io/instance=chart-1642804573"

You are now able to create Amazon Simple Storage Service (S3)
resources in your cluster!

The controller is running in "cluster" mode.
The controller is configured to run in the region: "us-west-2"

Visit https://aws-controllers-k8s.github.io/community/reference/ for an API
reference of all the resources that can be created using this controller.

For more information on the AWS Controller for Kubernetes (ACK) project, visit:
https://aws-controllers-k8s.github.io/community/
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
