### PR TITLE
Fix controller `ClusterRole` file generation

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -234,7 +234,7 @@ controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifac
 # for the user to specify if they want the role to be ClusterRole or Role by specifying installation scope
 # in the helm values.yaml. We do this by having a custom helm template named _controller-role-kind-patch.yaml 
 # which utilizes the template langauge and adding the auto generated rules to that template. 
-tail -n +8  $helm_output_dir/templates/role.yaml >> $helm_output_dir/templates/_controller-role-kind-patch.yaml
+tail -n +7  $helm_output_dir/templates/role.yaml >> $helm_output_dir/templates/_controller-role-kind-patch.yaml
 
 # We have some other standard Role files for a reader and writer role, so here we rename 
 # the `_controller-role-kind-patch.yaml ` file to `cluster-role-controller.yaml` 


### PR DESCRIPTION
This patch fixes the `tail` command to properly cut the generated
`role.yaml` file and avoid deleteng the `rules` section.

Context:

Recently we bumped `controller-tools` version to `v0.9.2` to support
building controller with go1.19. This change sneakily impacted the
`build-controller-release.sh` script, which caused our prow testing jobs
to fail.

To summarize the bug we can generate the `role.yaml` file using
controller-gen `0.7.0` and `0.9.2` and inspect the differences:

```bash
diff role-controller-gen0.9.2.yaml role-controller-gen0.7.0.yaml
0a1
>
```

We can observe that the new line that used it be generated at the top of
each file is no longer there, due to the fix introduced in 0.8.0 more
precisely in https://github.com/kubernetes-sigs/controller-tools/pull/626

This change combined with the command `tail -n +8` in the [build
controller release script](https://github.com/aws-controllers-k8s/code-generator/blob/v0.20.0/scripts/build-controller-release.sh#L237) causes the script to cut an extra line which
happens to be declaration of rules section in a controller ClusterRole
manifest. Hence the error observed in the prow logs:

```bash
Error: INSTALLATION FAILED: YAML parse error on emrcontainers-chart/templates/cluster-role-controller.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key
```

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
