### PR TITLE
always ensure operation overrides work

### DIFF
--- a/pkg/model/op.go
+++ b/pkg/model/op.go
@@ -150,32 +150,32 @@ func GetOpTypeAndResourceNameFromOpID(
 }
 
 func OpTypeFromString(s string) OpType {
-	switch s {
-	case "Create":
+	switch strings.ToLower(s) {
+	case "create":
 		return OpTypeCreate
-	case "CreateBatch":
+	case "createbatch":
 		return OpTypeCreateBatch
-	case "Delete":
+	case "delete":
 		return OpTypeDelete
-	case "Replace":
+	case "replace":
 		return OpTypeReplace
-	case "Update":
+	case "update":
 		return OpTypeUpdate
-	case "AddChild":
+	case "addchild":
 		return OpTypeAddChild
-	case "AddChildren":
+	case "addchildren":
 		return OpTypeAddChildren
-	case "RemoveChild":
+	case "removechild":
 		return OpTypeRemoveChild
-	case "RemoveChildren":
+	case "removechildren":
 		return OpTypeRemoveChildren
-	case "Get":
+	case "get", "readone", "read_one":
 		return OpTypeGet
-	case "List":
+	case "list", "readmany", "read_many":
 		return OpTypeList
-	case "GetAttributes":
+	case "getattributes":
 		return OpTypeGetAttributes
-	case "SetAttributes":
+	case "setattributes":
 		return OpTypeSetAttributes
 	}
 


### PR DESCRIPTION
There were two bugs in the code generator's construction of the OperationMap during API inference.

The first bug was a non-deterministic behaviour that showed itself when an API had multiple Operations of a single operation type (say, READ_ONE). The code that was responsible for determining which Operation mapped to which operation type for a particular resource was looping over the `aws-sdk-go` `private/model/api:API`'s `Operations` field, which is a map. Depending on the parsing of the underlying api-2.json files, same-typed Operations with different IDs -- e.g. `DescribeStreamSummary` and `DescribeStream` -- were being mapped to a single operation type -- OpTypeGet. Depending on which Operation ID came last, that is the operation that was being mapped, regardless of which one appeared in the OperationConfig configuration option that handles overrides.

The second bug was that the `OpTypeFromString` method was too strict in its comparison logic. The strings "get", "READ_ONE", "read_one" and "Get" should all lead to OpTypeGet, but only "Get" was being matched.

Fixes Issue aws-controllers-k8s/community#1555

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
