### PR TITLE
allow resource references across service controllers

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -284,6 +284,12 @@ type LateInitializeConfig struct {
 // read the referred 'API' resource and copy the value from 'Status.APIID' in
 // 'Integration' resource's 'APIID' field
 type ReferencesConfig struct {
+	// ServiceName mentions the AWS service name where 'Resource' exists
+	// ServiceName is the package name for AWS service package in
+	// aws-sdk-go/models/apis/<package_name>
+	// When not specified, 'ServiceName' defaults to service name of controller
+	// which contains generator.yaml
+	ServiceName string `json:"service_name,omitempty"`
 	// Resource mentions the K8s resource which is read to resolve the
 	// reference
 	Resource string `json:"resource"`

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -284,9 +284,15 @@ type LateInitializeConfig struct {
 // read the referred 'API' resource and copy the value from 'Status.APIID' in
 // 'Integration' resource's 'APIID' field
 type ReferencesConfig struct {
-	// ServiceName mentions the AWS service name where 'Resource' exists
-	// ServiceName is the package name for AWS service package in
-	// aws-sdk-go/models/apis/<package_name>
+	// ServiceName mentions the AWS service name where "Resource" exists.
+	// This field is used to generate the API Group for the "Resource".
+	//
+	// ServiceName is the go package name for AWS service in
+	// aws-sdk-go/service/<package_name>/api.go
+	// Ex: Use "opensearchservice" to refer "Domain" resource from
+	// opensearchservice-controller because it is the go package name for
+	// "aws-sdk-go/service/opensearchservice/api.go"
+	//
 	// When not specified, 'ServiceName' defaults to service name of controller
 	// which contains generator.yaml
 	ServiceName string `json:"service_name,omitempty"`

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -149,6 +149,35 @@ func (f *Field) GetReferenceFieldName() names.Names {
 	return names.New(refName)
 }
 
+// ReferencedServiceName returns the serviceName for the referenced resource
+// when the field has 'ReferencesConfig'
+// If the field does not have 'ReferencesConfig', empty string is returned
+func (f *Field) ReferencedServiceName() (referencedServiceName string) {
+	if f.FieldConfig != nil && f.FieldConfig.References != nil {
+		if f.FieldConfig.References.ServiceName != "" {
+			return f.FieldConfig.References.ServiceName
+		} else {
+			return f.CRD.sdkAPI.API.PackageName()
+		}
+	}
+	return referencedServiceName
+}
+
+// ReferencedResourceNamePlural returns the plural of referenced resource
+// when the field has a 'ReferencesConfig'
+// If the field does not have 'ReferencesConfig', empty string is returned
+func (f *Field) ReferencedResourceNamePlural() string {
+	var referencedResourceName string
+	pluralize := pluralize.NewClient()
+	if f.FieldConfig != nil && f.FieldConfig.References != nil {
+		referencedResourceName = f.FieldConfig.References.Resource
+	}
+	if referencedResourceName != "" {
+		return pluralize.Plural(referencedResourceName)
+	}
+	return referencedResourceName
+}
+
 // NewReferenceField returns a pointer to a new Field object.
 // The go-type of field is either slice of '*AWSResourceReferenceWrapper' or
 // '*AWSResourceReferenceWrapper' depending on whether 'shapeRef' parameter

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -18,9 +18,27 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 {{ end -}}
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+{{ $servicePackageName := .ServicePackageName -}}
+{{ $apiVersion := .APIVersion -}}
+{{ if .CRD.HasReferenceFields -}}
+{{ range $fieldName, $field := .CRD.Fields -}}
+{{ if and $field.HasReference (not (eq $field.ReferencedServiceName $servicePackageName)) -}}
+    {{ $field.ReferencedServiceName }}apitypes "github.com/aws-controllers-k8s/{{ $field.ReferencedServiceName }}-controller/apis/{{ $apiVersion }}"
+{{ end -}}
+{{ end -}}
+{{ end -}}
 )
+
+{{ if .CRD.HasReferenceFields -}}
+{{ range $fieldName, $field := .CRD.Fields -}}
+{{ if and $field.HasReference (not (eq $field.ReferencedServiceName $servicePackageName)) -}}
+// +kubebuilder:rbac:groups={{ $field.ReferencedServiceName -}}.services.k8s.aws,resources={{ ToLower $field.ReferencedResourceNamePlural }},verbs=get;list
+// +kubebuilder:rbac:groups={{ $field.ReferencedServiceName -}}.services.k8s.aws,resources={{ ToLower $field.ReferencedResourceNamePlural }}/status,verbs=get;list
+
+{{ end -}}
+{{ end -}}
+{{ end -}}
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -18,7 +18,6 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 {{ end -}}
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
 {{ $servicePackageName := .ServicePackageName -}}
 {{ $apiVersion := .APIVersion -}}
 {{ if .CRD.HasReferenceFields -}}
@@ -28,6 +27,8 @@ import (
 {{ end -}}
 {{ end -}}
 {{ end -}}
+
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
 )
 
 {{ if .CRD.HasReferenceFields -}}

--- a/templates/pkg/resource/references_read_referenced_resource.go.tpl
+++ b/templates/pkg/resource/references_read_referenced_resource.go.tpl
@@ -12,7 +12,11 @@ Where field is of type 'Field' from aws-controllers-k8s/code-generator/pkg/model
 				Namespace: namespace,
 				Name: *arr.Name,
 			}
+			{{ if eq .FieldConfig.References.ServiceName "" -}}
 			obj := svcapitypes.{{ .FieldConfig.References.Resource }}{}
+			{{ else -}}
+			obj := {{ .ReferencedServiceName }}apitypes.{{ .FieldConfig.References.Resource }}{}
+			{{ end -}}
 			err := apiReader.Get(ctx, namespacedName, &obj)
 			if err != nil {
 				return err


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1091

Description of changes:
* https://github.com/aws-controllers-k8s/community/pull/1092
* Adds a new `ServiceName` parameter in `ReferencesConfig` to indicate when the referenced resource is from another service controller
* Based on the `ServiceName` parameter imports the API-types from that service controller
* Adds the additional RBAC permissions to allow reading the referenced resource from another service controller

Tested by generating and running apigatewayv2-controller which refers the Subnet and SecurityGroup resource from ec2 controller. Please see the [proposal link](https://github.com/aws-controllers-k8s/community/pull/1092) for generated code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
