### PR TITLE
Add helm variable for Role Labels

### DIFF
--- a/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
+++ b/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
@@ -4,6 +4,10 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: ack-{{ .ServicePackageName }}-controller
+  labels:
+  {{ "{{- range $key, $value := .Values.clusterRole.labels }}" }}
+    {{ "{{ $key }}: {{ $value | quote }}" }}
+  {{ "{{- end }}" }}
 {{ "{{ else }}" }}
 kind: Role
 metadata:

--- a/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
+++ b/templates/helm/templates/_controller-role-kind-patch.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   name: ack-{{ .ServicePackageName }}-controller
   labels:
-  {{ "{{- range $key, $value := .Values.clusterRole.labels }}" }}
+  {{ "{{- range $key, $value := .Values.role.labels }}" }}
     {{ "{{ $key }}: {{ $value | quote }}" }}
   {{ "{{- end }}" }}
 {{ "{{ else }}" }}
@@ -13,5 +13,9 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: ack-{{ .ServicePackageName }}-controller
+  labels:
+  {{ "{{- range $key, $value := .Values.role.labels }}" }}
+    {{ "{{ $key }}: {{ $value | quote }}" }}
+  {{ "{{- end }}" }}
   namespace: {{ "{{ .Release.Namespace }}" }}
 {{ "{{ end }}" }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -65,8 +65,8 @@
       ],
       "type": "object"
     },
-    "clusterRole": {
-      "description": "ClusterRole settings",
+    "role": {
+      "description": "Role settings",
       "properties": {
         "labels": {
 	  "type": "object"

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -65,6 +65,14 @@
       ],
       "type": "object"
     },
+    "clusterRole": {
+      "description": "ClusterRole settings",
+      "properties": {
+        "labels": {
+	  "type": "object"
+	}
+      }
+    },
     "metrics": {
       "description": "Metrics settings",
       "properties": {

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -28,6 +28,9 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+clusterRole:
+ labels: {}
   
 metrics:
   service:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -29,7 +29,8 @@ deployment:
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
 
-clusterRole:
+# If "installScope: cluster" then these labels will be applied to ClusterRole
+role:
  labels: {}
   
 metrics:


### PR DESCRIPTION
Provide option for users to specify Role labels in helm values 

This is useful when using [k8s clusterRole aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
We can use aggregation rule labels to give other applications access to ack resources (Eg: Kubeflow in our case)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
