### PR TITLE
Ensure failed secret dereferencing is recoverable

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -948,7 +948,7 @@ func setSDKForContainer(
 //
 //     tmpSecret, err := rm.rr.SecretValueFromReference(ctx, ko.Spec.MasterUserPassword)
 //     if err != nil {
-//         return nil, err
+//         return nil, ackrequeue.Needed(err)
 //     }
 //     if tmpSecret != "" {
 //         res.SetMasterUserPassword(tmpSecret)
@@ -958,7 +958,7 @@ func setSDKForContainer(
 //
 //     tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
 //     if err != nil {
-//         return nil, err
+//         return nil, ackrequeue.Needed(err)
 //     }
 //     if tmpSecret != "" {
 //         f3elem = tmpSecret
@@ -989,10 +989,10 @@ func setSDKForSecret(
 		indent, secVar, sourceVarName,
 	)
 	//     if err != nil {
-	//         return nil, err
+	//         return nil, ackrequeue.Needed(err)
 	//     }
 	out += fmt.Sprintf("%s\tif err != nil {\n", indent)
-	out += fmt.Sprintf("%s\t\treturn nil, err\n", indent)
+	out += fmt.Sprintf("%s\t\treturn nil, ackrequeue.Needed(err)\n", indent)
 	out += fmt.Sprintf("%s\t}\n", indent)
 	//     if tmpSecret != "" {
 	//         res.SetMasterUserPassword(tmpSecret)

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -970,7 +970,7 @@ func TestSetSDK_Elasticache_ReplicationGroup_Create(t *testing.T) {
 	if r.ko.Spec.AuthToken != nil {
 		tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.AuthToken)
 		if err != nil {
-			return nil, err
+			return nil, ackrequeue.Needed(err)
 		}
 		if tmpSecret != "" {
 			res.SetAuthToken(tmpSecret)
@@ -1225,7 +1225,7 @@ func TestSetSDK_Elasticache_ReplicationGroup_Update_Override_Values(t *testing.T
 	if r.ko.Spec.AuthToken != nil {
 		tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.AuthToken)
 		if err != nil {
-			return nil, err
+			return nil, ackrequeue.Needed(err)
 		}
 		if tmpSecret != "" {
 			res.SetAuthToken(tmpSecret)
@@ -1347,7 +1347,7 @@ func TestSetSDK_Elasticache_User_Create_Override_Values(t *testing.T) {
 			if f3iter != nil {
 				tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f3iter)
 				if err != nil {
-					return nil, err
+					return nil, ackrequeue.Needed(err)
 				}
 				if tmpSecret != "" {
 					f3elem = tmpSecret
@@ -1974,7 +1974,7 @@ func TestSetSDK_MQ_Broker_Create(t *testing.T) {
 			if f18iter.Password != nil {
 				tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f18iter.Password)
 				if err != nil {
-					return nil, err
+					return nil, ackrequeue.Needed(err)
 				}
 				if tmpSecret != "" {
 					f18elem.SetPassword(tmpSecret)

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -13,6 +13,7 @@ import (
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
@@ -34,6 +35,7 @@ var (
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
 	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1318

Description of changes:
If an ACK resource is evaluated before a secret becomes available, the controller should attempt to retry (with exponential backoff) until the secret exists. This pull request ensures that any error returned by `SecretValueFromReference` is retried by the controller.

Note: I chose not to update the error values in `SecretValueFromReference` because I thought it was more appropriate that the SDK logic chose the requeue action, not the secret fetching method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
