### PR TITLE
Refactor model package to use `Config` accessors

### DIFF
--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -59,26 +59,6 @@ func (c *Config) IsIgnoredOperation(operation *awssdkmodel.Operation) bool {
 	return util.InStrings(operation.Name, c.Ignore.Operations)
 }
 
-// ListOpMatchFieldNames returns a slice of strings representing the field
-// names in the List operation's Output shape's element Shape that we should
-// check a corresponding value in the target Spec exists.
-func (c *Config) ListOpMatchFieldNames(
-	resName string,
-) []string {
-	res := []string{}
-	if c == nil {
-		return res
-	}
-	rConfig, found := c.Resources[resName]
-	if !found {
-		return res
-	}
-	if rConfig.ListOperation == nil {
-		return res
-	}
-	return rConfig.ListOperation.MatchFields
-}
-
 // UnmarshalJSON parses input for a either a string or
 // or a list and returns a StringArray.
 func (a *StringArray) UnmarshalJSON(b []byte) error {
@@ -176,6 +156,18 @@ func (c *Config) GetCustomCheckRequiredFieldsMissingMethod(
 	}
 
 	return operationConfig.CustomCheckRequiredFieldsMissingMethod
+}
+
+// OverrideValues returns a list of member values to override for a given operation
+func (c *Config) OverrideValues(operationName string) (map[string]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+	oConfig, ok := c.Operations[operationName]
+	if !ok {
+		return nil, false
+	}
+	return oConfig.OverrideValues, ok
 }
 
 // OperationConfig returns the OperationConfig for a given operation

--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -96,3 +96,93 @@ func (a *StringArray) UnmarshalJSON(b []byte) error {
 	}
 	return nil
 }
+
+// GetOutputWrapperFieldPath returns the JSON-Path of the output wrapper field
+// as *string for a given operation, if specified in generator config.
+func (c *Config) GetOutputWrapperFieldPath(
+	op *awssdkmodel.Operation,
+) *string {
+	if op == nil {
+		return nil
+	}
+	if c == nil {
+		return nil
+	}
+	opConfig, found := c.Operations[op.Name]
+	if !found {
+		return nil
+	}
+
+	if opConfig.OutputWrapperFieldPath == "" {
+		return nil
+	}
+	return &opConfig.OutputWrapperFieldPath
+}
+
+// SetOutputCustomMethodName returns custom set output operation as *string for
+// given operation on custom resource, if specified in generator config
+func (c *Config) SetOutputCustomMethodName(
+	// The operation to look for the Output shape
+	op *awssdkmodel.Operation,
+) *string {
+	if op == nil {
+		return nil
+	}
+	if c == nil {
+		return nil
+	}
+	opConfig, found := c.Operations[op.Name]
+	if !found {
+		return nil
+	}
+
+	if opConfig.SetOutputCustomMethodName == "" {
+		return nil
+	}
+	return &opConfig.SetOutputCustomMethodName
+}
+
+// GetCustomImplementation returns custom implementation method name for the
+// supplied operation as specified in generator config
+func (c *Config) GetCustomImplementation(
+	// The type of operation
+	op *awssdkmodel.Operation,
+) string {
+	if op == nil || c == nil {
+		return ""
+	}
+
+	operationConfig, found := c.Operations[op.Name]
+	if !found {
+		return ""
+	}
+
+	return operationConfig.CustomImplementation
+}
+
+// GetCustomCheckRequiredFieldsMissingMethod returns custom check required fields missing method
+// as string for custom resource, if specified in generator config
+func (c *Config) GetCustomCheckRequiredFieldsMissingMethod(
+	// The type of operation
+	op *awssdkmodel.Operation,
+) string {
+	if op == nil || c == nil {
+		return ""
+	}
+
+	operationConfig, found := c.Operations[op.Name]
+	if !found {
+		return ""
+	}
+
+	return operationConfig.CustomCheckRequiredFieldsMissingMethod
+}
+
+// OperationConfig returns the OperationConfig for a given operation
+func (c *Config) OperationConfig(opID string) (*OperationConfig, bool) {
+	if c == nil {
+		return nil, false
+	}
+	opConfig, ok := c.Operations[opID]
+	return &opConfig, ok
+}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -326,7 +326,7 @@ type ReconcileConfig struct {
 	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
 }
 
-// ResourceConfig returns the ResourceConfig for a given named resource
+// ResourceConfig returns the ResourceConfig for a given resource name
 func (c *Config) ResourceConfig(name string) (*ResourceConfig, bool) {
 	if c == nil {
 		return nil, false
@@ -337,7 +337,7 @@ func (c *Config) ResourceConfig(name string) (*ResourceConfig, bool) {
 
 // UnpacksAttributesMap returns true if the underlying API has
 // Get{Resource}Attributes/Set{Resource}Attributes API calls that map real,
-// schema'd fields to a raw `map[string]*string` for this resource (see SNS and
+// schema'd fields to a raw `map[string]*string` for a given resource name (see SNS and
 // SQS APIs)
 func (c *Config) UnpacksAttributesMap(resourceName string) bool {
 	if c == nil {
@@ -371,18 +371,6 @@ func (c *Config) SetAttributesSingleAttribute(resourceName string) bool {
 		return false
 	}
 	return resGenConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
-}
-
-// OverrideValues gives list of member values to override.
-func (c *Config) OverrideValues(operationName string) (map[string]string, bool) {
-	if c == nil {
-		return nil, false
-	}
-	oConfig, ok := c.Operations[operationName]
-	if !ok {
-		return nil, false
-	}
-	return oConfig.OverrideValues, ok
 }
 
 // ResourceFields returns a map, keyed by target/renamed field name, of
@@ -439,7 +427,7 @@ func (c *Config) GetCompareIgnoredFields(resName string) []string {
 	return rConfig.Compare.Ignore
 }
 
-// IsIgnoredResource returns true if Operation Name is configured to be ignored
+// IsIgnoredResource returns true if resource name is configured to be ignored
 // in generator config for the AWS service
 func (c *Config) IsIgnoredResource(resourceName string) bool {
 	if resourceName == "" {
@@ -634,4 +622,24 @@ func (c *Config) TerminalExceptionCodes(resourceName string) []string {
 		return resGenConfig.Exceptions.TerminalCodes
 	}
 	return nil
+}
+
+// ListOpMatchFieldNames returns a slice of strings representing the field
+// names in the List operation's Output shape's element Shape that we should
+// check a corresponding value in the target Spec exists.
+func (c *Config) ListOpMatchFieldNames(
+	resName string,
+) []string {
+	res := []string{}
+	if c == nil {
+		return res
+	}
+	rConfig, found := c.Resources[resName]
+	if !found {
+		return res
+	}
+	if rConfig.ListOperation == nil {
+		return res
+	}
+	return rConfig.ListOperation.MatchFields
 }

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -16,6 +16,8 @@ package config
 import (
 	"strings"
 
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
@@ -326,6 +328,9 @@ type ReconcileConfig struct {
 
 // ResourceConfig returns the ResourceConfig for a given named resource
 func (c *Config) ResourceConfig(name string) (*ResourceConfig, bool) {
+	if c == nil {
+		return nil, false
+	}
 	rc, ok := c.Resources[name]
 	return &rc, ok
 }
@@ -534,4 +539,99 @@ func (c *Config) GetResourcePrintAddAgeColumn(resourceName string) bool {
 		return rConfig.Print.AddAgeColumn
 	}
 	return false
+}
+
+// UpdateConditionsCustomMethodName returns custom update conditions operation
+// as *string for custom resource, if specified in generator config
+func (c *Config) UpdateConditionsCustomMethodName(resourceName string) string {
+	if c == nil {
+		return ""
+	}
+	resGenConfig, found := c.Resources[resourceName]
+	if !found {
+		return ""
+	}
+	return resGenConfig.UpdateConditionsCustomMethodName
+}
+
+// ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
+// the custom resource as int, if specified in generator config.
+func (c *Config) ReconcileRequeuOnSuccessSeconds(resourceName string) int {
+	if c == nil {
+		return 0
+	}
+	resGenConfig, found := c.Resources[resourceName]
+	if !found {
+		return 0
+	}
+	reconcile := resGenConfig.Reconcile
+	if reconcile != nil {
+		return reconcile.RequeueOnSuccessSeconds
+	}
+	// handles the default case
+	return 0
+}
+
+// CustomUpdateMethodName returns the name of the custom resourceManager method
+// for updating the resource state, if any has been specified in the generator
+// config
+func (c *Config) CustomUpdateMethodName(resourceName string) string {
+	if c == nil {
+		return ""
+	}
+	rConfig, found := c.Resources[resourceName]
+	if found {
+		if rConfig.UpdateOperation != nil {
+			return rConfig.UpdateOperation.CustomMethodName
+		}
+	}
+	return ""
+}
+
+// GetAllRenames returns all of the CRD's field renames observed in the generator config
+// for a given map of operations.
+func (c *Config) GetAllRenames(
+	resourceName string,
+	operations map[string]*awssdkmodel.Operation,
+) (map[string]string, error) {
+	renames := make(map[string]string)
+	if c == nil {
+		return renames, nil
+	}
+	resourceConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return renames, nil
+	}
+	if resourceConfig.Renames == nil || resourceConfig.Renames.Operations == nil {
+		return renames, nil
+	}
+
+	opRenameConfigs := resourceConfig.Renames.Operations
+	for opName, opRenameConfigs := range opRenameConfigs {
+		for _, op := range operations {
+			if opName != op.Name {
+				continue
+			}
+			for old, new := range opRenameConfigs.InputFields {
+				renames[old] = new
+			}
+			for old, new := range opRenameConfigs.OutputFields {
+				renames[old] = new
+			}
+		}
+	}
+	return renames, nil
+}
+
+// TerminalExceptionCodes returns terminal exception codes as
+// []string for custom resource, if specified in generator config
+func (c *Config) TerminalExceptionCodes(resourceName string) []string {
+	if c == nil {
+		return nil
+	}
+	resGenConfig, found := c.Resources[resourceName]
+	if found && resGenConfig.Exceptions != nil {
+		return resGenConfig.Exceptions.TerminalCodes
+	}
+	return nil
 }

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -23,3 +23,16 @@ type APIVersion struct {
 	// One and only one version can be set as the storage version.
 	Storage *bool `json:"storage,omitempty"`
 }
+
+// GetAPIVersions returns the API version(s) for a CRD
+func (c *Config) GetAPIVersions(crdName string) []APIVersion {
+	res := []APIVersion{}
+	if c == nil {
+		return res
+	}
+	resConfig, found := c.Resources[crdName]
+	if !found {
+		return res
+	}
+	return resConfig.APIVersions
+}

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -398,7 +398,7 @@ func (r *CRD) GetPrimaryKeyField() (*Field, error) {
 }
 
 // SetOutputCustomMethodName returns custom set output operation as *string for
-// given operation on custom resource, if specified in generator config
+// given operation on custom resource
 func (r *CRD) SetOutputCustomMethodName(
 	// The operation to look for the Output shape
 	op *awssdkmodel.Operation,
@@ -420,7 +420,7 @@ func (r *CRD) GetOutputShapeGoType(
 }
 
 // GetOutputWrapperFieldPath returns the JSON-Path of the output wrapper field
-// as *string for a given operation, if specified in generator config.
+// as *string for a given operation.
 func (r *CRD) GetOutputWrapperFieldPath(
 	op *awssdkmodel.Operation,
 ) *string {
@@ -428,7 +428,7 @@ func (r *CRD) GetOutputWrapperFieldPath(
 }
 
 // GetOutputShape returns the Output shape for a given operation and applies
-// wrapper field path overrides, if specified in generator config.
+// wrapper field path overrides.
 func (r *CRD) GetOutputShape(
 	op *awssdkmodel.Operation,
 ) (*awssdkmodel.Shape, error) {
@@ -499,13 +499,13 @@ func (r *CRD) GetCustomImplementation(
 }
 
 // UpdateConditionsCustomMethodName returns custom update conditions operation
-// as *string for custom resource, if specified in generator config
+// as *string for custom resource
 func (r *CRD) UpdateConditionsCustomMethodName() string {
 	return r.cfg.UpdateConditionsCustomMethodName(r.Names.Original)
 }
 
 // GetCustomCheckRequiredFieldsMissingMethod returns custom check required fields missing method
-// as string for custom resource, if specified in generator config
+// as string for custom resource
 func (r *CRD) GetCustomCheckRequiredFieldsMissingMethod(
 	// The type of operation
 	op *awssdkmodel.Operation,
@@ -558,7 +558,7 @@ func (r *CRD) PrintAgeColumn() bool {
 }
 
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
-// the custom resource as int, if specified in generator config.
+// the custom resource as int
 func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {
 	return r.cfg.ReconcileRequeuOnSuccessSeconds(r.Names.Original)
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -14,7 +14,7 @@
 package model
 
 // TerminalExceptionCodes returns terminal exception codes as
-// []string for custom resource, if specified in generator config
+// []string for custom resource
 func (r *CRD) TerminalExceptionCodes() []string {
 	return r.cfg.TerminalExceptionCodes(r.Names.Original)
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -16,14 +16,7 @@ package model
 // TerminalExceptionCodes returns terminal exception codes as
 // []string for custom resource, if specified in generator config
 func (r *CRD) TerminalExceptionCodes() []string {
-	if r.cfg == nil {
-		return nil
-	}
-	resGenConfig, found := r.cfg.Resources[r.Names.Original]
-	if found && resGenConfig.Exceptions != nil {
-		return resGenConfig.Exceptions.TerminalCodes
-	}
-	return nil
+	return r.cfg.TerminalExceptionCodes(r.Names.Original)
 }
 
 // ExceptionCode returns the name of the resource's Exception code for the

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -323,19 +323,15 @@ func NewSDKAPI(api *awssdkmodel.API, apiGroupSuffix string) *SDKAPI {
 	}
 }
 
-// Override the operation type and/or resource name if specified in config
+// Override the operation type and/or resource name, if specified in config
 func getOpTypeAndResourceName(opID string, cfg *ackgenconfig.Config) ([]OpType, string) {
 	opType, resName := GetOpTypeAndResourceNameFromOpID(opID, cfg)
 	opTypes := []OpType{opType}
 
-	if cfg == nil {
-		return opTypes, resName
-	}
-	if operationConfig, exists := cfg.Operations[opID]; exists {
+	if operationConfig, exists := cfg.OperationConfig(opID); exists {
 		if operationConfig.ResourceName != "" {
 			resName = operationConfig.ResourceName
 		}
-
 		for _, operationType := range operationConfig.OperationType {
 			opType = OpTypeFromString(operationType)
 			opTypes = append(opTypes, opType)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1184 (task 2; migrating access)

Description of changes:
* copy methods accessing `ackgenconfig` from model package to config package
* update methods in model package to leverage `ackgenconfig` accessors instead of directly accessing config
* align `ackgenconfig` accessors with config types (i.e. methods accessing `c.Resources` go in `pkg/config/resource.go`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
