### PR TITLE
Additional nil checks during reference resolution

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -161,6 +161,9 @@ var (
 		"CheckNilFieldPath": func(f *ackmodel.Field, sourceVarName string) string {
 			return code.CheckNilFieldPath(f, sourceVarName)
 		},
+		"CheckNilReferencesPath": func(f *ackmodel.Field, sourceVarName string) string {
+			return code.CheckNilReferencesPath(f, sourceVarName)
+		},
 	}
 )
 

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -16,9 +16,6 @@ import (
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	ctrlrtmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
-
-	svcresource "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/pkg/resource"
-	svctypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
 {{- /* Import the go types from service controllers whose resources are referenced in this service controller.
 If these referenced types are not added to scheme, this service controller will not be able to read
 resources across service controller. */ -}}
@@ -29,6 +26,9 @@ resources across service controller. */ -}}
 	{{ $referencedServiceName }}apitypes "github.com/aws-controllers-k8s/{{ $referencedServiceName }}-controller/apis/{{ $apiVersion }}"
 {{- end }}
 {{- end }}
+
+	svcresource "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/pkg/resource"
+	svctypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
 	{{/* TODO(a-hilaly): import apis/* packages to register webhooks */}}
 	{{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $servicePackageName }}-controller/pkg/resource/{{ $crdName }}"
 	{{end}}

--- a/templates/pkg/resource/references_read_referenced_resource.go.tpl
+++ b/templates/pkg/resource/references_read_referenced_resource.go.tpl
@@ -42,10 +42,13 @@ Where field is of type 'Field' from aws-controllers-k8s/code-generator/pkg/model
 					"{{ .FieldConfig.References.Resource }}",
 					namespace, *arr.Name)
 			}
-			if obj.{{ .FieldConfig.References.Path }} == nil {
+			{{ $nilCheck := CheckNilReferencesPath . "obj" -}}
+			{{ if not (eq $nilCheck "") -}}
+			if {{ $nilCheck }} {
 				return ackerr.ResourceReferenceMissingTargetFieldFor(
 					"{{ .FieldConfig.References.Resource }}",
 					namespace, *arr.Name,
 					"{{ .FieldConfig.References.Path }}")
 			}
+			{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Description of changes:
* This change adds additional nil checks for `ReferencesConfig.Path` during reference resolution
* This change also fixes import order inside `main.go.tpl`
* I thought of these improvements when adding KMSKey reference inside RDSCluster and RDSInstance.
* Successfully generated rds-controller locally with reference to KMSKey and also tested with existing apigatewayv2 controller which contains the references as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
