### PR TITLE
Align naming and return types for accessors in config package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,19 +106,6 @@ func (c *Config) GetCustomMapFieldMembers() []string {
 	return members
 }
 
-// ResourceContainsSecret returns true if any of the fields in any resource are
-// defined as secrets.
-func (c *Config) ResourceContainsSecret() bool {
-	for _, resource := range c.Resources {
-		for _, field := range resource.Fields {
-			if field.IsSecret {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // New returns a new Config object given a supplied
 // path to a config file
 func New(

--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -99,9 +99,9 @@ func (c *Config) GetOutputWrapperFieldPath(
 	return &opConfig.OutputWrapperFieldPath
 }
 
-// SetOutputCustomMethodName returns custom set output operation as *string for
+// GetSetOutputCustomMethodName returns custom set output operation as *string for
 // given operation on custom resource, if specified in generator config
-func (c *Config) SetOutputCustomMethodName(
+func (c *Config) GetSetOutputCustomMethodName(
 	// The operation to look for the Output shape
 	op *awssdkmodel.Operation,
 ) *string {
@@ -159,7 +159,7 @@ func (c *Config) GetCustomCheckRequiredFieldsMissingMethod(
 }
 
 // OverrideValues returns a list of member values to override for a given operation
-func (c *Config) OverrideValues(operationName string) (map[string]string, bool) {
+func (c *Config) GetOverrideValues(operationName string) (map[string]string, bool) {
 	if c == nil {
 		return nil, false
 	}
@@ -171,7 +171,7 @@ func (c *Config) OverrideValues(operationName string) (map[string]string, bool) 
 }
 
 // OperationConfig returns the OperationConfig for a given operation
-func (c *Config) OperationConfig(opID string) (*OperationConfig, bool) {
+func (c *Config) GetOperationConfig(opID string) (*OperationConfig, bool) {
 	if c == nil {
 		return nil, false
 	}

--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -47,9 +47,9 @@ type OperationConfig struct {
 	OperationType StringArray `json:"operation_type"`
 }
 
-// IsIgnoredOperation returns true if Operation Name is configured to be ignored
+// IsOperationIgnored returns true if Operation Name is configured to be ignored
 // in generator config for the AWS service
-func (c *Config) IsIgnoredOperation(operation *awssdkmodel.Operation) bool {
+func (c *Config) IsOperationIgnored(operation *awssdkmodel.Operation) bool {
 	if c == nil {
 		return false
 	}

--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -47,9 +47,9 @@ type OperationConfig struct {
 	OperationType StringArray `json:"operation_type"`
 }
 
-// IsOperationIgnored returns true if Operation Name is configured to be ignored
+// OperationIsIgnored returns true if Operation Name is configured to be ignored
 // in generator config for the AWS service
-func (c *Config) IsOperationIgnored(operation *awssdkmodel.Operation) bool {
+func (c *Config) OperationIsIgnored(operation *awssdkmodel.Operation) bool {
 	if c == nil {
 		return false
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -409,12 +409,12 @@ func (c *Config) ResourceSetsSingleAttribute(resourceName string) bool {
 }
 
 // GetResourceConfig returns the ResourceConfig for a given resource name
-func (c *Config) GetResourceConfig(name string) (*ResourceConfig, bool) {
+func (c *Config) GetResourceConfig(resourceName string) *ResourceConfig {
 	if c == nil {
-		return nil, false
+		return nil
 	}
-	rc, ok := c.Resources[name]
-	return &rc, ok
+	rc, _ := c.Resources[resourceName]
+	return &rc
 }
 
 // GetResourceFields returns a map, keyed by target/renamed field name, of
@@ -455,13 +455,13 @@ func (c *Config) GetResourceFieldByPath(resourceName string, fieldPath string) *
 	return nil
 }
 
-// GetCompareIgnoredFields returns the list of field path to ignore when
-// comparing two differnt objects
-func (c *Config) GetCompareIgnoredFields(resName string) []string {
+// GetCompareIgnoredFields returns the list of field paths to ignore when
+// comparing two different objects
+func (c *Config) GetCompareIgnoredFields(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
-	rConfig, ok := c.Resources[resName]
+	rConfig, ok := c.Resources[resourceName]
 	if !ok {
 		return nil
 	}
@@ -471,39 +471,38 @@ func (c *Config) GetCompareIgnoredFields(resName string) []string {
 	return rConfig.Compare.Ignore
 }
 
-// GetResourceFieldRename returns the renamed field for a Resource, a
-// supplied Operation ID and original field name and whether or not a renamed
-// override field name was found
-func (c *Config) GetResourceFieldRename(
-	resName string,
+// GetResourceFieldName returns a resource field name
+// after applying rename overrides, if configured
+func (c *Config) GetResourceFieldName(
+	resourceName string,
 	opID string,
 	origFieldName string,
-) (string, bool) {
+) string {
 	if c == nil {
-		return origFieldName, false
+		return origFieldName
 	}
-	rConfig, ok := c.Resources[resName]
+	rConfig, ok := c.Resources[resourceName]
 	if !ok {
-		return origFieldName, false
+		return origFieldName
 	}
 	if rConfig.Renames == nil {
-		return origFieldName, false
+		return origFieldName
 	}
 	oRenames, ok := rConfig.Renames.Operations[opID]
 	if !ok {
-		return origFieldName, false
+		return origFieldName
 	}
 	renamed, ok := oRenames.InputFields[origFieldName]
 	if !ok {
 		renamed, ok = oRenames.OutputFields[origFieldName]
 		if !ok {
-			return origFieldName, false
+			return origFieldName
 		}
 	}
-	return renamed, true
+	return renamed
 }
 
-// ResourceShortNames returns the CRD list of aliases
+// GetResourceShortNames returns the CRD list of aliases
 func (c *Config) GetResourceShortNames(resourceName string) []string {
 	if c == nil {
 		return nil
@@ -543,9 +542,9 @@ func (c *Config) GetUpdateConditionsCustomMethodName(resourceName string) string
 	return resGenConfig.UpdateConditionsCustomMethodName
 }
 
-// GetReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
+// GetReconcileRequeueOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int, if specified in generator config.
-func (c *Config) GetReconcileRequeuOnSuccessSeconds(resourceName string) int {
+func (c *Config) GetReconcileRequeueOnSuccessSeconds(resourceName string) int {
 	if c == nil {
 		return 0
 	}
@@ -582,17 +581,17 @@ func (c *Config) GetCustomUpdateMethodName(resourceName string) string {
 func (c *Config) GetAllRenames(
 	resourceName string,
 	operations map[string]*awssdkmodel.Operation,
-) (map[string]string, error) {
+) map[string]string {
 	renames := make(map[string]string)
 	if c == nil {
-		return renames, nil
+		return renames
 	}
 	resourceConfig, ok := c.Resources[resourceName]
 	if !ok {
-		return renames, nil
+		return renames
 	}
 	if resourceConfig.Renames == nil || resourceConfig.Renames.Operations == nil {
-		return renames, nil
+		return renames
 	}
 
 	opRenameConfigs := resourceConfig.Renames.Operations
@@ -609,7 +608,7 @@ func (c *Config) GetAllRenames(
 			}
 		}
 	}
-	return renames, nil
+	return renames
 }
 
 // GetTerminalExceptionCodes returns terminal exception codes as

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -455,9 +455,9 @@ func (c *Config) GetResourceFieldByPath(resourceName string, fieldPath string) *
 	return nil
 }
 
-// GetCompareIgnoredFields returns the list of field paths to ignore when
+// GetCompareIgnoredFieldPaths returns the list of field paths to ignore when
 // comparing two different objects
-func (c *Config) GetCompareIgnoredFields(resourceName string) []string {
+func (c *Config) GetCompareIgnoredFieldPaths(resourceName string) []string {
 	if c == nil {
 		return nil
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -326,9 +326,9 @@ type ReconcileConfig struct {
 	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
 }
 
-// IsResourceIgnored returns true if resource name is configured to be ignored
+// ResourceIsIgnored returns true if resource name is configured to be ignored
 // in generator config for the AWS service
-func (c *Config) IsResourceIgnored(resourceName string) bool {
+func (c *Config) ResourceIsIgnored(resourceName string) bool {
 	if resourceName == "" {
 		return true
 	}
@@ -338,9 +338,9 @@ func (c *Config) IsResourceIgnored(resourceName string) bool {
 	return util.InStrings(resourceName, c.Ignore.ResourceNames)
 }
 
-// IsResourceAdoptable returns true if resource name is configured to be adoptable.
+// ResourceIsAdoptable returns true if resource name is configured to be adoptable.
 // Default behavior is every resource can be adopted using AdoptionReconciler
-func (c *Config) IsResourceAdoptable(resourceName string) bool {
+func (c *Config) ResourceIsAdoptable(resourceName string) bool {
 	if c == nil {
 		return true
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -326,8 +326,8 @@ type ReconcileConfig struct {
 	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
 }
 
-// ResourceConfig returns the ResourceConfig for a given resource name
-func (c *Config) ResourceConfig(name string) (*ResourceConfig, bool) {
+// GetResourceConfig returns the ResourceConfig for a given resource name
+func (c *Config) GetResourceConfig(name string) (*ResourceConfig, bool) {
 	if c == nil {
 		return nil, false
 	}
@@ -357,12 +357,12 @@ func (c *Config) UnpacksAttributesMap(resourceName string) bool {
 	return false
 }
 
-// SetAttributesSingleAttribute returns true if the supplied resource name has
+// GetSetAttributesSingleAttribute returns true if the supplied resource name has
 // a SetAttributes operation that only actually changes a single attribute at a
 // time. See: SNS SetTopicAttributes API call, which is entirely different from
 // the SNS SetPlatformApplicationAttributes API call, which sets multiple
 // attributes at once. :shrug:
-func (c *Config) SetAttributesSingleAttribute(resourceName string) bool {
+func (c *Config) GetSetAttributesSingleAttribute(resourceName string) bool {
 	if c == nil {
 		return false
 	}
@@ -373,10 +373,10 @@ func (c *Config) SetAttributesSingleAttribute(resourceName string) bool {
 	return resGenConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
 }
 
-// ResourceFields returns a map, keyed by target/renamed field name, of
+// GetResourceFields returns a map, keyed by target/renamed field name, of
 // FieldConfig struct pointers that instruct the code generator how to handle
 // the interpretation of special Resource fields (both Spec and Status)
-func (c *Config) ResourceFields(resourceName string) map[string]*FieldConfig {
+func (c *Config) GetResourceFields(resourceName string) map[string]*FieldConfig {
 	if c == nil {
 		return map[string]*FieldConfig{}
 	}
@@ -387,10 +387,10 @@ func (c *Config) ResourceFields(resourceName string) map[string]*FieldConfig {
 	return resourceConfig.Fields
 }
 
-// ResourceFieldByPath returns the FieldConfig for a field from
+// GetResourceFieldByPath returns the FieldConfig for a field from
 // "resourceName" crd, where field.Path matches the passed "fieldPath" parameter.
 // This method performs the case-insensitive resource and fieldPath lookup.
-func (c *Config) ResourceFieldByPath(resourceName string, fieldPath string) *FieldConfig {
+func (c *Config) GetResourceFieldByPath(resourceName string, fieldPath string) *FieldConfig {
 	var resourceConfig ResourceConfig
 	if c == nil {
 		return nil
@@ -439,10 +439,10 @@ func (c *Config) IsIgnoredResource(resourceName string) bool {
 	return util.InStrings(resourceName, c.Ignore.ResourceNames)
 }
 
-// ResourceFieldRename returns the renamed field for a Resource, a
+// GetResourceFieldRename returns the renamed field for a Resource, a
 // supplied Operation ID and original field name and whether or not a renamed
 // override field name was found
-func (c *Config) ResourceFieldRename(
+func (c *Config) GetResourceFieldRename(
 	resName string,
 	opID string,
 	origFieldName string,
@@ -472,7 +472,7 @@ func (c *Config) ResourceFieldRename(
 }
 
 // ResourceShortNames returns the CRD list of aliases
-func (c *Config) ResourceShortNames(resourceName string) []string {
+func (c *Config) GetResourceShortNames(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
@@ -529,9 +529,9 @@ func (c *Config) GetResourcePrintAddAgeColumn(resourceName string) bool {
 	return false
 }
 
-// UpdateConditionsCustomMethodName returns custom update conditions operation
+// GetUpdateConditionsCustomMethodName returns custom update conditions operation
 // as *string for custom resource, if specified in generator config
-func (c *Config) UpdateConditionsCustomMethodName(resourceName string) string {
+func (c *Config) GetUpdateConditionsCustomMethodName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
@@ -542,9 +542,9 @@ func (c *Config) UpdateConditionsCustomMethodName(resourceName string) string {
 	return resGenConfig.UpdateConditionsCustomMethodName
 }
 
-// ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
+// GetReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int, if specified in generator config.
-func (c *Config) ReconcileRequeuOnSuccessSeconds(resourceName string) int {
+func (c *Config) GetReconcileRequeuOnSuccessSeconds(resourceName string) int {
 	if c == nil {
 		return 0
 	}
@@ -560,10 +560,10 @@ func (c *Config) ReconcileRequeuOnSuccessSeconds(resourceName string) int {
 	return 0
 }
 
-// CustomUpdateMethodName returns the name of the custom resourceManager method
+// GetCustomUpdateMethodName returns the name of the custom resourceManager method
 // for updating the resource state, if any has been specified in the generator
 // config
-func (c *Config) CustomUpdateMethodName(resourceName string) string {
+func (c *Config) GetCustomUpdateMethodName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
@@ -611,9 +611,9 @@ func (c *Config) GetAllRenames(
 	return renames, nil
 }
 
-// TerminalExceptionCodes returns terminal exception codes as
+// GetTerminalExceptionCodes returns terminal exception codes as
 // []string for custom resource, if specified in generator config
-func (c *Config) TerminalExceptionCodes(resourceName string) []string {
+func (c *Config) GetTerminalExceptionCodes(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
@@ -624,10 +624,10 @@ func (c *Config) TerminalExceptionCodes(resourceName string) []string {
 	return nil
 }
 
-// ListOpMatchFieldNames returns a slice of strings representing the field
+// GetListOpMatchFieldNames returns a slice of strings representing the field
 // names in the List operation's Output shape's element Shape that we should
 // check a corresponding value in the target Spec exists.
-func (c *Config) ListOpMatchFieldNames(
+func (c *Config) GetListOpMatchFieldNames(
 	resName string,
 ) []string {
 	res := []string{}

--- a/pkg/generate/code/check.go
+++ b/pkg/generate/code/check.go
@@ -39,8 +39,8 @@ func CheckExceptionMessage(
 	r *model.CRD,
 	httpStatusCode int,
 ) string {
-	rConfig, ok := cfg.GetResourceConfig(r.Names.Original)
-	if ok && rConfig.Exceptions != nil {
+	rConfig := cfg.GetResourceConfig(r.Names.Original)
+	if rConfig != nil && rConfig.Exceptions != nil {
 		excConfig, ok := rConfig.Exceptions.Errors[httpStatusCode]
 		if !ok {
 			return ""

--- a/pkg/generate/code/check.go
+++ b/pkg/generate/code/check.go
@@ -39,7 +39,7 @@ func CheckExceptionMessage(
 	r *model.CRD,
 	httpStatusCode int,
 ) string {
-	rConfig, ok := cfg.ResourceConfig(r.Names.Original)
+	rConfig, ok := cfg.GetResourceConfig(r.Names.Original)
 	if ok && rConfig.Exceptions != nil {
 		excConfig, ok := rConfig.Exceptions.Errors[httpStatusCode]
 		if !ok {

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -112,7 +112,7 @@ func FindPluralizedIdentifiersInShape(
 			// If the identifier field is renamed, we must take that into
 			// consideration in order to find the corresponding matching
 			// shapeIdentifier.
-			siRenamed, _ := r.Config().ResourceFieldRename(
+			siRenamed, _ := r.Config().GetResourceFieldRename(
 				r.Names.Original,
 				op.Name,
 				pluralize.Singular(si),
@@ -191,7 +191,7 @@ func FindPrimaryIdentifierFieldNames(
 			panic("Could not find corresponding spec or status field " +
 				"for primary identifier " + shapeField)
 		}
-		crField, _ = cfg.ResourceFieldRename(
+		crField, _ = cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			shapeField,

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -54,7 +54,7 @@ func FindIdentifiersInShape(
 
 	// Handles field renames
 	opType, _ := model.GetOpTypeAndResourceNameFromOpID(op.Name, r.Config())
-	renames, _ := r.GetAllRenames(opType)
+	renames := r.GetAllRenames(opType)
 	for _, memberName := range shape.MemberNames() {
 		lookupName := memberName
 		if renamedName, found := renames[memberName]; found {
@@ -111,8 +111,9 @@ func FindPluralizedIdentifiersInShape(
 		for _, ci := range crIdentifiers {
 			// If the identifier field is renamed, we must take that into
 			// consideration in order to find the corresponding matching
-			// shapeIdentifier.
-			siRenamed, _ := r.Config().GetResourceFieldRename(
+			// shapeIdentifier. Fetch field name from the config to apply
+			// renames, if applicable
+			siRenamed := r.Config().GetResourceFieldName(
 				r.Names.Original,
 				op.Name,
 				pluralize.Singular(si),
@@ -191,7 +192,8 @@ func FindPrimaryIdentifierFieldNames(
 			panic("Could not find corresponding spec or status field " +
 				"for primary identifier " + shapeField)
 		}
-		crField, _ = cfg.GetResourceFieldRename(
+		// Fetch field name from config to apply renames, if applicable
+		crField = cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			shapeField,

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -94,7 +94,7 @@ func CompareResource(
 ) string {
 	out := "\n"
 
-	fieldConfigs := cfg.ResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
 
 	// We need a deterministic order to traverse our top-level fields...
 	specFieldNames := []string{}
@@ -544,7 +544,7 @@ func CompareStruct(
 ) string {
 	out := ""
 
-	fieldConfigs := cfg.ResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
 
 	for _, memberName := range shape.MemberNames() {
 		memberShapeRef := shape.MemberRefs[memberName]

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -56,7 +56,7 @@ func getSortedLateInitFieldsAndConfig(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 ) ([]string, map[string]*ackgenconfig.LateInitializeConfig) {
-	fieldNameToConfig := cfg.ResourceFields(r.Names.Original)
+	fieldNameToConfig := cfg.GetResourceFields(r.Names.Original)
 	fieldNameToLateInitConfig := make(map[string]*ackgenconfig.LateInitializeConfig)
 	sortedLateInitFieldNames := make([]string, 0)
 	if len(fieldNameToConfig) > 0 {

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -31,7 +31,7 @@ func Test_FindLateInitializedFieldNames_EmptyFieldConfig(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// NO fieldConfig
-	assert.Empty(crd.Config().ResourceFields(crd.Names.Original))
+	assert.Empty(crd.Config().GetResourceFields(crd.Names.Original))
 	expected :=
 		`	var lateInitializeFieldNames = []string{}
 `
@@ -47,8 +47,8 @@ func Test_FindLateInitializedFieldNames_NoLateInitializations(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// FieldConfig without lateInitialize
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
-	assert.Nil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
+	assert.Nil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
 	expected :=
 		`	var lateInitializeFieldNames = []string{}
 `
@@ -63,10 +63,10 @@ func Test_FindLateInitializedFieldNames(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"])
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
 		`	var lateInitializeFieldNames = []string{"ImageTagMutability","Name",}
 `
@@ -82,7 +82,7 @@ func Test_LateInitializeFromReadOne_NoFieldsToLateInitialize(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// NO fieldConfig
-	assert.Empty(crd.Config().ResourceFields(crd.Names.Original))
+	assert.Empty(crd.Config().GetResourceFields(crd.Names.Original))
 	expected := "	return latest"
 	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "latest", 1))
 }
@@ -95,10 +95,10 @@ func Test_LateInitializeFromReadOne_NonNestedPath(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"])
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
 		`	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
@@ -120,10 +120,10 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 		`	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
@@ -188,10 +188,10 @@ func Test_IncompleteLateInitialization(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().ResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 		`	ko := rm.concreteResource(latest).ko.DeepCopy()
 	if ko.Spec.ImageScanningConfiguration != nil {

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -189,7 +189,7 @@ func SetResource(
 		targetAdaptedVarName := targetVarName
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.ResourceFieldRename(
+		fieldName, _ := cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -523,7 +523,7 @@ func setResourceReadMany(
 		targetAdaptedVarName := targetVarName
 
 		// Handles field renames, if applicable
-		fieldName, foundFieldRename := cfg.ResourceFieldRename(
+		fieldName, foundFieldRename := cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -763,7 +763,7 @@ func SetResourceGetAttributes(
 
 	// did we output an ACKResourceMetadata guard and constructor snippet?
 	mdGuardOut := false
-	fieldConfigs := cfg.ResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
 	sortedAttrFieldNames := []string{}
 	for fName, fConfig := range fieldConfigs {
 		if fConfig.IsAttribute {
@@ -990,7 +990,7 @@ func SetResourceIdentifiers(
 		}
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.ResourceFieldRename(
+		fieldName, _ := cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			memberName,

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -189,7 +189,7 @@ func SetResource(
 		targetAdaptedVarName := targetVarName
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.GetResourceFieldRename(
+		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -523,7 +523,7 @@ func setResourceReadMany(
 		targetAdaptedVarName := targetVarName
 
 		// Handles field renames, if applicable
-		fieldName, foundFieldRename := cfg.GetResourceFieldRename(
+		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -535,11 +535,6 @@ func setResourceReadMany(
 		} else if inStatus {
 			targetAdaptedVarName += cfg.PrefixConfig.StatusField
 			f = r.StatusFields[fieldName]
-		} else if foundFieldRename {
-			msg := fmt.Sprintf(
-				"Field rename %s for operation %s is not part of %s Spec or"+
-					" Status fields", memberName, op.Name, r.Names.Camel)
-			panic(msg)
 		} else {
 			// field not found in Spec or Status
 			continue
@@ -990,7 +985,7 @@ func SetResourceIdentifiers(
 		}
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.GetResourceFieldRename(
+		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			memberName,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -136,7 +136,7 @@ func SetSDK(
 		// attrMap["KmsMasterKeyId"] = r.ko.Spec.KMSMasterKeyID
 		// attrMap["Policy"] = r.ko.Spec.Policy
 		// res.SetAttributes(attrMap)
-		fieldConfigs := cfg.ResourceFields(r.Names.Original)
+		fieldConfigs := cfg.GetResourceFields(r.Names.Original)
 		out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
 		sortedAttrFieldNames := []string{}
 		for fName, fConfig := range fieldConfigs {
@@ -166,7 +166,7 @@ func SetSDK(
 		out += fmt.Sprintf("%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
 	}
 
-	opConfig, override := cfg.OverrideValues(op.Name)
+	opConfig, override := cfg.GetOverrideValues(op.Name)
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
@@ -215,7 +215,7 @@ func SetSDK(
 		sourceAdaptedVarName := sourceVarName
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.ResourceFieldRename(
+		fieldName, _ := cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -647,7 +647,7 @@ func SetSDKSetAttributes(
 			//     attrMap["Policy"] = r.ko.Spec.Policy
 			// }
 			// res.SetAttributes(attrMap)
-			fieldConfigs := cfg.ResourceFields(r.Names.Original)
+			fieldConfigs := cfg.GetResourceFields(r.Names.Original)
 			out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
 			sortedAttrFieldNames := []string{}
 			for fName, fConfig := range fieldConfigs {
@@ -755,7 +755,7 @@ func setSDKReadMany(
 	indent := strings.Repeat("\t", indentLevel)
 
 	resVarPath := ""
-	opConfig, override := cfg.OverrideValues(op.Name)
+	opConfig, override := cfg.GetOverrideValues(op.Name)
 	var err error
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if override {
@@ -778,7 +778,7 @@ func setSDKReadMany(
 		}
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.ResourceFieldRename(
+		fieldName, _ := cfg.GetResourceFieldRename(
 			r.Names.Original,
 			op.Name,
 			memberName,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -215,7 +215,7 @@ func SetSDK(
 		sourceAdaptedVarName := sourceVarName
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.GetResourceFieldRename(
+		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			memberName,
@@ -778,7 +778,7 @@ func setSDKReadMany(
 		}
 
 		// Handles field renames, if applicable
-		fieldName, _ := cfg.GetResourceFieldRename(
+		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
 			op.Name,
 			memberName,

--- a/pkg/generate/code/synced.go
+++ b/pkg/generate/code/synced.go
@@ -57,8 +57,8 @@ func ResourceIsSynced(
 	indentLevel int,
 ) string {
 	out := "\n"
-	resConfig, ok := cfg.GetResourceConfig(r.Names.Original)
-	if !ok || resConfig.Synced == nil || len(resConfig.Synced.When) == 0 {
+	resConfig := cfg.GetResourceConfig(r.Names.Original)
+	if resConfig == nil || resConfig.Synced == nil || len(resConfig.Synced.When) == 0 {
 		return out
 	}
 

--- a/pkg/generate/code/synced.go
+++ b/pkg/generate/code/synced.go
@@ -57,7 +57,7 @@ func ResourceIsSynced(
 	indentLevel int,
 ) string {
 	out := "\n"
-	resConfig, ok := cfg.ResourceConfig(r.Names.Original)
+	resConfig, ok := cfg.GetResourceConfig(r.Names.Original)
 	if !ok || resConfig.Synced == nil || len(resConfig.Synced.When) == 0 {
 		return out
 	}

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -261,7 +261,7 @@ func (r *CRD) SpecFieldNames() []string {
 // schema'd fields to a raw `map[string]*string` for this resource (see SNS and
 // SQS APIs)
 func (r *CRD) UnpacksAttributesMap() bool {
-	return r.cfg.UnpacksAttributesMap(r.Names.Original)
+	return r.cfg.ResourceContainsAttributesMap(r.Names.Original)
 }
 
 // CompareIgnoredFields returns the list of fields compare logic should ignore
@@ -275,14 +275,14 @@ func (r *CRD) CompareIgnoredFields() []string {
 // the SNS SetPlatformApplicationAttributes API call, which sets multiple
 // attributes at once. :shrug:
 func (r *CRD) SetAttributesSingleAttribute() bool {
-	return r.cfg.GetSetAttributesSingleAttribute(r.Names.Original)
+	return r.cfg.ResourceSetsSingleAttribute(r.Names.Original)
 }
 
 // UnpackAttributes grabs instructions about fields that are represented in the
 // AWS API as a `map[string]*string` but are actually real, schema'd fields and
 // adds Field definitions for those fields.
 func (r *CRD) UnpackAttributes() {
-	if !r.cfg.UnpacksAttributesMap(r.Names.Original) {
+	if !r.cfg.ResourceContainsAttributesMap(r.Names.Original) {
 		return
 	}
 	fieldConfigs := r.cfg.GetResourceFields(r.Names.Original)
@@ -539,7 +539,7 @@ func (r *CRD) SpecIdentifierField() *string {
 
 // IsAdoptable returns true if the resource can be adopted
 func (r *CRD) IsAdoptable() bool {
-	return r.cfg.ResourceIsAdoptable(r.Names.Original)
+	return r.cfg.IsResourceAdoptable(r.Names.Original)
 }
 
 // GetResourcePrintOrderByName returns the Printer Column order-by field name
@@ -554,7 +554,7 @@ func (r *CRD) GetResourcePrintOrderByName() string {
 // PrintAgeColumn returns whether the code generator should append 'Age'
 // kubebuilder:printcolumn comment marker
 func (r *CRD) PrintAgeColumn() bool {
-	return r.cfg.GetResourcePrintAddAgeColumn(r.Names.Camel)
+	return r.cfg.ResourceDisplaysAgeColumn(r.Names.Camel)
 }
 
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -266,7 +266,7 @@ func (r *CRD) UnpacksAttributesMap() bool {
 
 // CompareIgnoredFields returns the list of fields compare logic should ignore
 func (r *CRD) CompareIgnoredFields() []string {
-	return r.cfg.GetCompareIgnoredFields(r.Names.Original)
+	return r.cfg.GetCompareIgnoredFieldPaths(r.Names.Original)
 }
 
 // SetAttributesSingleAttribute returns true if the supplied resource name has

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -200,7 +200,7 @@ func (r *CRD) AddSpecField(
 	shapeRef *awssdkmodel.ShapeRef,
 ) {
 	fPath := memberNames.Camel
-	fConfig := r.cfg.ResourceFieldByPath(r.Names.Original, fPath)
+	fConfig := r.cfg.GetResourceFieldByPath(r.Names.Original, fPath)
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
 	if fConfig != nil && fConfig.Print != nil {
 		r.addSpecPrintableColumn(f)
@@ -225,7 +225,7 @@ func (r *CRD) AddStatusField(
 	shapeRef *awssdkmodel.ShapeRef,
 ) {
 	fPath := memberNames.Camel
-	fConfig := r.cfg.ResourceFieldByPath(r.Names.Original, fPath)
+	fConfig := r.cfg.GetResourceFieldByPath(r.Names.Original, fPath)
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
 	if fConfig != nil && fConfig.Print != nil {
 		r.addStatusPrintableColumn(f)
@@ -275,7 +275,7 @@ func (r *CRD) CompareIgnoredFields() []string {
 // the SNS SetPlatformApplicationAttributes API call, which sets multiple
 // attributes at once. :shrug:
 func (r *CRD) SetAttributesSingleAttribute() bool {
-	return r.cfg.SetAttributesSingleAttribute(r.Names.Original)
+	return r.cfg.GetSetAttributesSingleAttribute(r.Names.Original)
 }
 
 // UnpackAttributes grabs instructions about fields that are represented in the
@@ -285,7 +285,7 @@ func (r *CRD) UnpackAttributes() {
 	if !r.cfg.UnpacksAttributesMap(r.Names.Original) {
 		return
 	}
-	fieldConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fieldConfigs := r.cfg.GetResourceFields(r.Names.Original)
 	for fieldName, fieldConfig := range fieldConfigs {
 		if !fieldConfig.IsAttribute {
 			continue
@@ -313,7 +313,7 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 	if !r.cfg.IncludeACKMetadata {
 		return false
 	}
-	fieldConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fieldConfigs := r.cfg.GetResourceFields(r.Names.Original)
 	for fName, fConfig := range fieldConfigs {
 		if fConfig.IsARN {
 			return strings.EqualFold(fieldName, fName)
@@ -326,7 +326,7 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 // IsSecretField returns true if the supplied field *path* refers to a Field
 // that is a SecretKeyReference
 func (r *CRD) IsSecretField(path string) bool {
-	fConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
 	fConfig, found := fConfigs[path]
 	if found {
 		return fConfig.IsSecret
@@ -336,7 +336,7 @@ func (r *CRD) IsSecretField(path string) bool {
 
 // GetImmutableFieldPaths returns list of immutable field paths present in CRD
 func (r *CRD) GetImmutableFieldPaths() []string {
-	fConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
 	var immutableFields []string
 
 	for field, fieldConfig := range fConfigs {
@@ -350,7 +350,7 @@ func (r *CRD) GetImmutableFieldPaths() []string {
 
 // HasImmutableFieldChanges helper function that return true if there are any immutable field changes
 func (r *CRD) HasImmutableFieldChanges() bool {
-	fConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
 	for _, fieldConfig := range fConfigs {
 		if fieldConfig.IsImmutable {
 			return true
@@ -362,7 +362,7 @@ func (r *CRD) HasImmutableFieldChanges() bool {
 // IsARNPrimaryKey returns true if the CRD uses its ARN as its primary key in
 // ReadOne calls.
 func (r *CRD) IsARNPrimaryKey() bool {
-	resGenConfig, found := r.cfg.ResourceConfig(r.Names.Original)
+	resGenConfig, found := r.cfg.GetResourceConfig(r.Names.Original)
 	if !found {
 		return false
 	}
@@ -372,7 +372,7 @@ func (r *CRD) IsARNPrimaryKey() bool {
 // GetPrimaryKeyField returns the field designated as the primary key, nil if
 // none are specified or an error if multiple are designated.
 func (r *CRD) GetPrimaryKeyField() (*Field, error) {
-	fConfigs := r.cfg.ResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
 
 	var primaryField *Field
 	for fieldName, fieldConfig := range fConfigs {
@@ -403,7 +403,7 @@ func (r *CRD) SetOutputCustomMethodName(
 	// The operation to look for the Output shape
 	op *awssdkmodel.Operation,
 ) *string {
-	return r.cfg.SetOutputCustomMethodName(op)
+	return r.cfg.GetSetOutputCustomMethodName(op)
 }
 
 // GetOutputShapeGoType returns the Go type of the supplied operation's Output
@@ -501,7 +501,7 @@ func (r *CRD) GetCustomImplementation(
 // UpdateConditionsCustomMethodName returns custom update conditions operation
 // as *string for custom resource
 func (r *CRD) UpdateConditionsCustomMethodName() string {
-	return r.cfg.UpdateConditionsCustomMethodName(r.Names.Original)
+	return r.cfg.GetUpdateConditionsCustomMethodName(r.Names.Original)
 }
 
 // GetCustomCheckRequiredFieldsMissingMethod returns custom check required fields missing method
@@ -516,7 +516,7 @@ func (r *CRD) GetCustomCheckRequiredFieldsMissingMethod(
 // SpecIdentifierField returns the name of the "Name" or string identifier field
 // in the Spec.
 func (r *CRD) SpecIdentifierField() *string {
-	rConfig, found := r.cfg.ResourceConfig(r.Names.Original)
+	rConfig, found := r.cfg.GetResourceConfig(r.Names.Original)
 	if found {
 		for fName, fConfig := range rConfig.Fields {
 			if fConfig.IsPrimaryKey {
@@ -560,21 +560,21 @@ func (r *CRD) PrintAgeColumn() bool {
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int
 func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {
-	return r.cfg.ReconcileRequeuOnSuccessSeconds(r.Names.Original)
+	return r.cfg.GetReconcileRequeuOnSuccessSeconds(r.Names.Original)
 }
 
 // CustomUpdateMethodName returns the name of the custom resourceManager method
 // for updating the resource state, if any has been specified in the generator
 // config
 func (r *CRD) CustomUpdateMethodName() string {
-	return r.cfg.CustomUpdateMethodName(r.Names.Original)
+	return r.cfg.GetCustomUpdateMethodName(r.Names.Original)
 }
 
 // ListOpMatchFieldNames returns a slice of strings representing the field
 // names in the List operation's Output shape's element Shape that we should
 // check a corresponding value in the target Spec exists.
 func (r *CRD) ListOpMatchFieldNames() []string {
-	return r.cfg.ListOpMatchFieldNames(r.Names.Original)
+	return r.cfg.GetListOpMatchFieldNames(r.Names.Original)
 }
 
 // GetAllRenames returns all the field renames observed in the generator config
@@ -630,7 +630,7 @@ func (r *CRD) GetSanitizedMemberPath(
 	cfg := r.Config()
 
 	// Handles field renames, if applicable
-	fieldName, fieldRenamed := cfg.ResourceFieldRename(
+	fieldName, fieldRenamed := cfg.GetResourceFieldRename(
 		r.Names.Original,
 		op.Name,
 		memberName,
@@ -657,7 +657,7 @@ func (r *CRD) HasMember(
 	memberName string,
 	operationName string,
 ) (inSpec bool, inStatus bool) {
-	fieldName, _ := r.Config().ResourceFieldRename(
+	fieldName, _ := r.Config().GetResourceFieldRename(
 		r.Names.Original,
 		operationName,
 		memberName,
@@ -736,6 +736,6 @@ func NewCRD(
 		SpecFields:               map[string]*Field{},
 		StatusFields:             map[string]*Field{},
 		Fields:                   map[string]*Field{},
-		ShortNames:               cfg.ResourceShortNames(kind),
+		ShortNames:               cfg.GetResourceShortNames(kind),
 	}
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -539,7 +539,7 @@ func (r *CRD) SpecIdentifierField() *string {
 
 // IsAdoptable returns true if the resource can be adopted
 func (r *CRD) IsAdoptable() bool {
-	return r.cfg.IsResourceAdoptable(r.Names.Original)
+	return r.cfg.ResourceIsAdoptable(r.Names.Original)
 }
 
 // GetResourcePrintOrderByName returns the Printer Column order-by field name

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -16,7 +16,7 @@ package model
 // TerminalExceptionCodes returns terminal exception codes as
 // []string for custom resource
 func (r *CRD) TerminalExceptionCodes() []string {
-	return r.cfg.TerminalExceptionCodes(r.Names.Original)
+	return r.cfg.GetTerminalExceptionCodes(r.Names.Original)
 }
 
 // ExceptionCode returns the name of the resource's Exception code for the

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -275,7 +275,7 @@ func NewField(
 				cleanMemberNames := names.New(memberName)
 				memberPath := path + "." + cleanMemberNames.Camel
 				memberShape := containerShape.MemberRefs[memberName]
-				fConfigs := crd.cfg.ResourceFields(crd.Names.Original)
+				fConfigs := crd.cfg.GetResourceFields(crd.Names.Original)
 				memberField := NewField(
 					crd, memberPath, cleanMemberNames, memberShape, fConfigs[memberPath],
 				)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -92,7 +92,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 	setAttributesOps := (*opMap)[OpTypeSetAttributes]
 
 	for crdName, createOp := range createOps {
-		if m.cfg.IsIgnoredResource(crdName) {
+		if m.cfg.IsResourceIgnored(crdName) {
 			continue
 		}
 		crdNames := names.New(crdName)
@@ -127,7 +127,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			)
 			memberNames := names.New(fieldName)
 			memberNames.ModelOriginal = memberName
-			if memberName == "Attributes" && m.cfg.UnpacksAttributesMap(crdName) {
+			if memberName == "Attributes" && m.cfg.ResourceContainsAttributesMap(crdName) {
 				crd.UnpackAttributes()
 				continue
 			}
@@ -225,7 +225,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			memberNames := names.New(fieldName)
 
 			//TODO:(brycahta) should we support overriding these fields?
-			if memberName == "Attributes" && m.cfg.UnpacksAttributesMap(crdName) {
+			if memberName == "Attributes" && m.cfg.ResourceContainsAttributesMap(crdName) {
 				continue
 			}
 			if crd.IsPrimaryARNField(memberName) {
@@ -301,25 +301,25 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 // operations to nil that are configured to be ignored in generator config for
 // the AWS service
 func (m *Model) RemoveIgnoredOperations(ops *Ops) {
-	if m.cfg.IsIgnoredOperation(ops.Create) {
+	if m.cfg.IsOperationIgnored(ops.Create) {
 		ops.Create = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.ReadOne) {
+	if m.cfg.IsOperationIgnored(ops.ReadOne) {
 		ops.ReadOne = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.ReadMany) {
+	if m.cfg.IsOperationIgnored(ops.ReadMany) {
 		ops.ReadMany = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.Update) {
+	if m.cfg.IsOperationIgnored(ops.Update) {
 		ops.Update = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.Delete) {
+	if m.cfg.IsOperationIgnored(ops.Delete) {
 		ops.Delete = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.GetAttributes) {
+	if m.cfg.IsOperationIgnored(ops.GetAttributes) {
 		ops.GetAttributes = nil
 	}
-	if m.cfg.IsIgnoredOperation(ops.SetAttributes) {
+	if m.cfg.IsOperationIgnored(ops.SetAttributes) {
 		ops.SetAttributes = nil
 	}
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -92,7 +92,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 	setAttributesOps := (*opMap)[OpTypeSetAttributes]
 
 	for crdName, createOp := range createOps {
-		if m.cfg.IsResourceIgnored(crdName) {
+		if m.cfg.ResourceIsIgnored(crdName) {
 			continue
 		}
 		crdNames := names.New(crdName)
@@ -301,25 +301,25 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 // operations to nil that are configured to be ignored in generator config for
 // the AWS service
 func (m *Model) RemoveIgnoredOperations(ops *Ops) {
-	if m.cfg.IsOperationIgnored(ops.Create) {
+	if m.cfg.OperationIsIgnored(ops.Create) {
 		ops.Create = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.ReadOne) {
+	if m.cfg.OperationIsIgnored(ops.ReadOne) {
 		ops.ReadOne = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.ReadMany) {
+	if m.cfg.OperationIsIgnored(ops.ReadMany) {
 		ops.ReadMany = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.Update) {
+	if m.cfg.OperationIsIgnored(ops.Update) {
 		ops.Update = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.Delete) {
+	if m.cfg.OperationIsIgnored(ops.Delete) {
 		ops.Delete = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.GetAttributes) {
+	if m.cfg.OperationIsIgnored(ops.GetAttributes) {
 		ops.GetAttributes = nil
 	}
-	if m.cfg.IsOperationIgnored(ops.SetAttributes) {
+	if m.cfg.OperationIsIgnored(ops.SetAttributes) {
 		ops.SetAttributes = nil
 	}
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -120,7 +120,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 				return nil, ErrNilShapePointer
 			}
 			// Handles field renames, if applicable
-			fieldName, _ := m.cfg.GetResourceFieldRename(
+			fieldName := m.cfg.GetResourceFieldName(
 				crd.Names.Original,
 				createOp.Name,
 				memberName,
@@ -212,7 +212,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			}
 			// Check that the field in the output shape isn't the same as
 			// fields in the input shape (handles field renames, if applicable)
-			fieldName, _ := m.cfg.GetResourceFieldRename(
+			fieldName := m.cfg.GetResourceFieldName(
 				crd.Names.Original,
 				createOp.Name,
 				memberName,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -120,7 +120,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 				return nil, ErrNilShapePointer
 			}
 			// Handles field renames, if applicable
-			fieldName, _ := m.cfg.ResourceFieldRename(
+			fieldName, _ := m.cfg.GetResourceFieldRename(
 				crd.Names.Original,
 				createOp.Name,
 				memberName,
@@ -136,7 +136,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now any additional Spec fields that are required from other API
 		// operations.
-		for targetFieldName, fieldConfig := range m.cfg.ResourceFields(crdName) {
+		for targetFieldName, fieldConfig := range m.cfg.GetResourceFields(crdName) {
 			if fieldConfig.IsReadOnly {
 				// It's a Status field...
 				continue
@@ -212,7 +212,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			}
 			// Check that the field in the output shape isn't the same as
 			// fields in the input shape (handles field renames, if applicable)
-			fieldName, _ := m.cfg.ResourceFieldRename(
+			fieldName, _ := m.cfg.GetResourceFieldRename(
 				crd.Names.Original,
 				createOp.Name,
 				memberName,
@@ -238,7 +238,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now add the additional Status fields that are required from other
 		// API operations.
-		for targetFieldName, fieldConfig := range m.cfg.ResourceFields(crdName) {
+		for targetFieldName, fieldConfig := range m.cfg.GetResourceFields(crdName) {
 			if !fieldConfig.IsReadOnly {
 				// It's a Spec field...
 				continue
@@ -700,7 +700,7 @@ func (m *Model) processField(
 	fieldShape := fieldShapeRef.Shape
 	fieldShapeType := fieldShape.Type
 	fieldPath := parentFieldPath + fieldNames.Camel
-	fieldConfig := crd.Config().ResourceFieldByPath(crd.Names.Original, fieldPath)
+	fieldConfig := crd.Config().GetResourceFieldByPath(crd.Names.Original, fieldPath)
 	field := NewField(crd, fieldPath, fieldNames, fieldShapeRef, fieldConfig)
 	switch fieldShapeType {
 	case "structure":

--- a/pkg/model/multiversion/delta.go
+++ b/pkg/model/multiversion/delta.go
@@ -69,15 +69,8 @@ type CRDDelta struct {
 // spec and status fields deltas. src is the CRD of the spoke (source) version
 // and dst is the CRD of the hub (destination) version.
 func ComputeCRDFieldDeltas(src, dst *ackmodel.CRD) (*CRDDelta, error) {
-	dstRenames, err := dst.GetAllRenames(ackmodel.OpTypeCreate)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get resource field renames: %s", err)
-	}
-
-	srcRenames, err := src.GetAllRenames(ackmodel.OpTypeCreate)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get resource field renames: %s", err)
-	}
+	dstRenames := dst.GetAllRenames(ackmodel.OpTypeCreate)
+	srcRenames := src.GetAllRenames(ackmodel.OpTypeCreate)
 
 	renames, err := ComputeRenamesDelta(srcRenames, dstRenames)
 	if err != nil {

--- a/pkg/model/multiversion/delta_test.go
+++ b/pkg/model/multiversion/delta_test.go
@@ -385,10 +385,10 @@ func TestComputeFieldsDiff_ECR(t *testing.T) {
 				field.ShapeRef.Shape = newEmptyStructShape(tt.args.src.mutateShape)
 			}
 
-			srcRenames, err := srcCRD.GetAllRenames(ackmodel.OpTypeCreate)
-			require.Nil(err)
-			dstRenames, err := dstCRD.GetAllRenames(ackmodel.OpTypeCreate)
-			require.Nil(err)
+			srcRenames := srcCRD.GetAllRenames(ackmodel.OpTypeCreate)
+			require.NotNil(srcRenames)
+			dstRenames := dstCRD.GetAllRenames(ackmodel.OpTypeCreate)
+			require.NotNil(dstRenames)
 			renames, err := multiversion.ComputeRenamesDelta(srcRenames, dstRenames)
 			require.Nil(err)
 

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -328,7 +328,7 @@ func getOpTypeAndResourceName(opID string, cfg *ackgenconfig.Config) ([]OpType, 
 	opType, resName := GetOpTypeAndResourceNameFromOpID(opID, cfg)
 	opTypes := []OpType{opType}
 
-	if operationConfig, exists := cfg.OperationConfig(opID); exists {
+	if operationConfig, exists := cfg.GetOperationConfig(opID); exists {
 		if operationConfig.ResourceName != "" {
 			resName = operationConfig.ResourceName
 		}

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -219,7 +219,7 @@ func (a *SDKAPI) CRDNames(cfg *ackgenconfig.Config) []names.Names {
 	createOps := (*opMap)[OpTypeCreate]
 	crdNames := []names.Names{}
 	for crdName := range createOps {
-		if cfg.IsIgnoredResource(crdName) {
+		if cfg.IsResourceIgnored(crdName) {
 			continue
 		}
 		crdNames = append(crdNames, names.New(crdName))

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -219,7 +219,7 @@ func (a *SDKAPI) CRDNames(cfg *ackgenconfig.Config) []names.Names {
 	createOps := (*opMap)[OpTypeCreate]
 	crdNames := []names.Names{}
 	for crdName := range createOps {
-		if cfg.IsResourceIgnored(crdName) {
+		if cfg.ResourceIsIgnored(crdName) {
 			continue
 		}
 		crdNames = append(crdNames, names.New(crdName))


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1184

Description of changes:
* Prepend Getter names with `Get` and remove `error` and `bool` return types
* Re-Name Query (does resource have X, is resource Y) methods to be consistent and styled similarly
* Update comments and fix typos

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
