### PR TITLE
Correct the generated code for nested parent field reference.

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -143,6 +143,16 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
 	}
 	return nil
 }
+{{ else if not $isList -}}
+    if ko.Spec.{{ $field.ReferenceFieldPath }} != nil &&
+        ko.Spec.{{ $field.ReferenceFieldPath }}.From != nil  {
+        arr := ko.Spec.{{ $field.ReferenceFieldPath }}.From
+{{ template "read_referenced_resource_and_validate" $field }}
+            referencedValue := string(*obj.{{ $field.FieldConfig.References.Path }})
+            ko.Spec.{{ $field.Path }} = &referencedValue
+    }
+    return nil
+}
 {{ else }}
 {{ $parentField := index .CRD.Fields $fp.String }}
 {{ if eq $parentField.ShapeRef.Shape.Type "list" -}}


### PR DESCRIPTION
While generating the code for references for the Lambda function, more specifically for the S3 bucket field, we observe that there is use of array keywords with a non-array field e.g len(S3.Bucket) which is incorrect.

After debugging code-generator, we observe that there was an incorrect piece of code (most likely because of copy paste) that considered nested parent field as an array.

This patch fixes this issue by adding the right code for handling nested parent fields.

Unfortunately we cannot add unit tests for this change because this part of the code generation resides inside the template and it's not a part of the pkg/generate/code package.

Fixes https://github.com/aws-controllers-k8s/community/issues/1514

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
