### PR TITLE
Add missing Kustomize env vars

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -28,6 +28,8 @@ spec:
         args:
         - --aws-region
         - "$(AWS_REGION)"
+        - --aws-endpoint-url
+        - "$(AWS_ENDPOINT_URL)"
         - --enable-development-logging
         - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
         - --log-level
@@ -53,6 +55,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: AWS_REGION
+          value: ""
+        - name: AWS_ENDPOINT_URL
+          value: ""
+        - name: ACK_WATCH_NAMESPACE
+          value: ""
+        - name: ACK_ENABLE_DEVELOPMENT_LOGGING
+          value: "false"
+        - name: ACK_LOG_LEVEL
+          value: "info"
+        - name: ACK_RESOURCE_TAGS
+          value: "services.k8s.aws/managed=true,services.k8s.aws/created=%UTCNOW%,services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%"
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1224

Description of changes:
The environment variables being passed to the deployment in the generated Kustomization are not up-to-date with the [Helm chart](https://github.com/aws-controllers-k8s/code-generator/blob/7052f6808b237f97a2000e4c4f296b9ed2a0d7c0/templates/helm/templates/deployment.yaml#L66-L82). This pull request adds each of the environment variables with the same default values as the ones supplied in `values.yaml`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
