### PR TITLE
add ServicePackageName to ack-user-config and ack-user secrets

### DIFF
--- a/templates/config/controller/user-env.yaml.tpl
+++ b/templates/config/controller/user-env.yaml.tpl
@@ -10,8 +10,8 @@ spec:
       - name: controller
         envFrom:
           - configMapRef:
-              name: ack-user-config
+              name: ack-{{.ServicePackageName}}-user-config
               optional: false
           - secretRef:
-              name: ack-user-secrets
+              name: ack-{{.ServicePackageName}}-user-secrets
               optional: false


### PR DESCRIPTION
Issue #, if available:
- Fixes: aws-controllers-k8s/community#1149

Description of changes:
Add in support for service specific configmaps and secret so that a cluster admin can configure each service differently, or the same if they so choose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>
