### PR TITLE
Resolve references hooks

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -61,8 +61,8 @@ code paths:
 * delta_post_compare
 * late_initialize_pre_read_one
 * late_initialize_post_read_one
-* pre_resolve_references
-* post_resolve_references
+* references_pre_resolve
+* references_post_resolve
 
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE
@@ -112,11 +112,11 @@ readOne call inside AWSResourceManager.LateInitialize() method
 The "late_initialize_post_read_one" hooks are called AFTER making the
 readOne call inside AWSResourceManager.LateInitialize() method
 
-The "pre_resolve_references" hooks are called BEFORE resolving the
+The "references_pre_resolve" hooks are called BEFORE resolving the
 references for all Reference fields inside AWSResourceManager.ResolveReferences()
 method
 
-The "post_resolve_references" hooks are called AFTER resolving the
+The "references_post_resolve" hooks are called AFTER resolving the
 references for all Reference fields inside AWSResourceManager.ResolveReferences()
 method
 */

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -201,6 +201,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 {{- if $hookCode := Hook .CRD "late_initialize_post_read_one" }}
@@ -213,6 +214,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -40,7 +40,7 @@ func (rm *resourceManager) ResolveReferences(
 	namespace := res.MetaObject().GetNamespace()
 	ko := rm.concreteResource(res).ko.DeepCopy()
 	err := validateReferenceFields(ko)
-{{- if $hookCode := Hook .CRD "pre_resolve_references" }}
+{{- if $hookCode := Hook .CRD "references_pre_resolve" }}
 {{ $hookCode }}
 {{- end }}
 	{{ range $fieldName, $field := .CRD.Fields -}}
@@ -50,7 +50,7 @@ func (rm *resourceManager) ResolveReferences(
 	}
 	{{ end -}}
 	{{ end -}}
-{{- if $hookCode := Hook .CRD "post_resolve_references" }}
+{{- if $hookCode := Hook .CRD "references_post_resolve" }}
 {{ $hookCode }}
 {{- end }}
 	if hasNonNilReferences(ko) {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1180

Description of changes:
* This patch adds support for two custom hooks "pre_resolve_references" and "post_resolve_references"
* These hooks are needed to support TargetRef inside APIGatewayv2 Route resource where "integrations/" prefix is added before the referred IntegrationID.
* This patch also sets ResourceSynced condition to false when LateInitialization fails. This will help remove custom ResourceSynced condition handling inside `reconciler.go`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
