### PR TITLE
Refactor LateInitialize using `FieldConfig` Getters 

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -411,3 +411,33 @@ func (c *Config) GetFieldConfigByPath(resourceName string, fieldPath string) *Fi
 	}
 	return nil
 }
+
+// GetLateInitConfigByPath returns the LateInitializeConfig provided a resource and path to associated field.
+func (c *Config) GetLateInitConfigByPath(resourceName string, fieldPath string) *LateInitializeConfig {
+	if c == nil {
+		return nil
+	}
+	for fPath, fConfig := range c.GetFieldConfigs(resourceName) {
+		if strings.EqualFold(fPath, fieldPath) {
+			return fConfig.LateInitialize
+		}
+	}
+	return nil
+}
+
+// GetLateInitConfigs returns all LateInitializeConfigs for a given resource as a map.
+// The map is keyed by the resource's field names after applying renames, if applicable.
+func (c *Config) GetLateInitConfigs(resourceName string) map[string]*LateInitializeConfig {
+	if c == nil {
+		return nil
+	}
+	fieldNameToConfig := c.GetFieldConfigs(resourceName)
+	fieldNameToLateInitConfig := make(map[string]*LateInitializeConfig)
+	for fieldName := range fieldNameToConfig {
+		lateInitConfig := c.GetLateInitConfigByPath(resourceName, fieldName)
+		if lateInitConfig != nil {
+			fieldNameToLateInitConfig[fieldName] = lateInitConfig
+		}
+	}
+	return fieldNameToLateInitConfig
+}

--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -13,6 +13,8 @@
 
 package config
 
+import "strings"
+
 // SourceFieldConfig instructs the code generator how to handle a field in the
 // Resource's SpecFields/StatusFields collection that takes its value from an
 // abnormal source -- in other words, not the Create operation's Input or
@@ -382,4 +384,30 @@ type FieldConfig struct {
 	// TODO(jaypipes,crtbry): Figure out if we can roll the CustomShape stuff
 	// into this type override...
 	Type *string `json:"type,omitempty"`
+}
+
+// GetFieldConfigs returns all FieldConfigs for a given resource as a map.
+// The map is keyed by the resource's field names after applying renames, if applicable.
+func (c *Config) GetFieldConfigs(resourceName string) map[string]*FieldConfig {
+	if c == nil {
+		return map[string]*FieldConfig{}
+	}
+	resourceConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return map[string]*FieldConfig{}
+	}
+	return resourceConfig.Fields
+}
+
+// GetFieldConfigByPath returns the FieldConfig provided a resource and path to associated field.
+func (c *Config) GetFieldConfigByPath(resourceName string, fieldPath string) *FieldConfig {
+	if c == nil {
+		return nil
+	}
+	for fPath, fConfig := range c.GetFieldConfigs(resourceName) {
+		if strings.EqualFold(fPath, fieldPath) {
+			return fConfig
+		}
+	}
+	return nil
 }

--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -412,19 +412,6 @@ func (c *Config) GetFieldConfigByPath(resourceName string, fieldPath string) *Fi
 	return nil
 }
 
-// GetLateInitConfigByPath returns the LateInitializeConfig provided a resource and path to associated field.
-func (c *Config) GetLateInitConfigByPath(resourceName string, fieldPath string) *LateInitializeConfig {
-	if c == nil {
-		return nil
-	}
-	for fPath, fConfig := range c.GetFieldConfigs(resourceName) {
-		if strings.EqualFold(fPath, fieldPath) {
-			return fConfig.LateInitialize
-		}
-	}
-	return nil
-}
-
 // GetLateInitConfigs returns all LateInitializeConfigs for a given resource as a map.
 // The map is keyed by the resource's field names after applying renames, if applicable.
 func (c *Config) GetLateInitConfigs(resourceName string) map[string]*LateInitializeConfig {
@@ -440,4 +427,17 @@ func (c *Config) GetLateInitConfigs(resourceName string) map[string]*LateInitial
 		}
 	}
 	return fieldNameToLateInitConfig
+}
+
+// GetLateInitConfigByPath returns the LateInitializeConfig provided a resource and path to associated field.
+func (c *Config) GetLateInitConfigByPath(resourceName string, fieldPath string) *LateInitializeConfig {
+	if c == nil {
+		return nil
+	}
+	for fPath, fConfig := range c.GetFieldConfigs(resourceName) {
+		if strings.EqualFold(fPath, fieldPath) {
+			return fConfig.LateInitialize
+		}
+	}
+	return nil
 }

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -14,8 +14,6 @@
 package config
 
 import (
-	"strings"
-
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
@@ -415,44 +413,6 @@ func (c *Config) GetResourceConfig(resourceName string) *ResourceConfig {
 	}
 	rc, _ := c.Resources[resourceName]
 	return &rc
-}
-
-// GetResourceFields returns a map, keyed by target/renamed field name, of
-// FieldConfig struct pointers that instruct the code generator how to handle
-// the interpretation of special Resource fields (both Spec and Status)
-func (c *Config) GetResourceFields(resourceName string) map[string]*FieldConfig {
-	if c == nil {
-		return map[string]*FieldConfig{}
-	}
-	resourceConfig, ok := c.Resources[resourceName]
-	if !ok {
-		return map[string]*FieldConfig{}
-	}
-	return resourceConfig.Fields
-}
-
-// GetResourceFieldByPath returns the FieldConfig for a field from
-// "resourceName" crd, where field.Path matches the passed "fieldPath" parameter.
-// This method performs the case-insensitive resource and fieldPath lookup.
-func (c *Config) GetResourceFieldByPath(resourceName string, fieldPath string) *FieldConfig {
-	var resourceConfig ResourceConfig
-	if c == nil {
-		return nil
-	}
-
-	for resName, resConfig := range c.Resources {
-		if strings.EqualFold(resName, resourceName) {
-			resourceConfig = resConfig
-			break
-		}
-	}
-
-	for fPath, fConfig := range resourceConfig.Fields {
-		if strings.EqualFold(fPath, fieldPath) {
-			return fConfig
-		}
-	}
-	return nil
 }
 
 // GetCompareIgnoredFieldPaths returns the list of field paths to ignore when

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -94,7 +94,7 @@ func CompareResource(
 ) string {
 	out := "\n"
 
-	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 
 	// We need a deterministic order to traverse our top-level fields...
 	specFieldNames := []string{}
@@ -544,7 +544,7 @@ func CompareStruct(
 ) string {
 	out := ""
 
-	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 
 	for _, memberName := range shape.MemberNames() {
 		memberShapeRef := shape.MemberRefs[memberName]

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -56,7 +56,7 @@ func getSortedLateInitFieldsAndConfig(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
 ) ([]string, map[string]*ackgenconfig.LateInitializeConfig) {
-	fieldNameToConfig := cfg.GetResourceFields(r.Names.Original)
+	fieldNameToConfig := cfg.GetFieldConfigs(r.Names.Original)
 	fieldNameToLateInitConfig := make(map[string]*ackgenconfig.LateInitializeConfig)
 	sortedLateInitFieldNames := make([]string, 0)
 	if len(fieldNameToConfig) > 0 {

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -42,17 +42,16 @@ func FindLateInitializedFieldNames(
 	for fieldName := range lateInitConfigs {
 		lateInitFieldNames = append(lateInitFieldNames, fieldName)
 	}
-	if len(lateInitFieldNames) > 0 {
-		// sort the slice to help with short circuiting AWSResourceManager.LateInitialize()
-		sort.Strings(lateInitFieldNames)
-		out += fmt.Sprintf("%svar %s = []string{", indent, resVarName)
-		for _, fName := range lateInitFieldNames {
-			out += fmt.Sprintf("%q,", fName)
-		}
-		out += "}\n"
-	} else {
-		out += fmt.Sprintf("%svar %s = []string{}\n", indent, resVarName)
+	if len(lateInitFieldNames) == 0 {
+		return fmt.Sprintf("%svar %s = []string{}\n", indent, resVarName)
 	}
+	// sort the slice to help with short circuiting AWSResourceManager.LateInitialize()
+	sort.Strings(lateInitFieldNames)
+	out += fmt.Sprintf("%svar %s = []string{", indent, resVarName)
+	for _, fName := range lateInitFieldNames {
+		out += fmt.Sprintf("%q,", fName)
+	}
+	out += "}\n"
 	return out
 }
 
@@ -279,8 +278,7 @@ func IncompleteLateInitialization(
 		lateInitFieldNames = append(lateInitFieldNames, fieldName)
 	}
 	if len(lateInitFieldNames) == 0 {
-		out += fmt.Sprintf("%sreturn false", indent)
-		return out
+		return fmt.Sprintf("%sreturn false", indent)
 	}
 	sort.Strings(lateInitFieldNames)
 	out += fmt.Sprintf("%sko := rm.concreteResource(%s).ko.DeepCopy()\n", indent, resVarName)

--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -37,10 +37,16 @@ func FindLateInitializedFieldNames(
 ) string {
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
-	sortedFieldNames, _ := getSortedLateInitFieldsAndConfig(cfg, r)
-	if len(sortedFieldNames) > 0 {
+	var lateInitFieldNames []string
+	lateInitConfigs := cfg.GetLateInitConfigs(r.Names.Original)
+	for fieldName := range lateInitConfigs {
+		lateInitFieldNames = append(lateInitFieldNames, fieldName)
+	}
+	if len(lateInitFieldNames) > 0 {
+		// sort the slice to help with short circuiting AWSResourceManager.LateInitialize()
+		sort.Strings(lateInitFieldNames)
 		out += fmt.Sprintf("%svar %s = []string{", indent, resVarName)
-		for _, fName := range sortedFieldNames {
+		for _, fName := range lateInitFieldNames {
 			out += fmt.Sprintf("%q,", fName)
 		}
 		out += "}\n"
@@ -48,27 +54,6 @@ func FindLateInitializedFieldNames(
 		out += fmt.Sprintf("%svar %s = []string{}\n", indent, resVarName)
 	}
 	return out
-}
-
-// getSortedLateInitFieldsAndConfig returns the field names in alphabetically sorted order which have LateInitialization
-// configuration inside generator config and also a map from fieldName to LateInitializationConfig.
-func getSortedLateInitFieldsAndConfig(
-	cfg *ackgenconfig.Config,
-	r *model.CRD,
-) ([]string, map[string]*ackgenconfig.LateInitializeConfig) {
-	fieldNameToConfig := cfg.GetFieldConfigs(r.Names.Original)
-	fieldNameToLateInitConfig := make(map[string]*ackgenconfig.LateInitializeConfig)
-	sortedLateInitFieldNames := make([]string, 0)
-	if len(fieldNameToConfig) > 0 {
-		for fName, fConfig := range fieldNameToConfig {
-			if fConfig != nil && fConfig.LateInitialize != nil {
-				fieldNameToLateInitConfig[fName] = fConfig.LateInitialize
-				sortedLateInitFieldNames = append(sortedLateInitFieldNames, fName)
-			}
-		}
-		sort.Strings(sortedLateInitFieldNames)
-	}
-	return sortedLateInitFieldNames, fieldNameToLateInitConfig
 }
 
 // LateInitializeFromReadOne returns the gocode to set LateInitialization fields from the ReadOne output
@@ -147,14 +132,19 @@ func LateInitializeFromReadOne(
 ) string {
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
-	lateInitializedFieldNames, _ := getSortedLateInitFieldsAndConfig(cfg, r)
-	if len(lateInitializedFieldNames) == 0 {
+	var lateInitFieldNames []string
+	lateInitConfigs := cfg.GetLateInitConfigs(r.Names.Original)
+	for fieldName := range lateInitConfigs {
+		lateInitFieldNames = append(lateInitFieldNames, fieldName)
+	}
+	if len(lateInitFieldNames) == 0 {
 		return fmt.Sprintf("%sreturn %s", indent, targetResVarName)
 	}
+	sort.Strings(lateInitFieldNames)
 	out += fmt.Sprintf("%sobservedKo := rm.concreteResource(%s).ko.DeepCopy()\n", indent, sourceResVarName)
 	out += fmt.Sprintf("%slatestKo := rm.concreteResource(%s).ko.DeepCopy()\n", indent, targetResVarName)
 	// TODO(vijat@): Add validation for correct field path in lateInitializedFieldNames
-	for _, fName := range lateInitializedFieldNames {
+	for _, fName := range lateInitFieldNames {
 		// split the field name by period
 		// each substring represents a field.
 		fNameParts := strings.Split(fName, ".")
@@ -283,13 +273,18 @@ func IncompleteLateInitialization(
 ) string {
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
-	sortedLateInitFieldNames, _ := getSortedLateInitFieldsAndConfig(cfg, r)
-	if len(sortedLateInitFieldNames) == 0 {
+	var lateInitFieldNames []string
+	lateInitConfigs := cfg.GetLateInitConfigs(r.Names.Original)
+	for fieldName := range lateInitConfigs {
+		lateInitFieldNames = append(lateInitFieldNames, fieldName)
+	}
+	if len(lateInitFieldNames) == 0 {
 		out += fmt.Sprintf("%sreturn false", indent)
 		return out
 	}
+	sort.Strings(lateInitFieldNames)
 	out += fmt.Sprintf("%sko := rm.concreteResource(%s).ko.DeepCopy()\n", indent, resVarName)
-	for _, fName := range sortedLateInitFieldNames {
+	for _, fName := range lateInitFieldNames {
 		// split the field name by period
 		// each substring represents a field.
 		fNameParts := strings.Split(fName, ".")

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -31,7 +31,7 @@ func Test_FindLateInitializedFieldNames_EmptyFieldConfig(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// NO fieldConfig
-	assert.Empty(crd.Config().GetResourceFields(crd.Names.Original))
+	assert.Empty(crd.Config().GetFieldConfigs(crd.Names.Original))
 	expected :=
 		`	var lateInitializeFieldNames = []string{}
 `
@@ -47,8 +47,8 @@ func Test_FindLateInitializedFieldNames_NoLateInitializations(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// FieldConfig without lateInitialize
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
-	assert.Nil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"])
+	assert.Nil(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"].LateInitialize)
 	expected :=
 		`	var lateInitializeFieldNames = []string{}
 `
@@ -63,10 +63,10 @@ func Test_FindLateInitializedFieldNames(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"])
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
 		`	var lateInitializeFieldNames = []string{"ImageTagMutability","Name",}
 `
@@ -82,7 +82,7 @@ func Test_LateInitializeFromReadOne_NoFieldsToLateInitialize(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
 	// NO fieldConfig
-	assert.Empty(crd.Config().GetResourceFields(crd.Names.Original))
+	assert.Empty(crd.Config().GetFieldConfigs(crd.Names.Original))
 	expected := "	return latest"
 	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "latest", 1))
 }
@@ -95,10 +95,10 @@ func Test_LateInitializeFromReadOne_NonNestedPath(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"])
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageTagMutability"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageTagMutability"])
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageTagMutability"].LateInitialize)
 	expected :=
 		`	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
@@ -120,10 +120,10 @@ func Test_LateInitializeFromReadOne_NestedPath(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 		`	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
@@ -188,10 +188,10 @@ func Test_IncompleteLateInitialization(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Repository")
 	require.NotNil(crd)
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["Name"])
-	assert.NotEmpty(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["Name"].LateInitialize)
-	assert.NotNil(crd.Config().GetResourceFields(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"])
+	assert.NotEmpty(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"])
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["Name"].LateInitialize)
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["ImageScanningConfiguration.ScanOnPush"].LateInitialize)
 	expected :=
 		`	ko := rm.concreteResource(latest).ko.DeepCopy()
 	if ko.Spec.ImageScanningConfiguration != nil {

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -758,7 +758,7 @@ func SetResourceGetAttributes(
 
 	// did we output an ACKResourceMetadata guard and constructor snippet?
 	mdGuardOut := false
-	fieldConfigs := cfg.GetResourceFields(r.Names.Original)
+	fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 	sortedAttrFieldNames := []string{}
 	for fName, fConfig := range fieldConfigs {
 		if fConfig.IsAttribute {

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -136,7 +136,7 @@ func SetSDK(
 		// attrMap["KmsMasterKeyId"] = r.ko.Spec.KMSMasterKeyID
 		// attrMap["Policy"] = r.ko.Spec.Policy
 		// res.SetAttributes(attrMap)
-		fieldConfigs := cfg.GetResourceFields(r.Names.Original)
+		fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 		out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
 		sortedAttrFieldNames := []string{}
 		for fName, fConfig := range fieldConfigs {
@@ -647,7 +647,7 @@ func SetSDKSetAttributes(
 			//     attrMap["Policy"] = r.ko.Spec.Policy
 			// }
 			// res.SetAttributes(attrMap)
-			fieldConfigs := cfg.GetResourceFields(r.Names.Original)
+			fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 			out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
 			sortedAttrFieldNames := []string{}
 			for fName, fConfig := range fieldConfigs {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -200,7 +200,7 @@ func (r *CRD) AddSpecField(
 	shapeRef *awssdkmodel.ShapeRef,
 ) {
 	fPath := memberNames.Camel
-	fConfig := r.cfg.GetResourceFieldByPath(r.Names.Original, fPath)
+	fConfig := r.cfg.GetFieldConfigByPath(r.Names.Original, fPath)
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
 	if fConfig != nil && fConfig.Print != nil {
 		r.addSpecPrintableColumn(f)
@@ -225,7 +225,7 @@ func (r *CRD) AddStatusField(
 	shapeRef *awssdkmodel.ShapeRef,
 ) {
 	fPath := memberNames.Camel
-	fConfig := r.cfg.GetResourceFieldByPath(r.Names.Original, fPath)
+	fConfig := r.cfg.GetFieldConfigByPath(r.Names.Original, fPath)
 	f := NewField(r, fPath, memberNames, shapeRef, fConfig)
 	if fConfig != nil && fConfig.Print != nil {
 		r.addStatusPrintableColumn(f)
@@ -285,7 +285,7 @@ func (r *CRD) UnpackAttributes() {
 	if !r.cfg.ResourceContainsAttributesMap(r.Names.Original) {
 		return
 	}
-	fieldConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fieldConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 	for fieldName, fieldConfig := range fieldConfigs {
 		if !fieldConfig.IsAttribute {
 			continue
@@ -313,7 +313,7 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 	if !r.cfg.IncludeACKMetadata {
 		return false
 	}
-	fieldConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fieldConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 	for fName, fConfig := range fieldConfigs {
 		if fConfig.IsARN {
 			return strings.EqualFold(fieldName, fName)
@@ -326,7 +326,7 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 // IsSecretField returns true if the supplied field *path* refers to a Field
 // that is a SecretKeyReference
 func (r *CRD) IsSecretField(path string) bool {
-	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 	fConfig, found := fConfigs[path]
 	if found {
 		return fConfig.IsSecret
@@ -336,7 +336,7 @@ func (r *CRD) IsSecretField(path string) bool {
 
 // GetImmutableFieldPaths returns list of immutable field paths present in CRD
 func (r *CRD) GetImmutableFieldPaths() []string {
-	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 	var immutableFields []string
 
 	for field, fieldConfig := range fConfigs {
@@ -350,7 +350,7 @@ func (r *CRD) GetImmutableFieldPaths() []string {
 
 // HasImmutableFieldChanges helper function that return true if there are any immutable field changes
 func (r *CRD) HasImmutableFieldChanges() bool {
-	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 	for _, fieldConfig := range fConfigs {
 		if fieldConfig.IsImmutable {
 			return true
@@ -372,7 +372,7 @@ func (r *CRD) IsARNPrimaryKey() bool {
 // GetPrimaryKeyField returns the field designated as the primary key, nil if
 // none are specified or an error if multiple are designated.
 func (r *CRD) GetPrimaryKeyField() (*Field, error) {
-	fConfigs := r.cfg.GetResourceFields(r.Names.Original)
+	fConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
 
 	var primaryField *Field
 	for fieldName, fieldConfig := range fConfigs {

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -275,7 +275,7 @@ func NewField(
 				cleanMemberNames := names.New(memberName)
 				memberPath := path + "." + cleanMemberNames.Camel
 				memberShape := containerShape.MemberRefs[memberName]
-				fConfigs := crd.cfg.GetResourceFields(crd.Names.Original)
+				fConfigs := crd.cfg.GetFieldConfigs(crd.Names.Original)
 				memberField := NewField(
 					crd, memberPath, cleanMemberNames, memberShape, fConfigs[memberPath],
 				)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -136,7 +136,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now any additional Spec fields that are required from other API
 		// operations.
-		for targetFieldName, fieldConfig := range m.cfg.GetResourceFields(crdName) {
+		for targetFieldName, fieldConfig := range m.cfg.GetFieldConfigs(crdName) {
 			if fieldConfig.IsReadOnly {
 				// It's a Status field...
 				continue
@@ -238,7 +238,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now add the additional Status fields that are required from other
 		// API operations.
-		for targetFieldName, fieldConfig := range m.cfg.GetResourceFields(crdName) {
+		for targetFieldName, fieldConfig := range m.cfg.GetFieldConfigs(crdName) {
 			if !fieldConfig.IsReadOnly {
 				// It's a Spec field...
 				continue
@@ -700,7 +700,7 @@ func (m *Model) processField(
 	fieldShape := fieldShapeRef.Shape
 	fieldShapeType := fieldShape.Type
 	fieldPath := parentFieldPath + fieldNames.Camel
-	fieldConfig := crd.Config().GetResourceFieldByPath(crd.Names.Original, fieldPath)
+	fieldConfig := crd.Config().GetFieldConfigByPath(crd.Names.Original, fieldPath)
 	field := NewField(crd, fieldPath, fieldNames, fieldShapeRef, fieldConfig)
 	switch fieldShapeType {
 	case "structure":


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1184

Description of changes:
* Relocate `FieldConfig` Getters to `field.go`; clarify names
* Add `LateInitializeConfig` Getters
* Update `late_initalize.go` to replace direct config access with Getters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
