### PR TITLE
Added missing pullSecrets & pullPolicy

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ include "service-account.name" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - command:
         - ./bin/controller
@@ -50,6 +56,7 @@ spec:
         - --watch-namespace
         - "$(ACK_WATCH_NAMESPACE)"
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller
         ports:
           - name: http


### PR DESCRIPTION
Signed-off-by: Nick Fisher <nxf5025@gmail.com>

Description of changes: The helm chart's values.yaml files have the ability to set `pullPolicy` & `pullSecrets`, but the deployment.yaml does not contain the proper blocks to render the settings. This PR adds both of those.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
