### PR TITLE
Generate `Region()` method for `resourceIdentifiers`

### DIFF
--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -46,6 +46,11 @@ func (ids *fakeIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	return &owner
 }
 
+func (ids *fakeIdentifiers) Region() *ackv1alpha1.AWSRegion {
+	region := ackv1alpha1.AWSRegion("us-west-2")
+	return &region
+}
+
 type fakeDescriptor struct{}
 
 func (fd *fakeDescriptor) GroupKind() *metav1.GroupKind {

--- a/templates/pkg/resource/identifiers.go.tpl
+++ b/templates/pkg/resource/identifiers.go.tpl
@@ -31,3 +31,12 @@ func (ri *resourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	}
 	return nil
 }
+
+// Region returns the AWS region in which the resource exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
+	if ri.meta != nil {
+		return ri.meta.Region
+	}
+	return nil
+}

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -182,6 +182,9 @@ func (rm *resourceManager) setStatusDefaults (
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
+	if ko.Status.ACKResourceMetadata.Region == nil {
+		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}


### PR DESCRIPTION
Follow up to https://github.com/aws-controllers-k8s/runtime/pull/79

This patch modifies the code-generator to generate a `Region` function
so that a resource can also satisfy the `Identifiers` interface. This
the patch also extends the `setStatusDefaults` so that it correctly
populates the `status.ResourceMetadata.Region` with the aws region in
which it is created/managed

Description of changes:
- Add `Region()` method to resourceIdentifiers template.
- Modifies `setStatusDefaults` to  be able to set the a default region.
- Update `runtime_test.go`

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
