### PR TITLE
Use latest from sdk create/update for rm.onError()

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -113,6 +113,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
+	    if created != nil {
+	        return rm.onError(created, err)
+	    }
 		return rm.onError(r, err)
 	}
 	return rm.onSuccess(created)
@@ -140,6 +143,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, delta)
 	if err != nil {
+	    if updated != nil {
+	        return rm.onError(updated, err)
+	    }
 		return rm.onError(latest, err)
 	}
 	return rm.onSuccess(updated)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1336

Description of changes:
* After the sdkCreate/sdkUpdate call, the resource manager was still using the latest from ReadOne call when invoking `rm.onError` method
* Instead it should use the resource returned from sdkCreate and sdkUpdate call

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
