### PR TITLE
Set Terminal Condition if ACK Terminal Error

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -4,6 +4,7 @@ package {{ .CRD.Names.Snake }}
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -218,8 +219,8 @@ func (rm *resourceManager) updateConditions (
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err ==  ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type:   ackv1alpha1.ConditionTypeTerminal,
@@ -227,7 +228,7 @@ func (rm *resourceManager) updateConditions (
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)


### PR DESCRIPTION
Set terminal condition if ACK Terminal Error is thrown.

ACK Terminal errors can be used to set terminal conditions
if controller validations fail.

```
	if *latestStatus == "create-failed" {
		return nil, ackerr.TerminalError.New(errors.New("cluster cannot be updated as its status is not 'available'."))
	}

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
