### PR TITLE
Consider renaming when trying to find pluralized identifier shapes

### DIFF
--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -109,8 +109,18 @@ func FindPluralizedIdentifiersInShape(
 	pluralize := pluralize.NewClient()
 	for _, si := range shapeIdentifiers {
 		for _, ci := range crIdentifiers {
-			if strings.EqualFold(pluralize.Singular(si),
-				pluralize.Singular(ci)) {
+			// If the identifier field is renamed, we must take that into
+			// consideration in order to find the corresponding matching
+			// shapeIdentifier.
+			siRenamed, _ := r.Config().ResourceFieldRename(
+				r.Names.Original,
+				op.Name,
+				pluralize.Singular(si),
+			)
+			if strings.EqualFold(
+				siRenamed,
+				pluralize.Singular(ci),
+			) {
 				// The CRD identifiers being used for comparison reflect any
 				// renamed field names in the API model shape.
 				if crField == "" {

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -1800,3 +1800,30 @@ func TestSetSDK_EC2_VPC_ReadMany(t *testing.T) {
 		code.SetSDK(crd.Config(), crd, model.OpTypeList, "r.ko", "res", 1),
 	)
 }
+
+func Test_SetSDK_ECR_Repository_newListRequestPayload(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ecr", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-renamed-identifier-field.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Repository")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Status.RegistryID != nil {
+		res.SetRegistryId(*r.ko.Status.RegistryID)
+	}
+	if r.ko.Spec.Name != nil {
+		f3 := []*string{}
+		f3 = append(f3, r.ko.Spec.Name)
+		res.SetRepositoryNames(f3)
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeList, "r.ko", "res", 1),
+	)
+}

--- a/pkg/testdata/models/apis/ecr/0000-00-00/generator-renamed-identifier-field.yaml
+++ b/pkg/testdata/models/apis/ecr/0000-00-00/generator-renamed-identifier-field.yaml
@@ -1,0 +1,10 @@
+resources:
+  Repository:
+    renames:
+      operations:
+        CreateRepository:
+          input_fields:
+            RepositoryName: Name
+        DescribeRepositories:
+          input_fields:
+            RepositoryName: Name


### PR DESCRIPTION
Description of changes:

Currently `FindPluralizedIdentifiersInShape` doesn't take into
consideration CRD field renames. This patch enhances the 
function to be able to lookup field renames and properly find the
matching identifier field.

Fixes https://github.com/aws-controllers-k8s/community/issues/1208

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.