### PR TITLE
Update controller tools to `v0.9.2`

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTROLLER_TOOLS_VERSION="v0.7.0"
+CONTROLLER_TOOLS_VERSION="v0.9.2"
 HELM_VERSION="v3.7"
 
 # setting the -x option if debugging is true


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1438

Description of changes:
The current version of `controller-tools` does not support go1.19 (failing with internal atomic type failures). This pull request updates to the latest version, which works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
