### PR TITLE
updating olm kustomize to remove default values from env

### DIFF
--- a/templates/config/controller/olm-kustomization.yaml.tpl
+++ b/templates/config/controller/olm-kustomization.yaml.tpl
@@ -1,4 +1,22 @@
 {{ template "controller_kustomization" . }}
 
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: ack-{{ .ServicePackageName }}-controller
+    patch: |-
+        - op: replace
+          path: '/spec/template/spec/containers/0/env'
+          value: []
+        - op: add
+          path: '/spec/template/spec/containers/0/env/0'
+          value:
+            name: ACK_SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
 patchesStrategicMerge:
-- user-env.yaml
+  - user-env.yaml


### PR DESCRIPTION
Issue #, if available:
- Fixes: aws-controllers-k8s/community#1238

Description of changes:
Updating the olm kustomize file to go back to previous state before default values were added into the `env` section of the `deployment.yaml.tpl`. Ideally it would be best to be able to keep these defaults, but even moving everything into the `env` and away from the `envFrom` did not work properly in a cluster, so I feel this is the best option that we have.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>