### PR TITLE
added buildmode=pie flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
     go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
     -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
     -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -buildmode=pie \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 
 FROM $base_image

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -52,6 +52,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
     go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
     -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
     -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -buildmode=pie \
     -modfile="${work_dir}/go.local.mod" \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 


### PR DESCRIPTION
Issue #, if available:
Closes https://github.com/aws-controllers-k8s/community/issues/1134

Description of changes:
Thanks in advance for your review. This adds the `-buildmode=pie` flag to get ASLR, improving the security posture of the binary.

Since it may increase memory usage, I wasn't sure if we should also increase the default memory requests/limits in the helm chart, so let me know if you think this should be included?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
