### PR TITLE
Support other auth mechanisms

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
+        {{- if .Values.deployment.secretEnvVars }}
+        envFrom:
+        - secretRef:
+            name: {{ include "app.fullname" . }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -73,10 +73,10 @@ spec:
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
-        {{- if .Values.deployment.secretEnvVars }}
+        {{- if .Values.deployment.env.fromSecret.vars }}
         envFrom:
         - secretRef:
-            name: {{ default (include "app.fullname" .) .Values.deployment.secretName }}
+            name: {{ default (include "app.fullname" .) .Values.deployment.env.fromSecret.name }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         {{- if .Values.deployment.secretEnvVars }}
         envFrom:
         - secretRef:
-            name: {{ include "app.fullname" . }}
+            name: {{ default (include "app.fullname" .) .Values.deployment.secretName }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/helm/templates/secret.yaml
+++ b/templates/helm/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.deployment.secretEnvVars -}}
+{{- if .Values.deployment.env.fromSecret.vars -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ default (include "app.fullname" .) .Values.deployment.secretName }}
+  name: {{ default (include "app.fullname" .) .Values.deployment.env.fromSecret.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "chart.name-version" . }}
     control-plane: controller
 data:
-{{- range $key, $value := .Values.deployment.secretEnvVars }}
+{{- range $key, $value :=.Values.deployment.env.fromSecret.vars }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/templates/helm/templates/secret.yaml
+++ b/templates/helm/templates/secret.yaml
@@ -14,6 +14,6 @@ metadata:
     control-plane: controller
 data:
 {{- range $key, $value := .Values.deployment.secretEnvVars }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/templates/helm/templates/secret.yaml
+++ b/templates/helm/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.deployment.secretEnvVars -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    k8s-app: {{ include "app.name" . }}
+    helm.sh/chart: {{ include "chart.name-version" . }}
+    control-plane: controller
+data:
+{{- range $key, $value := .Values.deployment.secretEnvVars }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end -}}

--- a/templates/helm/templates/secret.yaml
+++ b/templates/helm/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ default (include "app.fullname" .) .Values.deployment.secretName }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -60,13 +60,13 @@
           "type": "string"
         },
         "secretEnvVars": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
           }
+        },
+        "secretName": {
+          "type": "string"
         }
       },
       "required": [

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -58,6 +58,15 @@
         },
         "priorityClassName": {
           "type": "string"
+        },
+        "secretEnvVars": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": [

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -59,14 +59,25 @@
         "priorityClassName": {
           "type": "string"
         },
-        "secretEnvVars": {
+        "env": {
+          "description": "Environment variable related settings",
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "properties": {
+            "fromSecret": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "vars": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
-        },
-        "secretName": {
-          "type": "string"
         }
       },
       "required": [

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -29,14 +29,17 @@ deployment:
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
 
-  # Map of key/value pairs to be put in secret to act as a source for environment variables for the controller.
-  # Can be used to authenticate without IRSA (although IRSA is recommended)
-  # eg. AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-  # eg. AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
-  secretEnvVars: {}
-
-  # Name of the secret to store your envvars, defaults to app fullname
-  secretName: ""
+  # env contains configuration for environment variables in the Deployment
+  env:
+    # fromSecret contains configuration for environment variables in the Deployment
+    # read from a Secret that is automatically created by Helm
+    fromSecret:
+      # name is the name of the Secret that is created that contains environment
+      # variables inserted into the Deployment (defaults to the application full name)
+      name: ""
+      # vars contains a map of key/value pairs representing the environment variables
+      # that will be inserted into the Secret and read into the Deployment
+      vars: {}
   
 metrics:
   service:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -28,6 +28,12 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+  # List of key/value pairs to be put in secret to act as a source for environment variables for the controller.
+  # Can be used to authenticate without IRSA
+  # eg. - AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
+  # eg. - AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  secretEnvVars: []
   
 metrics:
   service:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -29,11 +29,14 @@ deployment:
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
 
-  # List of key/value pairs to be put in secret to act as a source for environment variables for the controller.
-  # Can be used to authenticate without IRSA
-  # eg. - AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-  # eg. - AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
-  secretEnvVars: []
+  # Map of key/value pairs to be put in secret to act as a source for environment variables for the controller.
+  # Can be used to authenticate without IRSA (although IRSA is recommended)
+  # eg. AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
+  # eg. AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  secretEnvVars: {}
+
+  # Name of the secret to store your envvars, defaults to app fullname
+  secretName: ""
   
 metrics:
   service:


### PR DESCRIPTION
Issue #, if available:
Relates https://github.com/aws-controllers-k8s/community/issues/1041

Description of changes:
This allows users of the helm chart to pass in a list of ENVVARs to the controller. These can include auth via AWS envvars.
Since the nature of these may be sensitive they are stored in a Secret rather than directly into the container spec.
Envar precedence will still be the ones set directly in the container spec, so there is no chance of these overwriting a setting elsewhere.
Assuming this is an acceptable way of doing this, I can raise a follow-up updating the docs with some other auth methods other than IRSA (inc AWS envvars and Kiam)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
