### PR TITLE
reset resolved references if any reference cannot be resolved

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -72,6 +72,11 @@ func (rm *resourceManager) ResolveReferences(
 {{- if $hookCode := Hook .CRD "references_post_resolve" }}
 {{ $hookCode }}
 {{- end }}
+	// If there was an error while resolving any reference, reset all the
+	// resolved values so that they do not get persisted inside etcd
+	if err != nil {
+		ko = rm.concreteResource(res).ko.DeepCopy()
+	}
 	if hasNonNilReferences(ko) {
 		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
 	}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1342

Description of changes:
TL;DR:
* This change makes sure that partially resolved references do not get added to concrete resource inside `rm.ResolveReferences` unless all the references can be successfully resolved.

Detailed Version
* Inside `rm.ResolveReferences`, all the references are resolved sequentially and whenever any reference resolution fails it short circuits other reference resolutions.
* However the successfully resolved references, before the first fail one, get updated inside the concrete resource(ko).
* An error from `rm.ResolveReferences` causes the `HandleReconcilerError` to call PatchMetadataAndSpec, and the partial resolved references get persisted inside etcd.
* When the resolved references get persisted inside etcd, they cause the validation failure on next reconciler loop that both Ref and Id field cannot be present at the same time.
* The resolved references do not get persisted in etcd when reference resolution is successful because the desired object in memory get replaced by resolvedRefDesired and does not present resolved references as candidate for patch merge. During the failure desired object does not get replaced by resolvedRefDesired and presents the resolved references as patch candidate.
* We cannot update desired with resolvedRefDesired in an error case because then we will lose diff of ACK conditions added by `rm.ResolveReferences`.
* Ignoring the partially resolved reference during an error in `rm.ResolveReferences` is a clean and simple solution.
* I tested this by running apigatewayv2 tests locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
