### PR TITLE
initialize existing tags inside rm.EnsureTags

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -294,6 +294,8 @@ func (rm *resourceManager) EnsureTags(
     } else {
         existingTags = r.ko.Spec.{{ $tagField.Path }}
     }
+{{ else -}}
+    existingTags = r.ko.Spec.{{ $tagField.Path }}
 {{ end -}}
 	resourceTags := ToACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1328

Description of changes:
* If the NilFieldPath check is empty, which means that "Tag" field is present at top level, initialize the existing tags inside "AWSResourceManager.ExistingTags" method
* Validated by locally testing using apigatewayv2-controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
