### PR TITLE
Add RBAC permissions for FieldExport

### DIFF
--- a/templates/pkg/resource/registry.go.tpl
+++ b/templates/pkg/resource/registry.go.tpl
@@ -9,11 +9,11 @@ import (
 
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=fieldexports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=fieldexports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
-{{ if .GeneratorConfig.ResourceContainsSecret -}}
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-{{- end }}
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;patch
 
 var (
 	reg = ackrt.NewRegistry()


### PR DESCRIPTION
Description of changes:
Adds all RBAC permissions for the `FieldExport` custom resource, and `patch` to `secrets` and `configmaps`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
