### PR TITLE
allow empty string as resourceTag entry

### DIFF
--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -192,7 +192,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^.*=.*$"
+        "pattern": "(^$|^.*=.*$)"
       }
     },
     "serviceAccount": {


### PR DESCRIPTION
Description of changes:
* allow empty string inside resourceTags entry so that users can override the default ACK tag behavior using `--set resourceTags={}` param during helm installation
* tested locally that this change allows removing the default ACK tags behavior during helm installation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
