### PR TITLE
refactoring --image-repository arg so it can be used across cmds

### DIFF
--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -58,9 +58,6 @@ func init() {
 	olmCmd.PersistentFlags().BoolVar(
 		&optDisableCommonKeywords, "no-common-keywords", false, "does not include common keywords in the rendered cluster service version",
 	)
-	olmCmd.PersistentFlags().StringVar(
-		&optImageRepository, "image-repository", "", "the Docker image repository that stores the ACK service controller. Default: 'public.ecr.aws/aws-controllers-k8s/$service-controller'",
-	)
 
 	rootCmd.AddCommand(olmCmd)
 }

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -26,10 +26,7 @@ import (
 	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 )
 
-var (
-	optReleaseOutputPath string
-	optImageRepository   string
-)
+var optReleaseOutputPath string
 
 var releaseCmd = &cobra.Command{
 	Use:   "release <service> <release_version>",
@@ -38,9 +35,6 @@ var releaseCmd = &cobra.Command{
 }
 
 func init() {
-	releaseCmd.PersistentFlags().StringVar(
-		&optImageRepository, "image-repository", "", "the Docker image repository to use in release artifacts. Defaults to 'public.ecr.aws/aws-controllers-k8s/$service-controller'",
-	)
 	releaseCmd.PersistentFlags().StringVarP(
 		&optReleaseOutputPath, "output", "o", "", "path to root directory to create generated files. Defaults to "+optServicesDir+"/$service",
 	)

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -44,6 +44,7 @@ var (
 	optMetadataConfigPath  string
 	optOutputPath          string
 	optServiceAccountName  string
+	optImageRepository     string
 )
 
 var rootCmd = &cobra.Command{
@@ -124,6 +125,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optServiceAccountName, "service-account-name", "", "The name of the ServiceAccount used for ACK service controller",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&optImageRepository, "image-repository", "", "the Docker image repository to use in release artifacts. Defaults to 'public.ecr.aws/aws-controllers-k8s/$service-controller'",
 	)
 }
 

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -249,6 +249,9 @@ if [[ $ACK_GENERATE_OLM == "true" ]]; then
     if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
         ag_olm_args="$ag_olm_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
     fi
+    if [ -n "$ACK_GENERATE_IMAGE_REPOSITORY" ]; then
+        ag_olm_args="$ag_olm_args --image-repository $ACK_GENERATE_IMAGE_REPOSITORY"
+    fi
 
     $ACK_GENERATE_BIN_PATH olm $ag_olm_args
     $SCRIPTS_DIR/olm-create-bundle.sh "$SERVICE" "$RELEASE_VERSION"

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -7,7 +7,7 @@ metadata:
     capabilities: {{.Annotations.CapabilityLevel}}
     operatorframework.io/suggested-namespace: "ack-system"
     repository: {{.Annotations.Repository}}
-    containerImage: {{.Annotations.ContainerImage}}/{{.ServicePackageName}}-controller:v{{.Version}}
+    containerImage: {{ .ImageRepository }}:{{ .ReleaseVersion }}
     description: {{.Annotations.ShortDescription}}
     createdAt: {{.CreatedAt}}
     support: {{.Annotations.Support}}


### PR DESCRIPTION
Issue #, if available:
- Fixes: aws-controllers-k8s/community#1154
- Fixes: aws-controllers-k8s/community#780

Description of changes:
- refactoring --image-repository arg so it can be used across cmds
- removing redundant steps in the olm-create-bundle script that is now handled in code/kustomize directly
- referencing new template args in CSV tpl to keep it consistent with the deployment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>