### PR TITLE
Add release image to Kustomization

### DIFF
--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -58,6 +58,9 @@ func init() {
 	olmCmd.PersistentFlags().BoolVar(
 		&optDisableCommonKeywords, "no-common-keywords", false, "does not include common keywords in the rendered cluster service version",
 	)
+	olmCmd.PersistentFlags().StringVar(
+		&optImageRepository, "image-repository", "", "the Docker image repository that stores the ACK service controller. Default: 'public.ecr.aws/aws-controllers-k8s/$service-controller'",
+	)
 
 	rootCmd.AddCommand(olmCmd)
 }
@@ -74,6 +77,9 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	svcAlias := strings.ToLower(args[0])
 	if optOutputPath == "" {
 		optOutputPath = filepath.Join(optServicesDir, svcAlias)
+	}
+	if optImageRepository == "" {
+		optImageRepository = fmt.Sprintf("public.ecr.aws/aws-controllers-k8s/%s-controller", svcAlias)
 	}
 
 	version := args[1]
@@ -119,7 +125,7 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	}
 
 	// generate templates
-	ts, err := olmgenerate.BundleAssets(m, commonMeta, svcConf, version, optTemplateDirs)
+	ts, err := olmgenerate.BundleAssets(m, commonMeta, svcConf, version, optImageRepository, optTemplateDirs)
 	if err != nil {
 		return err
 	}

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -30,7 +30,6 @@ var (
 	controllerConfigTemplatePaths = []string{
 		"config/controller/deployment.yaml.tpl",
 		"config/controller/service.yaml.tpl",
-		"config/controller/kustomization.yaml.tpl",
 		"config/default/kustomization.yaml.tpl",
 		"config/rbac/cluster-role-binding.yaml.tpl",
 		"config/rbac/role-reader.yaml.tpl",
@@ -41,7 +40,6 @@ var (
 		"config/overlays/namespaced/kustomization.yaml.tpl",
 	}
 	controllerIncludePaths = []string{
-		"config/controller/kustomization_def.yaml.tpl",
 		"boilerplate.go.tpl",
 		"pkg/resource/references_read_referenced_resource.go.tpl",
 		"pkg/resource/sdk_find_read_one.go.tpl",

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	releaseTemplatePaths = []string{
+		"config/controller/kustomization.yaml.tpl",
 		"helm/templates/cluster-role-binding.yaml.tpl",
 		"helm/Chart.yaml.tpl",
 		"helm/values.yaml.tpl",
@@ -33,8 +34,10 @@ var (
 		"helm/templates/role-writer.yaml.tpl",
 		"helm/templates/_controller-role-kind-patch.yaml.tpl",
 	}
-	releaseIncludePaths = []string{}
-	releaseCopyPaths    = []string{
+	releaseIncludePaths = []string{
+		"config/controller/kustomization_def.yaml.tpl",
+	}
+	releaseCopyPaths = []string{
 		"helm/templates/_helpers.tpl",
 		"helm/templates/deployment.yaml",
 		"helm/templates/metrics-service.yaml",

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -76,9 +76,11 @@ func Release(
 	metaVars := m.MetaVars()
 	releaseVars := &templateReleaseVars{
 		metaVars,
+		ImageReleaseVars{
+			ReleaseVersion:  releaseVersion,
+			ImageRepository: imageRepository,
+		},
 		metadata,
-		releaseVersion,
-		imageRepository,
 		serviceAccountName,
 	}
 	for _, path := range releaseTemplatePaths {
@@ -91,17 +93,21 @@ func Release(
 	return ts, nil
 }
 
-// templateReleaseVars contains template variables for the template that
-// outputs Go code for a release artifact
-type templateReleaseVars struct {
-	templateset.MetaVars
-	Metadata *ackmetadata.ServiceMetadata
+type ImageReleaseVars struct {
 	// ReleaseVersion is the semver release tag (or Git SHA1 commit) that is
 	// used for the binary image artifacts and Helm release version
 	ReleaseVersion string
 	// ImageRepository is the Docker image repository to inject into the Helm
 	// values template
 	ImageRepository string
+}
+
+// templateReleaseVars contains template variables for the template that
+// outputs Go code for a release artifact
+type templateReleaseVars struct {
+	templateset.MetaVars
+	ImageReleaseVars
+	Metadata *ackmetadata.ServiceMetadata
 	// ServiceAccountName is the name of the ServiceAccount used in the Helm chart
 	ServiceAccountName string
 }

--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -6,6 +6,7 @@ import (
 	ttpl "text/template"
 	"time"
 
+	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 	opsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -41,7 +42,8 @@ func BundleAssets(
 	m *ackmodel.Model,
 	commonMeta CommonMetadata,
 	serviceConfig ServiceConfig,
-	vers string,
+	releaseVersion string,
+	imageRepository string,
 	templateBasePaths []string,
 ) (*templateset.TemplateSet, error) {
 
@@ -57,8 +59,13 @@ func BundleAssets(
 		return nil, err
 	}
 
+	olmVersion := strings.TrimLeft(releaseVersion, "v")
 	olmVars := templateOLMVars{
-		vers,
+		ackgenerate.ImageReleaseVars{
+			ReleaseVersion:  releaseVersion,
+			ImageRepository: imageRepository,
+		},
+		olmVersion,
 		time.Now().Format("2006-01-02 15:04:05"),
 		m.MetaVars(),
 		commonMeta,
@@ -88,6 +95,7 @@ func BundleAssets(
 }
 
 type templateOLMVars struct {
+	ackgenerate.ImageReleaseVars
 	Version   string
 	CreatedAt string
 	templateset.MetaVars

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -243,14 +243,13 @@ if [[ $ACK_GENERATE_OLM == "true" ]]; then
     DEFAULT_ACK_GENERATE_OLMCONFIG_PATH="$SERVICE_CONTROLLER_SOURCE_PATH/olm/olmconfig.yaml"
     ACK_GENERATE_OLMCONFIG_PATH=${ACK_GENERATE_OLMCONFIG_PATH:-$DEFAULT_ACK_GENERATE_OLMCONFIG_PATH}
 
-    olm_version=$(echo $RELEASE_VERSION | tr -d "v")
-    ag_olm_args="$SERVICE $olm_version -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --olm-config $ACK_GENERATE_OLMCONFIG_PATH --aws-sdk-go-version $AWS_SDK_GO_VERSION"
+    ag_olm_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --olm-config $ACK_GENERATE_OLMCONFIG_PATH --aws-sdk-go-version $AWS_SDK_GO_VERSION"
 
     if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
         ag_olm_args="$ag_olm_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
     fi
 
     $ACK_GENERATE_BIN_PATH olm $ag_olm_args
-    $SCRIPTS_DIR/olm-create-bundle.sh "$SERVICE" "$olm_version"
+    $SCRIPTS_DIR/olm-create-bundle.sh "$SERVICE" "$RELEASE_VERSION"
 
 fi

--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -35,7 +35,7 @@ Usage:
   $(basename "$0") <service> <version>
 
 <service> should be an AWS service API aliases that you wish to build -- e.g.
-'s3' 'sns' or 'sqs'
+'s3' 'sns' or 'sqs'. <version> should be the semver of the OLM bundle.
 
 Environment variables:
   BUNDLE_DEFAULT_CHANNEL                    The default channel to publish the OLM bundle to.

--- a/templates/config/controller/kustomization_def.yaml.tpl
+++ b/templates/config/controller/kustomization_def.yaml.tpl
@@ -6,6 +6,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ack-{{ .ServicePackageName }}-controller
-  newTag: latest
+  newName: {{ .ImageRepository }}
+  newTag: {{ .ReleaseVersion }}
 {{end}}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1076

Description of changes:
Adds the `config/controller/kustomization.yaml` file to the release part of the build, so that we can inject the release version and URL to the controller image path. 

Example of new `kustomization.yaml` (for S3):
```yaml
resources:
- deployment.yaml
- service.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
images:
- name: controller
  newName: public.ecr.aws/aws-controllers-k8s/s3-controller
  newTag: v0.0.11
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
