### PR TITLE
ACK runtime update to v0.19.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.19.1
+	github.com/aws-controllers-k8s/runtime v0.19.2
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/dlclark/regexp2 v1.4.0
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.19.1 h1:OBV7vbIbLFRpXdAwJfoPGphhjTa7xSc3pS/kuYlKzRU=
-github.com/aws-controllers-k8s/runtime v0.19.1/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
+github.com/aws-controllers-k8s/runtime v0.19.2 h1:Oar0P5eIIXlA+DolGwurw2+wyY5j+d/dxbisZTsrRLw=
+github.com/aws-controllers-k8s/runtime v0.19.2/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=


### PR DESCRIPTION
Description of changes:
* ACK runtime update to v0.19.2 . [Release Notes](https://github.com/aws-controllers-k8s/runtime/releases/tag/v0.19.2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
