### PR TITLE
Fix Spec field length

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -564,7 +564,8 @@ func CompareStruct(
 		var compareConfig *ackgenconfig.CompareFieldConfig
 		// memberFieldPath contains the field path along with the prefix cfg.PrefixConfig.SpecField + "." hence we
 		// would need to substring to exclude cfg.PrefixConfig.SpecField + "." to get correct field config.
-		fieldConfig := fieldConfigs[memberFieldPath[len(cfg.PrefixConfig.SpecField) + 1 :len(memberFieldPath)]]
+		specFieldLen := len(strings.TrimPrefix(cfg.PrefixConfig.SpecField, "."))
+		fieldConfig := fieldConfigs[memberFieldPath[specFieldLen + 1: len(memberFieldPath)]]
 		if fieldConfig != nil {
 			compareConfig = fieldConfig.Compare
 		}

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -475,3 +475,49 @@ func TestCompareResource_APIGatewayv2_Route(t *testing.T) {
 		),
 	)
 }
+
+func TestCompareResource_MemoryDB_User(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "memorydb")
+
+	crd := testutil.GetCRDByName(t, g, "User")
+	require.NotNil(crd)
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.AccessString, b.ko.Spec.AccessString) {
+		delta.Add("Spec.AccessString", a.ko.Spec.AccessString, b.ko.Spec.AccessString)
+	} else if a.ko.Spec.AccessString != nil && b.ko.Spec.AccessString != nil {
+		if *a.ko.Spec.AccessString != *b.ko.Spec.AccessString {
+			delta.Add("Spec.AccessString", a.ko.Spec.AccessString, b.ko.Spec.AccessString)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.AuthenticationMode, b.ko.Spec.AuthenticationMode) {
+		delta.Add("Spec.AuthenticationMode", a.ko.Spec.AuthenticationMode, b.ko.Spec.AuthenticationMode)
+	} else if a.ko.Spec.AuthenticationMode != nil && b.ko.Spec.AuthenticationMode != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.AuthenticationMode.Type, b.ko.Spec.AuthenticationMode.Type) {
+			delta.Add("Spec.AuthenticationMode.Type", a.ko.Spec.AuthenticationMode.Type, b.ko.Spec.AuthenticationMode.Type)
+		} else if a.ko.Spec.AuthenticationMode.Type != nil && b.ko.Spec.AuthenticationMode.Type != nil {
+			if *a.ko.Spec.AuthenticationMode.Type != *b.ko.Spec.AuthenticationMode.Type {
+				delta.Add("Spec.AuthenticationMode.Type", a.ko.Spec.AuthenticationMode.Type, b.ko.Spec.AuthenticationMode.Type)
+			}
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
+`
+	assert.Equal(
+		expected,
+		code.CompareResource(
+			crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+		),
+	)
+}

--- a/pkg/testdata/models/apis/memorydb/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/memorydb/0000-00-00/generator.yaml
@@ -11,6 +11,20 @@ resources:
       terminal_codes:
         - InvalidParameterValueException
         - UserAlreadyExistsFault
+    renames:
+      operations:
+        CreateUser:
+          input_fields:
+            UserName: Name
+        UpdateUser:
+          input_fields:
+            UserName: Name
+        DeleteUser:
+          input_fields:
+            UserName: Name
+        DescribeUsers:
+          input_fields:
+            UserName: Name
     fields:
       AuthenticationMode.Passwords:
         is_secret: true


### PR DESCRIPTION
Updated to trim the prefix "." to calculate the length of the `Spec`.

`cfg.PrefixConfig.SpecField` value is `.Spec` so old code `len(cfg.PrefixConfig.SpecField) + 1` constructed incorrect field path and ignored the config set in `generator.yaml`

Added unit test to validate that below block is not generated.

```
if !ackcompare.SliceStringPEqual(a.ko.Spec.AuthenticationMode.Passwords, b.ko.Spec.AuthenticationMode.Passwords) {
	delta.Add("Spec.AuthenticationMode.Passwords", a.ko.Spec.AuthenticationMode.Passwords, b.ko.Spec.AuthenticationMode.Passwords)
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
