### PR TITLE
Return a terminal error when `sdkUpdate` is not implemented

### DIFF
--- a/templates/pkg/resource/sdk_update_not_implemented.go.tpl
+++ b/templates/pkg/resource/sdk_update_not_implemented.go.tpl
@@ -5,7 +5,6 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return nil, ackerr.NewTerminalError(ackerr.NotImplemented)
 }
 {{- end -}}


### PR DESCRIPTION
Currently the generated sdk code throws a simple error when `sdkUpdate`
is not implemented. This is only observable in the controller logs and
users are not able to read this information from their resource's
status/conditions.
    
This patch forces `sdkUpdate` to return a terminal error instead of a
normal error.
Fixes https://github.com/aws-controllers-k8s/community/issues/1521

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
