### PR TITLE
Fix reference import templating

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -24,7 +24,7 @@ import (
 {{ range $referencedServiceName := .CRD.ReferencedServiceNames -}}
 {{ if not (eq $referencedServiceName $servicePackageName) -}}
     {{ $referencedServiceName }}apitypes "github.com/aws-controllers-k8s/{{ $referencedServiceName }}-controller/apis/{{ $apiVersion }}"
-{{- end }}
+{{ end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Description of changes:
The current implementation attempts to put all service type imports on the same line. This pull request ensures each import gets a separate line per service and compiles correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
