### PR TITLE
Fixes the bug that ToACKTags function does not handle an edge case.

### DIFF
--- a/templates/pkg/resource/tags.go.tpl
+++ b/templates/pkg/resource/tags.go.tpl
@@ -46,10 +46,12 @@ func ToACKTags(tags {{ $tagFieldGoType }}) acktags.Tags {
     }
 {{ else if eq "list" $tagFieldShapeType }}
     for _, t := range tags {
-        if t.{{ $valueMemberName }} == nil {
-            result[*t.{{ $keyMemberName}}] = ""
-        } else {
-            result[*t.{{ $keyMemberName }}] = *t.{{ $valueMemberName }}
+        if t.{{ $keyMemberName}} != nil {
+            if t.{{ $valueMemberName }} == nil {
+                    result[*t.{{ $keyMemberName}}] = ""
+                } else {
+                    result[*t.{{ $keyMemberName }}] = *t.{{ $valueMemberName }}
+                }
         }
     }
 {{ end }}

--- a/templates/pkg/resource/tags.go.tpl
+++ b/templates/pkg/resource/tags.go.tpl
@@ -48,10 +48,10 @@ func ToACKTags(tags {{ $tagFieldGoType }}) acktags.Tags {
     for _, t := range tags {
         if t.{{ $keyMemberName}} != nil {
             if t.{{ $valueMemberName }} == nil {
-                    result[*t.{{ $keyMemberName}}] = ""
-                } else {
-                    result[*t.{{ $keyMemberName }}] = *t.{{ $valueMemberName }}
-                }
+                result[*t.{{ $keyMemberName}}] = ""
+            } else {
+                result[*t.{{ $keyMemberName }}] = *t.{{ $valueMemberName }}
+            }
         }
     }
 {{ end }}


### PR DESCRIPTION
Issue [#1549](https://github.com/aws-controllers-k8s/community/issues/1549)

Description of changes:
- Avoids panic code when customer provides a tag with nil key and nil value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
