### PR TITLE
Normalize field names specific to comparison in generator config

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -112,7 +112,13 @@ func CompareResource(
 		secondResAdaptedVarName += "." + specField.Names.Camel
 
 		var compareConfig *ackgenconfig.CompareFieldConfig
-		fieldConfig := fieldConfigs[fieldName]
+
+		// TODO(amine,john): This is fragile. We actually need to have a way of
+		// normalizing names in a lossless fashion...
+		//
+		// We chose to normalize names as camel case.
+		fieldNameCamel := names.New(fieldName).Camel
+		fieldConfig := fieldConfigs[fieldNameCamel]
 		if fieldConfig != nil {
 			compareConfig = fieldConfig.Compare
 		}

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -476,6 +476,35 @@ func TestCompareResource_APIGatewayv2_Route(t *testing.T) {
 	)
 }
 
+func TestCompareResource_IAM_OIDC_URL(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "iam", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-oidc-url.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "OpenIDConnectProvider")
+	require.NotNil(crd)
+	expected := `
+	if !ackcompare.SliceStringPEqual(a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList) {
+		delta.Add("Spec.ClientIDList", a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList)
+	}
+	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
+	if !ackcompare.SliceStringPEqual(a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList) {
+		delta.Add("Spec.ThumbprintList", a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList)
+	}
+`
+	assert.Equal(
+		expected,
+		code.CompareResource(
+			crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+		),
+	)
+}
+
 func TestCompareResource_MemoryDB_User(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/testdata/models/apis/iam/0000-00-00/generator-oidc-url.yaml
+++ b/pkg/testdata/models/apis/iam/0000-00-00/generator-oidc-url.yaml
@@ -1,0 +1,22 @@
+ignore:
+  resource_names:
+   - AccessKey
+   - AccountAlias
+   - Group
+   - InstanceProfile
+   - LoginProfile
+   #  OpenIDConnectProvider
+   - Policy
+   - PolicyVersion
+   - Role
+   - SAMLProvider
+   - ServiceLinkedRole
+   - ServiceSpecificCredential
+   - User
+   - VirtualMFADevice
+resources:
+  OpenIDConnectProvider:
+    fields:
+      URL:
+        compare:
+          is_ignored: true


### PR DESCRIPTION
While generating code for iam-controller OIDC resource, we found a tiny bug causing the code-generator to generate comparison code for a field that was marked as `compare.is_ignored`.
This was found to be the result of the code-generator not properly normalizing field names.

This patch fixes this bug by normalizing the field name using camel case.
This not a good long term fix. Ideally normalization should happen earlier.

Co-authored-by: John Jacobs <jljaco@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
