### PR TITLE
Add `IPAM` and `TPM` to initialisms

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -66,7 +66,8 @@ var (
 		// prefix-converted (should be "md5OfBody")
 		{"MD5Of", "MD5Of", "md5Of", regexp.MustCompile("M[dD]5Of", regexp.None)},
 		// Prevent "MultipartUpload" from becoming "MultIPartUpload"
-		{"Ip", "IP", "ip", regexp.MustCompile("Ip(?!art)", regexp.None)},
+		// and "IPAM" from becoming "IPam"
+		{"Ip", "IP", "ip", regexp.MustCompile("Ip(?!art|am)", regexp.None)},
 		// Model fields containing AMI will always capitalize the 'A' hence we don't
 		// have to look for words starting with a lowercase 'A'
 		{"Amis", "AMIs", "amis", regexp.MustCompile("Amis", regexp.None)},
@@ -110,6 +111,7 @@ var (
 		// Prevent "IOPS" from becoming "IOps"
 		{"Io", "IO", "io", regexp.MustCompile("Io(?!ps)", regexp.None)},
 		{"Iops", "IOPS", "iops", nil},
+		{"Ipam", "IPAM", "ipam", nil},
 		{"Json", "JSON", "json", nil},
 		{"Jwt", "JWT", "jwt", nil},
 		{"Kms", "KMS", "kms", nil},
@@ -133,6 +135,7 @@ var (
 		{"Ssl", "SSL", "ssl", nil},
 		{"Tcp", "TCP", "tcp", nil},
 		{"Tde", "TDE", "tde", nil},
+		{"Tpm", "TPM", "tpm", nil},
 		{"Tls", "TLS", "tls", nil},
 		{"Udp", "UDP", "udp", nil},
 		// Need to prevent "security" from becoming "SecURIty"

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -56,6 +56,7 @@ func TestNames(t *testing.T) {
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance"},
 		{"Iops", "IOPS", "iops", "iops"},
 		{"Ip", "IP", "ip", "ip"},
+		{"Ipam", "IPAM", "ipam", "ipam"},
 		{"Frame", "Frame", "frame", "frame"},
 		{"KeyId", "KeyID", "keyID", "key_id"},
 		{"KeyID", "KeyID", "keyID", "key_id"},
@@ -78,6 +79,7 @@ func TestNames(t *testing.T) {
 		{"Sqs", "SQS", "sqs", "sqs"},
 		{"SriovNetSupport", "SRIOVNetSupport", "sriovNetSupport", "sriov_net_support"},
 		{"SSEKMSKeyID", "SSEKMSKeyID", "sseKMSKeyID", "sse_kms_key_id"},
+		{"Tpm", "TPM", "tpm", "tpm"},
 		{"UUID", "UUID", "uuid", "uuid"},
 		{"Vlan", "VLAN", "vlan", "vlan"},
 	}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: adds IPAM (IP Address Management) and TPM (Trusted Platform Module) to initialisms

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
