### PR TITLE
making user-secret in user-env optional to support IRSA

### DIFF
--- a/templates/config/controller/user-env.yaml.tpl
+++ b/templates/config/controller/user-env.yaml.tpl
@@ -14,4 +14,4 @@ spec:
               optional: false
           - secretRef:
               name: ack-{{.ServicePackageName}}-user-secrets
-              optional: false
+              optional: true


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
To start supporting IRSA in OpenShift clusters, the `user-secret` now needs to be optional.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>