### PR TITLE
Fix generation of attribute-based APIs

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -94,7 +94,7 @@ func CompareResource(
 ) string {
 	out := "\n"
 
-	fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
+	resConfig := cfg.GetResourceConfig(r.Names.Camel)
 
 	// We need a deterministic order to traverse our top-level fields...
 	specFieldNames := []string{}
@@ -111,18 +111,21 @@ func CompareResource(
 		secondResAdaptedVarName := secondResVarName + cfg.PrefixConfig.SpecField
 		secondResAdaptedVarName += "." + specField.Names.Camel
 
+		var fieldConfig *ackgenconfig.FieldConfig
 		var compareConfig *ackgenconfig.CompareFieldConfig
 
-		// TODO(amine,john): This is fragile. We actually need to have a way of
-		// normalizing names in a lossless fashion...
-		//
-		// We chose to normalize names as camel case.
-		fieldNameCamel := names.New(fieldName).Camel
-		fieldConfig := fieldConfigs[fieldNameCamel]
+		if resConfig != nil {
+			fieldConfig = resConfig.GetFieldConfig(fieldName)
+		}
 		if fieldConfig != nil {
 			compareConfig = fieldConfig.Compare
 		}
 
+		if fieldConfig != nil && fieldConfig.IsAttribute {
+			// NOTE(jaypipes): We compare the Attributes collection
+			// specially...
+			continue
+		}
 		if compareConfig != nil && compareConfig.IsIgnored {
 			continue
 		}

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -406,8 +406,8 @@ func SetSDKGetAttributes(
 	indent := strings.Repeat("\t", indentLevel)
 
 	inputFieldOverrides := map[string][]string{}
-	rConfig, ok := cfg.Resources[r.Names.Original]
-	if !ok {
+	rConfig := cfg.GetResourceConfig(r.Names.Original)
+	if rConfig == nil {
 		// This is a bug in the code generation if this occurs...
 		msg := fmt.Sprintf(
 			"called SetSDKGetAttributes for a resource '%s' that doesn't have a ResourceConfig",
@@ -421,7 +421,6 @@ func SetSDKGetAttributes(
 			inputFieldOverrides[memberName] = override.Values
 		}
 	}
-
 	for _, memberName := range inputShape.MemberNames() {
 		if r.IsPrimaryARNField(memberName) {
 			// if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {

--- a/pkg/model/op.go
+++ b/pkg/model/op.go
@@ -173,9 +173,9 @@ func OpTypeFromString(s string) OpType {
 		return OpTypeGet
 	case "list", "readmany", "read_many":
 		return OpTypeList
-	case "getattributes":
+	case "getattributes", "get_attributes":
 		return OpTypeGetAttributes
-	case "setattributes":
+	case "setattributes", "set_attributes":
 		return OpTypeSetAttributes
 	}
 


### PR DESCRIPTION
The code generation for attribute-based APIs (SNS, SQS, etc) had not been kept up to date for 2+ years, meaning that the SNS and SQS controllers could not be regenerated to bring in updated ACK runtimes or aws-sdk-go releases.

This commit gets the attribute-based API code generation back into shape. Most of the changes in here were around the code generator being able to find either ResourceConfig or FieldConfig objects using case-insensitive matching, which turned out to be the main cause for code generator failures when re-generating the SNS controller.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
