### PR TITLE
adding operator-sdk to the code-generator /bin folder

### DIFF
--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -8,13 +8,15 @@
 # variable OPERATOR_SDK_VERSION and if that is not set, the value of the
 # DEFAULT_OPERATOR_SDK_VERSION variable.
 #
-# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/operator-sdk
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /code-generator/bin/operator-sdk
 
 set -eo pipefail
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
-DEFAULT_OPERATOR_SDK_VERSION="1.7.1"
+DEFAULT_OPERATOR_SDK_BIN_PATH="$ROOT_DIR/../code-generator/bin"
+OPERATOR_SDK_BIN_PATH=${OPERATOR_SDK_BIN_PATH:-$DEFAULT_OPERATOR_SDK_BIN_PATH}
+DEFAULT_OPERATOR_SDK_VERSION="1.17.0"
 
 source "${SCRIPTS_DIR}/lib/common.sh"
 
@@ -22,13 +24,19 @@ __operator_sdk_version="${1}"
 if [ "x${__operator_sdk_version}" == "x" ]; then
     __operator_sdk_version=${OPERATOR_SDK_VERSION:-$DEFAULT_OPERATOR_SDK_VERSION}
 fi
-if ! is_installed operator-sdk; then
+if ! is_installed ${OPERATOR_SDK_BIN_PATH}/operator-sdk; then
     __platform=$(uname | tr '[:upper:]' '[:lower:]')
     __tmp_install_dir=$(mktemp -d -t install-operator-sdk-XXX)
     __operator_sdk_url="https://github.com/operator-framework/operator-sdk/releases/download/v${__operator_sdk_version}/operator-sdk_${__platform}_amd64"
+
+    __install_dir=${OPERATOR_SDK_BIN_PATH}
+    # If __install_dir does not exist, create it
+    [[ -d $__install_dir ]] || mkdir -p "$__install_dir"
+    __install_path="$__install_dir/operator-sdk"
+
     echo -n "installing operator-sdk from ${__operator_sdk_url} ... "
     curl -sq -L ${__operator_sdk_url} --output ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
     chmod +x ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
-    sudo mv ${__tmp_install_dir}/operator-sdk_${__platform}_amd64 /usr/local/bin/operator-sdk
+    sudo mv "${__tmp_install_dir}/operator-sdk_${__platform}_amd64" "$__install_path"
     echo "ok."
 fi

--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -10,6 +10,8 @@ ROOT_DIR="$SCRIPTS_DIR/.."
 BUILD_DIR="$ROOT_DIR/build"
 DEFAULT_BUNDLE_CHANNEL="alpha"
 PRESERVE=${PRESERVE:-"false"}
+DEFAULT_OPERATOR_SDK_BIN_PATH="$ROOT_DIR/../code-generator/bin"
+OPERATOR_SDK_BIN_PATH=${OPERATOR_SDK_BIN_PATH:-$DEFAULT_OPERATOR_SDK_BIN_PATH}
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 
@@ -17,7 +19,7 @@ source "$SCRIPTS_DIR/lib/common.sh"
 
 check_is_installed uuidgen
 check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
-check_is_installed operator-sdk "You can install Operator SDK with the helmer scripts/install-operator-sdk.sh"
+check_is_installed ${OPERATOR_SDK_BIN_PATH}/operator-sdk "You can install Operator SDK with the helper scripts/install-operator-sdk.sh"
 
 function clean_up {
     if [[ "$PRESERVE" == false ]]; then
@@ -64,6 +66,8 @@ Environment variables:
                                     Default: false
   BUNDLE_GENERATE_EXTRA_ARGS        Extra arguments to pass into the command
                                     'operator-sdk generate bundle'.
+  OPERATOR_SDK_BIN_PATH             Overrides the path to the operator-sdk binary.
+                                    Default: $DEFAULT_OPERATOR_SDK_BIN_PATH
 "
 
 if [ $# -ne 2 ]; then
@@ -127,7 +131,7 @@ fi
 # in the controller-specific repositories.
 mkdir -p $BUNDLE_OUTPUT_PATH
 pushd $BUNDLE_OUTPUT_PATH 1> /dev/null
-kustomize build $tmp_kustomize_config_dir/manifests | operator-sdk generate bundle $opsdk_gen_bundle_args 
+kustomize build $tmp_kustomize_config_dir/manifests | ${OPERATOR_SDK_BIN_PATH}/operator-sdk generate bundle $opsdk_gen_bundle_args
 popd 1> /dev/null
 
-operator-sdk bundle validate $BUNDLE_OUTPUT_PATH/bundle
+${OPERATOR_SDK_BIN_PATH}/operator-sdk bundle validate $BUNDLE_OUTPUT_PATH/bundle


### PR DESCRIPTION
Issue #, if available:
N/A
Description of changes:
Since there is a change in operator-sdk that isn't compatible with the way ACK `deployment.yaml`'s are built, it's best if we install and use a specific version in the `/bin` folder of the `code-generator`. This way no matter what version of `operator-sdk` a developer has installed, we can control what versions are used for local development and release of this project. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>
