### PR TITLE
Add Terminal condition when immutable field is updated

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -56,6 +56,9 @@ var (
 	controllerCopyPaths = []string{}
 	controllerFuncMap   = ttpl.FuncMap{
 		"ToLower": strings.ToLower,
+		"TrimPrefix": func(s string, prefix string) string {
+			return strings.TrimPrefix(s, prefix)
+		},
 		"Dereference": func(s *string) string {
 			return *s
 		},
@@ -169,9 +172,9 @@ var (
 		"CheckNilReferencesPath": func(f *ackmodel.Field, sourceVarName string) string {
 			return code.CheckNilReferencesPath(f, sourceVarName)
 		},
-                "Each": func (args ...interface{}) []interface{} {
-                        return args
-                },
+		"Each": func(args ...interface{}) []interface{} {
+			return args
+		},
 		"GoCodeInitializeNestedStructField": func(r *ackmodel.CRD,
 			sourceVarName string, f *ackmodel.Field, apiPkgImportName string,
 			indentLevel int) string {

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -5,6 +5,7 @@ package {{ .CRD.Names.Snake }}
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -32,6 +33,7 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -326,57 +328,15 @@ func (rm *resourceManager) getImmutableFieldChanges(
 	delta *ackcompare.Delta,
 ) []string {
 	var fields []string;
-
+{{- $prefixConfig := .CRD.Config.PrefixConfig }}
 	{{- range $immutableField := .CRD.GetImmutableFieldPaths }}
-		if delta.DifferentAt("{{$immutableField}}") {
+{{- $specPrefix := $prefixConfig.SpecField }}
+		if delta.DifferentAt("{{ TrimPrefix $specPrefix "." }}.{{$immutableField}}") {
 			fields = append(fields,"{{$immutableField}}")
 		}
 	{{- end }}
 
 	return fields
-}
-
-// handleImmutableFieldsChangedCondition validates the immutable fields and set appropriate condition
-func (rm *resourceManager) handleImmutableFieldsChangedCondition(
-	r *resource,
-	delta *ackcompare.Delta,
-) *resource {
-
-	fields := rm.getImmutableFieldChanges(delta)
-	ko := r.ko.DeepCopy()
-	var advisoryCondition *ackv1alpha1.Condition = nil
-	for _, condition := range ko.Status.Conditions {
-		if condition.Type == ackv1alpha1.ConditionTypeAdvisory {
-			advisoryCondition = condition
-			break
-		}
-	}
-
-	// Remove the advisory condition if issue is no longer present
-	if len(fields) == 0 && advisoryCondition != nil{
-		var newConditions []*ackv1alpha1.Condition
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type != ackv1alpha1.ConditionTypeAdvisory {
-				newConditions = append(newConditions,condition)
-			}
-		}
-		ko.Status.Conditions = newConditions
-	}
-
-	if len(fields) > 0 {
-		if advisoryCondition == nil {
-			advisoryCondition = &ackv1alpha1.Condition{
-				Type: ackv1alpha1.ConditionTypeAdvisory,
-			}
-			ko.Status.Conditions = append(ko.Status.Conditions, advisoryCondition)
-		}
-
-		advisoryCondition.Status = corev1.ConditionTrue
-		message := "Immutable Spec fields have been modified : " + strings.Join(fields, ",")
-		advisoryCondition.Message = &message
-	}
-
-	return &resource{ko}
 }
 {{- end }}
 {{- if $hookCode := Hook .CRD "sdk_file_end" }}

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -38,7 +38,10 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 {{- if .CRD.HasImmutableFieldChanges }}
-	desired = rm.handleImmutableFieldsChangedCondition(desired, delta)
+    if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
+        msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
+        return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
+    }
 {{- end }}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1374

Description of changes:
* Use the correct delta key `Spec.FieldName` when finding changes to immutable field
* If an immutable field is updated, add the Terminal condition in resource and do not continue with update operation until desired state is valid again

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
