### PR TITLE
using go env GOARCH to detect system arch instead of uname

### DIFF
--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -26,7 +26,7 @@ if [ "x${__operator_sdk_version}" == "x" ]; then
 fi
 if ! is_installed ${OPERATOR_SDK_BIN_PATH}/operator-sdk; then
     __platform=$(uname | tr '[:upper:]' '[:lower:]')
-    __arch=$(uname -m | tr '[:upper:]' '[:lower:]')
+    __arch=$(go env GOARCH | tr '[:upper:]' '[:lower:]')
     __tmp_install_dir=$(mktemp -d -t install-operator-sdk-XXX)
     __operator_sdk_url="https://github.com/operator-framework/operator-sdk/releases/download/v${__operator_sdk_version}/operator-sdk_${__platform}_${__arch}"
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
`uname` does not always match the friendly arch that operator-sdk, an example is that on a normal mac you get `x86_64` which fails to download since operator-sdk is released as `amd64`, there could be other examples as well.

Other things I thought of, since we might not want to rely on `go env` and be tied to go-tools:
- `uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/g'`
- have this script take in arch as an arg

Let me know which approach would be best


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Signed-off-by: Adam D. Cornett <adc@redhat.com>