### PR TITLE
Add helper function so go template can create slice

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -169,9 +169,9 @@ var (
 		"CheckNilReferencesPath": func(f *ackmodel.Field, sourceVarName string) string {
 			return code.CheckNilReferencesPath(f, sourceVarName)
 		},
-    "Each": func (args ...interface{}) []interface{} {
-      return args
-    },
+                "Each": func (args ...interface{}) []interface{} {
+                        return args
+                },
 		"GoCodeInitializeNestedStructField": func(r *ackmodel.CRD,
 			sourceVarName string, f *ackmodel.Field, apiPkgImportName string,
 			indentLevel int) string {

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -169,6 +169,9 @@ var (
 		"CheckNilReferencesPath": func(f *ackmodel.Field, sourceVarName string) string {
 			return code.CheckNilReferencesPath(f, sourceVarName)
 		},
+                "MakeSlice": func (args ...interface{}) []interface{} {
+                        return args
+                },
 	}
 )
 

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -169,7 +169,7 @@ var (
 		"CheckNilReferencesPath": func(f *ackmodel.Field, sourceVarName string) string {
 			return code.CheckNilReferencesPath(f, sourceVarName)
 		},
-                "MakeSlice": func (args ...interface{}) []interface{} {
+                "Each": func (args ...interface{}) []interface{} {
                         return args
                 },
 	}


### PR DESCRIPTION
Issue #, if available: no issue

Description of changes:
Create a small helper function so go template can create slice.
It will be used by rds controller soon. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
