### PR TITLE
Remove patch version from Dockerfile Golang base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-n
 # Build the manager binary
 # TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
 # supports golang 1.17
-FROM public.ecr.aws/bitnami/golang:1.17.5 as builder
+FROM public.ecr.aws/bitnami/golang:1.17 as builder
 
 ARG service_alias
 # The tuple of controller image version information

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,7 +3,7 @@ ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-n
 # Build the manager binary
 # TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
 # supports golang 1.17
-FROM public.ecr.aws/bitnami/golang:1.17.5 as builder
+FROM public.ecr.aws/bitnami/golang:1.17 as builder
 
 ARG service_alias
 # The tuple of controller image version information


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1241

Description of changes:
Removes the patch version from the Golang base image in our Dockerfiles. This should now use the latest Go 1.17 patch when building images - meaning we can capture the latest security fixes as soon as they become available in the bitnami image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
