### PR TITLE
crossplane: do not generate/use region field for IAM resources

### DIFF
--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -18,9 +18,11 @@ import (
 
 // {{ .CRD.Kind }}Parameters defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Parameters struct {
+	{{- if ne .APIGroup "iam.aws.crossplane.io"  }}
 	// Region is which region the {{ .CRD.Kind }} will be created.
 	// +kubebuilder:validation:Required
 	Region string `json:"region"`
+	{{- end }}
 	{{- range $fieldName, $field := .CRD.SpecFields }}
 	{{- if $field.ShapeRef }}
 	{{ $field.ShapeRef.Documentation }}

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -44,7 +44,11 @@ func (c *connector) Connect(ctx context.Context, mg cpresource.Managed) (managed
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
 	}
+	{{- if ne .APIGroup "iam.aws.crossplane.io"  }}
 	sess, err := awsclient.GetConfigV1(ctx, c.kube, mg, cr.Spec.ForProvider.Region)
+	{{- else }}
+	sess, err := awsclient.GetConfigV1(ctx, c.kube, mg, awsclient.GlobalRegion)
+	{{- end }}
 	if err != nil {
 		return nil, errors.Wrap(err, errCreateSession)
 	}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1150

Description of changes: Disable `region` field generation and its usage for IAM resources since their clients don't work with regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
