### PR TITLE
Use resp variable in sdkFind

### DIFF
--- a/templates/pkg/resource/sdk_find_get_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_find_get_attributes.go.tpl
@@ -25,6 +25,7 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.GetAttributes }}
+    _ = resp
 	resp, err = rm.sdkapi.{{ .CRD.Ops.GetAttributes.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_get_attributes_post_request" }}
 {{ $hookCode }}

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -25,6 +25,7 @@ func (rm *resourceManager) sdkFind(
 {{ $hookCode }}
 {{- end }}
 	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.ReadMany }}
+    _ = resp
 	resp, err = rm.sdkapi.{{ .CRD.Ops.ReadMany.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_many_post_request" }}
 {{ $hookCode }}

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -26,6 +26,7 @@ func (rm *resourceManager) sdkFind(
 {{- end }}
 
 	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.ReadOne }}
+    _ = resp
 	resp, err = rm.sdkapi.{{ .CRD.Ops.ReadOne.ExportedName }}WithContext(ctx, input)
 {{- if $hookCode := Hook .CRD "sdk_read_one_post_request" }}
 {{ $hookCode }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
I've tried to generate sqs-controller with 0.16.5 runtime, and on running test got this error:
``` 
$ make test
go test -v ./...
?   	github.com/aws-controllers-k8s/sqs-controller/apis/v1alpha1	[no test files]
# github.com/aws-controllers-k8s/sqs-controller/pkg/resource/queue
pkg/resource/queue/sdk.go:68:6: resp declared but not used
make: *** [Makefile:19: test] Error 2
```
This patch should fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
