### PR TITLE
Crossplane's provider-aws has moved to the crossplane-contrib org

### DIFF
--- a/templates/crossplane/README.md
+++ b/templates/crossplane/README.md
@@ -8,5 +8,5 @@ go run -tags codegen cmd/ack-generate/main.go crossplane <resource name> \
     --output <directory for provider>
 ```
 
-See [Contributing New Resource Using ACK](https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md)
+See [Contributing New Resource Using ACK](https://github.com/crossplane-contrib/provider-aws/blob/master/CODE_GENERATION.md)
 for details.

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -20,8 +20,8 @@ import (
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 
-	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServicePackageName }}/{{ .APIVersion}}"
-	awsclient "github.com/crossplane/provider-aws/pkg/clients"
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/{{ .ServicePackageName }}/{{ .APIVersion}}"
+	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
 const (

--- a/templates/crossplane/pkg/conversions.go.tpl
+++ b/templates/crossplane/pkg/conversions.go.tpl
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
 
-	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServicePackageName }}/{{ .APIVersion}}"
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/{{ .ServicePackageName }}/{{ .APIVersion}}"
 )
 
 // NOTE(muvaf): We return pointers in case the function needs to start with an


### PR DESCRIPTION
Description of changes: This updates the templates accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
