### PR TITLE
Add a new generator config to append a `Synced` printer column

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -305,6 +305,11 @@ type PrintConfig struct {
 	// NOTE: this is the Kubernetes resource Age (creation time at the api-server/etcd)
 	// and not the AWS resource Age.
 	AddAgeColumn bool `json:"add_age_column"`
+	// AddSyncedColumn is used to append a kubebuilder marker comment to show the status of a
+	// resource in `kubectl get` response.
+	//
+	// Default value is true.
+	AddSyncedColumn *bool `json:"add_synced_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
 }
@@ -386,6 +391,23 @@ func (c *Config) ResourceDisplaysAgeColumn(resourceName string) bool {
 	}
 	if rConfig.Print != nil {
 		return rConfig.Print.AddAgeColumn
+	}
+	return false
+}
+
+// ResourceDisplaysSyncedColumn returns true if the resource is
+// configured to display the synced status.
+func (c *Config) ResourceDisplaysSyncedColumn(resourceName string) bool {
+	if c == nil {
+		return false
+	}
+	rConfig, ok := c.Resources[resourceName]
+	if !ok {
+		return false
+	}
+	if rConfig.Print != nil {
+		// default value should be true.
+		return rConfig.Print.AddSyncedColumn == nil || *rConfig.Print.AddSyncedColumn
 	}
 	return false
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -557,6 +557,12 @@ func (r *CRD) PrintAgeColumn() bool {
 	return r.cfg.ResourceDisplaysAgeColumn(r.Names.Camel)
 }
 
+// PrintSyncedColumn returns whether the code generator should append 'Sync'
+// kubebuilder:printcolumn comment marker
+func (r *CRD) PrintSyncedColumn() bool {
+	return r.cfg.ResourceDisplaysSyncedColumn(r.Names.Camel)
+}
+
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int
 func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -53,6 +53,9 @@ type {{ .CRD.Kind }}Status struct {
 {{- range $column := .CRD.AdditionalPrinterColumns }}
 // +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},priority={{$column.Priority}},JSONPath=`{{$column.JSONPath}}`
 {{- end }}
+{{- if .CRD.PrintSyncedColumn }}
+// +kubebuilder:printcolumn:name="Synced",type="boolean",priority=0,JSONPath=".status.conditions[?(@.type==\"ACK.ResourceSynced\")].status"
+{{- end }}
 {{- if .CRD.PrintAgeColumn }}
 // +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
 {{- end }}


### PR DESCRIPTION
Issue: aws-controllers-k8s/community#1281

Description:

Since all ACK kubernetes resources have a synced condition status,
we need a way to instruct the code generator to generate kubebuilder
marker comments that will append the SYNCED field the `kubectl get`
response.

This patch extends Resource.PrintConfig to allow configuring the
ack-generate to generate such marker comments.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
