### PR TITLE
Remove faulty suffix trim from Helm deployment

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
       affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
       {{ end -}}
       {{ if .Values.deployment.priorityClassName -}}
-      priorityClassName: {{ .Values.deployment.priorityClassName -}}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{ end -}}
       hostIPC: false
       hostNetwork: false


### PR DESCRIPTION
Description of changes:
Removes a suffix trim character from the Helm deployment template. This trim was causing the string to concatenate with the next line and create an error. Removing this ensures it stays as a separate line if the `priorityClassName` is specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
