### PR TITLE
ACK runtime update v0.18.0 => v0.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
-VERSION ?= "v0.18.0"
+VERSION ?= "v0.18.1"
 GITCOMMIT=$(shell git rev-parse HEAD)
 BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 IMPORT_PATH=github.com/aws-controllers-k8s/code-generator

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.18.0
+	github.com/aws-controllers-k8s/runtime v0.18.1
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.18.0 h1:su+L290Agveb9s17aD4GHerqtkcnTNaSaMR6+C8h86Q=
-github.com/aws-controllers-k8s/runtime v0.18.0/go.mod h1:pK+LlQRxxWKC9mRHnGz8/WRI8Dcvjg4ZGmK8rVwb51Y=
+github.com/aws-controllers-k8s/runtime v0.18.1 h1:eHmW7ObuGqnz/QpOKnZqHY2QuZmk8uROyXOvqKc7WjY=
+github.com/aws-controllers-k8s/runtime v0.18.1/go.mod h1:pK+LlQRxxWKC9mRHnGz8/WRI8Dcvjg4ZGmK8rVwb51Y=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=


### PR DESCRIPTION
Description of changes:

* ACK runtime update v0.18.0 => v0.18.1
* ACK runtime v0.18.1 [release notes](https://github.com/aws-controllers-k8s/runtime/compare/v0.18.0...v0.18.1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
