### PR TITLE
Add support for references within lists of structs

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -19,6 +19,7 @@ import (
 	ttpl "text/template"
 
 	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/fieldpath"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
@@ -59,6 +60,9 @@ var (
 		},
 		"ResourceExceptionCode": func(r *ackmodel.CRD, httpStatusCode int) string {
 			return r.ExceptionCode(httpStatusCode)
+		},
+		"ConstructFieldPath": func(targetFieldPath string) *fieldpath.Path {
+			return fieldpath.FromString(targetFieldPath)
 		},
 		"GoCodeSetExceptionMessageCheck": func(r *ackmodel.CRD, httpStatusCode int) string {
 			return code.CheckExceptionMessage(r.Config(), r, httpStatusCode)

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -15,6 +15,7 @@ package ack
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 	ttpl "text/template"
 
@@ -263,6 +264,7 @@ func Controller(
 	for serviceName := range referencedServiceNamesMap {
 		referencedServiceNames = append(referencedServiceNames, serviceName)
 	}
+	sort.Strings(referencedServiceNames)
 	cmdVars := &templateCmdVars{
 		metaVars,
 		snakeCasedCRDNames,

--- a/pkg/generate/code/resource_reference.go
+++ b/pkg/generate/code/resource_reference.go
@@ -171,10 +171,9 @@ func ReferenceFieldsPresent(
 				}
 			}
 
-			returnOut += " || (" + nestedStructNilCheck(*fp.Copy(), fieldAccessPrefix)
-			returnOut += fmt.Sprintf("%s.%s != nil", fieldAccessPrefix,
+			nilCheck := nestedStructNilCheck(*fp.Copy(), fieldAccessPrefix) + " && " + fmt.Sprintf("%s.%s != nil", fieldAccessPrefix,
 				field.ReferenceFieldPath())
-			returnOut += ")"
+			returnOut += " || (" + strings.TrimPrefix(nilCheck, " && ") + ")"
 		}
 	}
 	return iteratorsOut + returnOut

--- a/pkg/generate/code/resource_reference.go
+++ b/pkg/generate/code/resource_reference.go
@@ -69,8 +69,8 @@ func ReferenceFieldsValidation(
 				if !ok {
 					panic(fmt.Sprintf("CRD %s has no Field with prefix %s", crd.Kind, fieldNamePrefix))
 				}
-				// field is a list
-				if len(fieldConfig.MemberFields) > 0 {
+
+				if fieldConfig.ShapeRef.Shape.Type == "list" {
 					out += fmt.Sprintf("%sfor _, iter%d := range %s {\n", fIndent, fieldDepth, pathVarPrefix)
 					// reset the path variable name
 					pathVarPrefix = fmt.Sprintf("iter%d", fieldDepth)

--- a/pkg/generate/code/resource_reference.go
+++ b/pkg/generate/code/resource_reference.go
@@ -22,14 +22,20 @@ import (
 )
 
 // ReferenceFieldsValidation produces the go code to validate reference field and
-// corresponding identifier field.
+// corresponding identifier field. Iterates through all references within
+// slices, if necessary.
+// for _, iter0 := range ko.Spec.Routes {
+//   if iter0.GatewayRef != nil && iter0.GatewayID != nil {
+//     return ackerr.ResourceReferenceAndIDNotSupportedFor("Routes.GatewayID", "Routes.GatewayRef")
+//   }
+// }
 // Sample code:
 // if ko.Spec.APIRef != nil && ko.Spec.APIID != nil {
-//		return ackerr.ResourceReferenceAndIDNotSupportedFor("APIID", "APIRef")
-//	}
-//	if ko.Spec.APIRef == nil && ko.Spec.APIID == nil {
-//		return ackerr.ResourceReferenceOrIDRequiredFor("APIID", "APIRef")
-//	}
+//   return ackerr.ResourceReferenceAndIDNotSupportedFor("APIID", "APIRef")
+// }
+// if ko.Spec.APIRef == nil && ko.Spec.APIID == nil {
+//   return ackerr.ResourceReferenceOrIDRequiredFor("APIID", "APIRef")
+// }
 func ReferenceFieldsValidation(
 	crd *model.CRD,
 	sourceVarName string,
@@ -120,6 +126,11 @@ func ReferenceFieldsValidation(
 // a non-nil reference field is present in a resource. This checks helps in deciding
 // whether ACK.ReferencesResolved condition should be added to resource status
 // Sample Code:
+// for _, iter35 := range ko.Spec.Routes {
+//   if iter35.GatewayRef != nil {
+//     return true
+//   }
+// }
 // return false || (ko.Spec.APIRef != nil)
 func ReferenceFieldsPresent(
 	crd *model.CRD,

--- a/pkg/generate/code/resource_reference_test.go
+++ b/pkg/generate/code/resource_reference_test.go
@@ -181,14 +181,18 @@ func Test_ReferenceFieldsPresent_NestedSliceOfStructsReference(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "RouteTable")
 	require.NotNil(crd)
 	expected :=
-		`for _, iter32 := range ko.Spec.Routes {
-	if iter32.GatewayRef != nil {
-		return true
+		`if ko.Spec.Routes != nil {
+	for _, iter32 := range ko.Spec.Routes {
+		if iter32.GatewayRef != nil {
+			return true
+		}
 	}
 }
-for _, iter35 := range ko.Spec.Routes {
-	if iter35.NATGatewayRef != nil {
-		return true
+if ko.Spec.Routes != nil {
+	for _, iter35 := range ko.Spec.Routes {
+		if iter35.NATGatewayRef != nil {
+			return true
+		}
 	}
 }
 return false || (ko.Spec.VPCRef != nil)`

--- a/pkg/generate/code/resource_reference_test.go
+++ b/pkg/generate/code/resource_reference_test.go
@@ -118,7 +118,7 @@ func Test_ReferenceFieldsPresent_NoReferenceConfig(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Api")
 	require.NotNil(crd)
-	expected := "false"
+	expected := "return false"
 	assert.Equal(expected, code.ReferenceFieldsPresent(crd, "ko"))
 }
 
@@ -133,7 +133,7 @@ func Test_ReferenceFieldsPresent_SingleReference(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Integration")
 	require.NotNil(crd)
-	expected := "false || (ko.Spec.APIRef != nil)"
+	expected := "return false || (ko.Spec.APIRef != nil)"
 	assert.Equal(expected, code.ReferenceFieldsPresent(crd, "ko"))
 }
 
@@ -150,7 +150,7 @@ func Test_ReferenceFieldsPresent_SliceOfReferences(t *testing.T) {
 	// just to test code generation for slices of reference
 	crd := testutil.GetCRDByName(t, g, "VpcLink")
 	require.NotNil(crd)
-	expected := "false || (ko.Spec.SecurityGroupRefs != nil) || (ko.Spec.SubnetRefs != nil)"
+	expected := "return false || (ko.Spec.SecurityGroupRefs != nil) || (ko.Spec.SubnetRefs != nil)"
 	assert.Equal(expected, code.ReferenceFieldsPresent(crd, "ko"))
 }
 
@@ -165,6 +165,32 @@ func Test_ReferenceFieldsPresent_NestedReference(t *testing.T) {
 
 	crd := testutil.GetCRDByName(t, g, "Authorizer")
 	require.NotNil(crd)
-	expected := "false || (ko.Spec.JWTConfiguration != nil && ko.Spec.JWTConfiguration.IssuerRef != nil)"
+	expected := "return false || (ko.Spec.JWTConfiguration != nil && ko.Spec.JWTConfiguration.IssuerRef != nil)"
+	assert.Equal(expected, code.ReferenceFieldsPresent(crd, "ko"))
+}
+
+func Test_ReferenceFieldsPresent_NestedSliceOfStructsReference(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ec2",
+		&testutil.TestingModelOptions{
+			GeneratorConfigFile: "generator-with-nested-reference.yaml",
+		})
+
+	crd := testutil.GetCRDByName(t, g, "RouteTable")
+	require.NotNil(crd)
+	expected :=
+		`for _, iter32 := range ko.Spec.Routes {
+	if iter32.GatewayRef != nil {
+		return true
+	}
+}
+for _, iter35 := range ko.Spec.Routes {
+	if iter35.NATGatewayRef != nil {
+		return true
+	}
+}
+return false || (ko.Spec.VPCRef != nil)`
 	assert.Equal(expected, code.ReferenceFieldsPresent(crd, "ko"))
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -703,6 +703,7 @@ func (r *CRD) ReferencedServiceNames() (serviceNames []string) {
 	for serviceName, _ := range serviceNamesMap {
 		serviceNames = append(serviceNames, serviceName)
 	}
+	sort.Strings(serviceNames)
 	return serviceNames
 }
 

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-nested-reference.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-nested-reference.yaml
@@ -145,6 +145,10 @@ resources:
         references:
           resource: InternetGateway
           path: Status.InternetGatewayID
+      Routes.NATGatewayId:
+        references:
+          resource: NATGateway
+          path: Status.NATGatewayID
     hooks:
       sdk_create_post_set_output:
         template_path: hooks/route_table/sdk_create_post_set_output.go.tpl

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-nested-reference.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-nested-reference.yaml
@@ -1,0 +1,331 @@
+ignore:
+  operations:
+    - ModifyTransitGateway
+    - ModifyVpcEndpoint
+  field_paths:
+    - AllocateAddressInput.DryRun
+    - CreateDhcpOptionsInput.DryRun
+    - CreateInternetGatewayInput.DryRun
+    - CreateNatGatewayInput.ClientToken
+    - CreateNatGatewayInput.DryRun
+    - CreateRouteInput.DryRun
+    - CreateRouteInput.RouteTableId
+    - CreateRouteTableInput.DryRun
+    - CreateSecurityGroupInput.DryRun
+    - CreateSubnetInput.DryRun
+    - CreateTransitGatewayInput.DryRun
+    - CreateVpcInput.DryRun
+    - CreateVpcEndpointInput.DryRun
+    - DeleteRouteInput.DryRun
+    - DeleteRouteInput.RouteTableId
+    # support EC2-VPC only
+    - DeleteSecurityGroupInput.GroupName
+    # support EC2-VPC only
+    - AllocateAddressInput.Domain
+    - AllocateAddressOutput.Domain
+  resource_names:
+    - AccountAttribute
+    - CapacityReservation
+    - CapacityReservationFleet
+    - CarrierGateway
+    - ClientVpnEndpoint
+    - ClientVpnRoute
+    - CustomerGateway
+    - DefaultSubnet
+    - DefaultVpc
+    - DhcpOptions
+    - EgressOnlyInternetGateway
+    - Fleet
+    - FpgaImage
+    - Image
+    - Instance
+    - InstanceEventWindow
+    - InstanceExportTask
+    - InternetGateway
+    - KeyPair
+    - LaunchTemplateVersion
+    - LaunchTemplate
+    - LocalGatewayRouteTableVpcAssociation
+    - LocalGatewayRoute
+    - ManagedPrefixList
+    - NatGateway
+    - NetworkAclEntry
+    - NetworkAcl
+    - NetworkInsightsPath
+    - NetworkInterfacePermission
+    - NetworkInterface
+    - PlacementGroup
+    - ReplaceRootVolumeTask
+    - ReservedInstancesListing
+    - RestoreImageTask
+    #- RouteTable
+    - Route
+    - SecurityGroup
+    - Snapshot
+    - SpotDatafeedSubscription
+    - StoreImageTask
+    - Subnet
+    - SubnetCidrReservation
+    - TrafficMirrorFilterRule
+    - TrafficMirrorFilter
+    - TrafficMirrorSession
+    - TrafficMirrorTarget
+    - TransitGatewayConnectPeer
+    - TransitGatewayConnect
+    - TransitGatewayMulticastDomain
+    - TransitGatewayPeeringAttachment
+    - TransitGatewayPrefixListReference
+    - TransitGatewayRouteTable
+    - TransitGatewayRoute
+    - TransitGatewayVpcAttachment
+    - TransitGateway
+    - Volume
+    - VpcEndpointConnectionNotification
+    - VpcEndpointServiceConfiguration
+    - VpcEndpoint
+    - Vpc
+    - VpcCidrBlock
+    - VpcPeeringConnection
+    - VpnConnectionRoute
+    - VpnConnection
+    - VpnGateway
+
+operations:
+  AllocateAddress:
+    operation_type:
+      - Create
+    resource_name: ElasticIPAddress
+  DescribeAddresses:
+    operation_type:
+      - List
+    resource_name: ElasticIPAddress
+  ReleaseAddress:
+    operation_type:
+      - Delete
+    resource_name: ElasticIPAddress
+  CreateNatGateway:
+    output_wrapper_field_path: NatGateway
+  CreateVpcEndpoint:
+    output_wrapper_field_path: VpcEndpoint
+  DeleteVpcEndpoints:
+    operation_type:
+      - Delete
+    resource_name: VpcEndpoint
+resources:
+  DhcpOptions:
+    fields:
+      DHCPConfigurations.Values:
+        set:
+          - from: AttributeValue.Value
+  RouteTable:
+    exceptions:
+      terminal_codes:
+        - InvalidVpcID.Malformed
+        - InvalidVpcID.NotFound
+        - InvalidParameterValue
+    fields:
+      # RouteStatuses as Route to ensure
+      # fields set server-side (active, origin)
+      # are exposed in Status
+      RouteStatuses:
+        from:
+          operation: DescribeRouteTables
+          path: RouteTables.Routes
+        is_read_only: true
+      # Routes as CreateRouteInput to ensure only
+      # user-editable fields are exposed in Spec
+      Routes:
+        custom_field:
+          list_of: CreateRouteInput
+      VpcId:
+        references:
+          resource: VPC
+          path: Status.VPCID
+      Routes.GatewayId:
+        references:
+          resource: InternetGateway
+          path: Status.InternetGatewayID
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/route_table/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/route_table/sdk_read_many_post_set_output.go.tpl
+      sdk_file_end:
+        template_path: hooks/route_table/sdk_file_end.go.tpl
+    update_operation:
+      custom_method_name: customUpdateRouteTable
+  ElasticIPAddress:
+    exceptions:
+      terminal_codes:
+        - IdempotentParameterMismatch
+        - InvalidAction
+        - InvalidCharacter
+        - InvalidClientTokenId
+        - InvalidPaginationToken
+        - InvalidParameter
+        - InvalidParameterCombination
+        - InvalidParameterValue
+        - InvalidQueryParameter
+        - MalformedQueryString
+        - MissingAction
+        - MissingAuthenticationToken
+        - MissingParameter
+        - UnknownParameter
+        - UnsupportedInstanceAttribute
+        - UnsupportedOperation
+        - UnsupportedProtocol
+        - ValidationError
+    fields:
+      AllocationId:
+        is_primary_key: true
+        print:
+          name: ALLOCATION-ID
+      PublicIp:
+        print:
+          name: PUBLIC-IP
+    list_operation:
+      match_fields:
+        - AllocationId
+    hooks:
+      sdk_create_post_build_request:
+        template_path: hooks/elastic_ip_address/sdk_create_post_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/elastic_ip_address/sdk_delete_post_build_request.go.tpl
+      sdk_read_many_pre_build_request:
+        template_path: hooks/elastic_ip_address/sdk_read_many_pre_build_request.go.tpl
+      sdk_read_many_post_build_request:
+        template_path: hooks/elastic_ip_address/sdk_read_many_post_build_request.go.tpl
+  InternetGateway:
+    fields:
+      VPC:
+        from:
+          operation: AttachInternetGateway
+          path: VpcId
+        references:
+          resource: VPC
+          path: Status.VPCID
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/internet_gateway/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/internet_gateway/sdk_read_many_post_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/internet_gateway/sdk_delete_pre_build_request.go.tpl
+    update_operation:
+      custom_method_name: customUpdateInternetGateway
+  NatGateway:
+    fields:
+      AllocationId:
+        references:
+          resource: ElasticIPAddress
+          path: Status.AllocationID
+      SubnetId:
+        references:
+          resource: Subnet
+          path: Status.SubnetID
+    synced:
+      when:
+        - path: Status.State
+          in:
+            - available
+  SecurityGroup:
+    fields:
+      # support EC2-VPC only
+      Id:
+        is_primary_key: true
+      VpcId:
+        is_required: true
+        references:
+          resource: VPC
+          path: Status.VPCID
+    renames:
+      operations:
+        CreateSecurityGroup:
+          input_fields:
+            GroupName: Name
+          output_fields:
+            GroupId: Id
+        DeleteSecurityGroup:
+          input_fields:
+            GroupId: Id
+            GroupName: Name
+        DescribeSecurityGroups:
+          input_fields:
+            GroupIds: Ids
+            GroupNames: Names
+    exceptions:
+      terminal_codes:
+        - InvalidVpcID.Malformed
+        - InvalidVpcID.NotFound
+        - VPCIdNotSpecified
+  Subnet:
+    fields:
+      RouteTables:
+        custom_field:
+          list_of: String
+        references:
+          resource: RouteTable
+          path: Status.RouteTableID
+      VpcId:
+        references:
+          resource: VPC
+          path: Status.VPCID
+    exceptions:
+      terminal_codes:
+        - InvalidVpcID.Malformed
+        - InvalidVpcID.NotFound
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/subnet/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/subnet/sdk_read_many_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateSubnet
+  Vpc:
+    update_operation:
+      custom_method_name: customUpdate
+    exceptions:
+      terminal_codes:
+        - InvalidParameterCombination
+    fields:
+      EnableDNSSupport:
+        from:
+          operation: ModifyVpcAttribute
+          path: EnableDnsSupport.Value
+      EnableDNSHostnames:
+        from:
+          operation: ModifyVpcAttribute
+          path: EnableDnsHostnames.Value
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/vpc/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/vpc/sdk_read_many_post_set_output.go.tpl
+  VpcEndpoint:
+    fields:
+      PolicyDocument:
+        late_initialize: {}
+      VpcId:
+        references:
+          resource: VPC
+          path: Status.VPCID
+      RouteTableIds:
+        references:
+          resource: RouteTable
+          path: Status.RouteTableID
+      SecurityGroupIds:
+        references:
+          resource: SecurityGroup
+          path: Status.ID
+      SubnetIds:
+        references:
+          resource: Subnet
+          path: Status.SubnetID
+    exceptions:
+      terminal_codes:
+        - InvalidVpcId.Malformed
+        - InvalidVpcId.NotFound
+        - InvalidServiceName
+    hooks:
+      sdk_delete_post_build_request:
+        template_path: hooks/vpc_endpoint/sdk_delete_post_build_request.go.tpl

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -114,7 +114,7 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
 {{ $_ := $fp.Pop -}}
 {{ $isNested := gt $fp.Size 0 -}}
 {{ $isList := eq $field.ShapeRef.Shape.Type "list" -}}
-{{ if not $isList -}}
+{{ if and (not $isList) (not $isNested) -}}
 	if ko.Spec.{{ $field.ReferenceFieldPath }} != nil &&
 		ko.Spec.{{ $field.ReferenceFieldPath }}.From != nil {
 			arr := ko.Spec.{{ $field.ReferenceFieldPath }}.From
@@ -156,7 +156,7 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
 
 {{ template "read_referenced_resource_and_validate" $field }}
 			referencedValue := string(*obj.{{ $field.FieldConfig.References.Path }})
-			elem.{{ $field.Names.Camel }} = &val
+			elem.{{ $field.Names.Camel }} = &referencedValue
 		}
 	}
 	return nil

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -89,7 +89,7 @@ func validateReferenceFields(ko *svcapitypes.{{ .CRD.Names.Camel }}) error {
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.{{ .CRD.Names.Camel }}) bool {
-	return {{ GoCodeContainsReferences .CRD "ko"}}
+	{{ GoCodeContainsReferences .CRD "ko"}}
 }
 
 {{ range $fieldName, $field := .CRD.Fields }}
@@ -136,8 +136,8 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
             ko.Spec.{{ $field.Path }} = &referencedValue
 	}
 	return nil
-}
 {{end -}}
+}
 {{ else -}}
 {{ $parentField := index .CRD.Fields $fp.String }}
 {{ if eq $parentField.ShapeRef.Shape.Type "list" -}}

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -109,7 +109,7 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
         return nil
     }
 {{ end -}}
-{{ if eq $field.ShapeRef.Shape.Type "list" -}}
+{{ if gt (len $field.MemberFields) 0 -}}
 	if ko.Spec.{{ $field.ReferenceFieldPath }} != nil &&
 	   len(ko.Spec.{{ $field.ReferenceFieldPath }}) > 0 {
 		resolvedReferences := []*string{}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1256

Description of changes:
This pull request adds support for references that occur within lists of structs. It updates the generated `references.go` files in each controller to now iterate through the structs to check for the existence of references and again for resolving their individual references. Rather than creating a new slice of structs with resolved references, it instead resolves the references in place - updating the base field value and leaving the reference untouched. 

This pull request has been tested against the APIGatewayv2 and EC2 resource reference tests, as well as manually against the EC2 changes that inspired the original issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
