### PR TITLE
Add storageversion kubebuilder marker in Crossplane pipeline

### DIFF
--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -62,6 +62,7 @@ type {{ .CRD.Kind }}Status struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Issue #, if available:

Description of changes:
For cases where we do not delete the old version, we need to mark the generated type with storage version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
