### PR TITLE
Use metadata as source of truth for latest version

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -96,7 +96,11 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModelWithLatestAPIVersion(svcAlias)
+	metadata, err := ackmetadata.NewServiceMetadata(optMetadataConfigPath)
+	if err != nil {
+		return err
+	}
+	m, err := loadModelWithLatestAPIVersion(svcAlias, metadata)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	ackgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/ack"
+	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 )
 
 var (
@@ -59,7 +60,11 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModelWithLatestAPIVersion(svcAlias)
+	metadata, err := ackmetadata.NewServiceMetadata(optMetadataConfigPath)
+	if err != nil {
+		return err
+	}
+	m, err := loadModelWithLatestAPIVersion(svcAlias, metadata)
 	if err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/olm.go
+++ b/cmd/ack-generate/command/olm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	olmgenerate "github.com/aws-controllers-k8s/code-generator/pkg/generate/olm"
+	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 )
 
 const (
@@ -87,7 +88,11 @@ func generateOLMAssets(cmd *cobra.Command, args []string) error {
 	if err := ensureSDKRepo(ctx, optCacheDir, optRefreshCache); err != nil {
 		return err
 	}
-	m, err := loadModelWithLatestAPIVersion(svcAlias)
+	metadata, err := ackmetadata.NewServiceMetadata(optMetadataConfigPath)
+	if err != nil {
+		return err
+	}
+	m, err := loadModelWithLatestAPIVersion(svcAlias, metadata)
 	if err != nil {
 		return err
 	}

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -252,6 +252,9 @@ if [[ $ACK_GENERATE_OLM == "true" ]]; then
     if [ -n "$ACK_GENERATE_IMAGE_REPOSITORY" ]; then
         ag_olm_args="$ag_olm_args --image-repository $ACK_GENERATE_IMAGE_REPOSITORY"
     fi
+    if [ -n "$ACK_METADATA_CONFIG_PATH" ]; then
+        ag_olm_args="$ag_olm_args --metadata-config-path $ACK_METADATA_CONFIG_PATH"
+    fi
 
     $ACK_GENERATE_BIN_PATH olm $ag_olm_args
     $SCRIPTS_DIR/olm-create-bundle.sh "$SERVICE" "$RELEASE_VERSION"


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1361

Description of changes:
Code-generator currently compares the subdirectories in the API output directory (`apis/`) to determine the latest K8s version of the CRDs. The information about which API versions should be generated, and their status (`available`, `deprecated`, etc.), already exist in the `metadata.yaml` file. This pull request updates the source of truth for the code-generator to be the `metadata.yaml` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
