### PR TITLE
Keep local import separation inside references.go.tpl

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -24,9 +24,9 @@ import (
 {{ range $fieldName, $field := .CRD.Fields -}}
 {{ if and $field.HasReference (not (eq $field.ReferencedServiceName $servicePackageName)) -}}
     {{ $field.ReferencedServiceName }}apitypes "github.com/aws-controllers-k8s/{{ $field.ReferencedServiceName }}-controller/apis/{{ $apiVersion }}"
-{{ end -}}
-{{ end -}}
-{{ end -}}
+{{- end }}
+{{- end }}
+{{- end }}
 
 	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
 )


### PR DESCRIPTION
Description of changes:
* Do not strip the whitespace character **after** third-party imports
*  without the new-line, gofmt was reordering "svcapitypes" import with third-party imports
* validated the fix by generating service controllers locally and the imports inside `references.go` were correct
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
