### PR TITLE
update RAM initialism

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -119,6 +119,8 @@ var (
 		{"Nat", "NAT", "nat", regexp.MustCompile("Nat(?!i)", regexp.None)},
 		{"Oidc", "OIDC", "oidc", nil},
 		{"Ocsp", "OCSP", "ocsp", nil},
+		// Capitalize the 'd' following RAM in certain cases
+		{"Ramdisk", "RAMDisk", "ramDisk", regexp.MustCompile("Ramdisk", regexp.None)},
 		// Model fields starting with 'Ram' refer to RAM
 		{"Ram", "RAM", "ram", regexp.MustCompile("Ram", regexp.None)},
 		{"Rfc", "RFC", "rfc", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -70,6 +70,7 @@ func TestNames(t *testing.T) {
 		{"Package", "Package", "package_", "package_"},
 		{"Param", "Param", "param", "param"},
 		{"Ram", "RAM", "ram", "ram"},
+		{"RamdiskId", "RAMDiskID", "ramDiskID", "ram_disk_id"},
 		{"RamDiskId", "RAMDiskID", "ramDiskID", "ram_disk_id"},
 		{"RepositoryUriTest", "RepositoryURITest", "repositoryURITest", "repository_uri_test"},
 		{"RequestedAmiVersion", "RequestedAMIVersion", "requestedAMIVersion", "requested_ami_version"},


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/ec2-controller/pull/52

Description of changes:
* adds `Ramdisk` to initialisms because the source did not consistently camel case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
