### PR TITLE
Allow `SetFieldConfig` to refer to nested Input Shape Fields

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -114,7 +114,7 @@ var (
 			if setCfg != nil && setCfg.Ignore {
 				return ""
 			}
-			return code.SetResourceForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, setCfg, sourceVarName, sourceShapeRef, indentLevel)
+			return code.SetResourceForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, setCfg, sourceVarName, sourceShapeRef, "", indentLevel)
 		},
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -308,6 +308,7 @@ func SetResource(
 					setCfg,
 					sourceAdaptedVarName,
 					sourceMemberShapeRef,
+					f.Names.Camel,
 					indentLevel+1,
 				)
 				out += setResourceForScalar(
@@ -578,6 +579,7 @@ func setResourceReadMany(
 					setCfg,
 					sourceAdaptedVarName,
 					sourceMemberShapeRef,
+					f.Names.Camel,
 					indentLevel+2,
 				)
 				out += setResourceForScalar(
@@ -1156,6 +1158,8 @@ func setResourceForContainer(
 	sourceVarName string,
 	// ShapeRef of the source struct field
 	sourceShapeRef *awssdkmodel.ShapeRef,
+	// currentPath is the absolute path to targetFieldName for nested fields
+	currentPath string,
 	indentLevel int,
 ) string {
 	switch sourceShapeRef.Shape.Type {
@@ -1168,6 +1172,7 @@ func setResourceForContainer(
 			targetSetCfg,
 			sourceVarName,
 			sourceShapeRef,
+			currentPath,
 			indentLevel,
 		)
 	case "list":
@@ -1179,6 +1184,7 @@ func setResourceForContainer(
 			targetSetCfg,
 			sourceVarName,
 			sourceShapeRef,
+			currentPath,
 			indentLevel,
 		)
 	case "map":
@@ -1190,6 +1196,7 @@ func setResourceForContainer(
 			targetSetCfg,
 			sourceVarName,
 			sourceShapeRef,
+			currentPath,
 			indentLevel,
 		)
 	default:
@@ -1219,6 +1226,8 @@ func SetResourceForStruct(
 	sourceVarName string,
 	// ShapeRef of the source struct field
 	sourceShapeRef *awssdkmodel.ShapeRef,
+	// currentPath is the absolute path to targetFieldName for nested fields
+	currentPath string,
 	indentLevel int,
 ) string {
 	out := ""
@@ -1259,6 +1268,7 @@ func SetResourceForStruct(
 					nil,
 					sourceAdaptedVarName,
 					memberShapeRef,
+					currentPath+"."+cleanNames.Camel,
 					indentLevel+1,
 				)
 				out += setResourceForScalar(
@@ -1300,6 +1310,8 @@ func setResourceForSlice(
 	sourceVarName string,
 	// ShapeRef of the source slice field
 	sourceShapeRef *awssdkmodel.ShapeRef,
+	// currentPath is the absolute path to targetFieldName for nested fields
+	currentPath string,
 	indentLevel int,
 ) string {
 	out := ""
@@ -1378,6 +1390,7 @@ func setResourceForSlice(
 			targetSetCfg,
 			iterVarName,
 			&sourceShape.MemberRef,
+			currentPath,
 			indentLevel+1,
 		)
 	}
@@ -1411,6 +1424,8 @@ func setResourceForMap(
 	sourceVarName string,
 	// ShapeRef of the source map field
 	sourceShapeRef *awssdkmodel.ShapeRef,
+	// currentPath is the absolute path to targetFieldName for nested fields
+	currentPath string,
 	indentLevel int,
 ) string {
 	out := ""
@@ -1443,6 +1458,7 @@ func setResourceForMap(
 		nil,
 		valIterVarName,
 		&sourceShape.ValueRef,
+		currentPath,
 		indentLevel+1,
 	)
 	addressOfVar := ""

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator.yaml
@@ -68,8 +68,11 @@ operations:
     output_wrapper_field_path: VpcEndpoint
 
 resources:
-  DHCPOptions:
-
+  DhcpOptions:
+    fields:
+      DHCPConfigurations.Values:
+        set:
+          - from: AttributeValue.Value
   SecurityGroup:
     renames:
       operations:


### PR DESCRIPTION
Issue #, if available: [#1146](https://github.com/aws-controllers-k8s/community/issues/1146)

code-generator has issues generating Go code to set a Resource's Spec field when the Go type of a Create Input shape field is different from the Go type of the *same-named field* in the Output shape. The `pkg/generate/config.SetConfig` was introduced to solve this problem; however, the current implementation does not support `SetFieldConfig` for **nested** Create Input shape fields (Resource Spec fields). 

For example, when generating EC2 DHCPOptions Resource the `CreateDhcpOptionsInput` Shape contains an attribute, `Values []*string` but the `CreateDhcpOptionsOutput` Shape has the same-named field as a different type: `Values []*AttributeValue`. `AttributeValue` struct has a `Value *string` attribute which is what we want code-generator to use to populate `Values []*string`. In other words, set `CreateDhcpOptionsInput.DhcpConfigurations.Values []*string` using `CreateDhcpOptionsInput.DhcpOptions.DhcpConfigurations.Values.Value *string`.  The `DhcpConfigurations.Values` is the **nested** Create Input Shape field in this case.

This patch allows users to define a **nested** Input Shape Field (Resource Field in `generator.yaml`) in `SetFieldConfig` to resolve Shape mismatches occurring within top "level" fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
