### PR TITLE
Add a configuration for `additional_columns` at the Resource level

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,14 +75,14 @@ type PrefixConfig struct {
 }
 
 // GetAdditionalColumns extracts AdditionalColumns defined for a given Resource
-func (c *Config) GetAdditionalColumns(resourceName string) []AdditionalColumnConfig {
+func (c *Config) GetAdditionalColumns(resourceName string) []*AdditionalColumnConfig {
 	if c == nil {
-		return []AdditionalColumnConfig{}
+		return []*AdditionalColumnConfig{}
 	}
 
 	resourceConfig, ok := c.Resources[resourceName]
-	if !ok || resourceConfig.Print == nil || resourceConfig.Print.AdditionalColumns == nil {
-		return []AdditionalColumnConfig{}
+	if !ok || resourceConfig.Print == nil || len(resourceConfig.Print.AdditionalColumns) == 0 {
+		return []*AdditionalColumnConfig{}
 	}
 	return resourceConfig.Print.AdditionalColumns
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,12 +77,12 @@ type PrefixConfig struct {
 // GetAdditionalColumns extracts AdditionalColumns defined for a given Resource
 func (c *Config) GetAdditionalColumns(resourceName string) []*AdditionalColumnConfig {
 	if c == nil {
-		return []*AdditionalColumnConfig{}
+        return nil
 	}
 
 	resourceConfig, ok := c.Resources[resourceName]
 	if !ok || resourceConfig.Print == nil || len(resourceConfig.Print.AdditionalColumns) == 0 {
-		return []*AdditionalColumnConfig{}
+		return nil
 	}
 	return resourceConfig.Print.AdditionalColumns
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,19 @@ type PrefixConfig struct {
 	StatusField string `json:"status_field,omitempty"`
 }
 
+// GetAdditionalColumns extracts AdditionalColumns defined for a given Resource
+func (c *Config) GetAdditionalColumns(resourceName string) []AdditionalColumnConfig {
+	if c == nil {
+		return []AdditionalColumnConfig{}
+	}
+
+	resourceConfig, ok := c.Resources[resourceName]
+	if !ok || resourceConfig.Print == nil || resourceConfig.Print.AdditionalColumns == nil {
+		return []AdditionalColumnConfig{}
+	}
+	return resourceConfig.Print.AdditionalColumns
+}
+
 // GetCustomListFieldMembers finds all of the custom list fields that need to
 // be generated as defined in the generator config.
 func (c *Config) GetCustomListFieldMembers() []string {

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -317,10 +317,20 @@ type UpdateOperationConfig struct {
 	CustomMethodName string `json:"custom_method_name"`
 }
 
+// AdditionalConfig can be used to specify additional printer columns to be included
+// in a Resource's output from kubectl
 type AdditionalColumnConfig struct {
+	// the name to display in the column's output
 	Name string `json:"name"`
+	// the JSONPath definining the source of the output
 	JSONPath string `json:"json_path"`
+	// the OpenAPI type of the output
+	// c.f., https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
 	Type string `json:"type"`
+	// the priority of the column in the resource's output
+	Priority int `json:"priority,omitempty"`
+	// the zero-based index of the position at which to display the column in output
+	Index int `json:"index,omitempty"`
 }
 
 // PrintConfig informs instruct the code generator on how to sort kubebuilder
@@ -343,7 +353,7 @@ type PrintConfig struct {
 
 	// AdditionalColumns can be used to add arbitrary extra columns to a Resource's output
 	// if present, should be a list of objects, each containing: name, json_path, and type
-	AdditionalColumns []AdditionalColumnConfig `json:"additional_columns,omitempty"`
+	AdditionalColumns []*AdditionalColumnConfig `json:"additional_columns,omitempty"`
 }
 
 // ReconcileConfig describes options for controlling the reconciliation

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -317,6 +317,12 @@ type UpdateOperationConfig struct {
 	CustomMethodName string `json:"custom_method_name"`
 }
 
+type AdditionalColumnConfig struct {
+	Name string `json:"name"`
+	JSONPath string `json:"json_path"`
+	Type string `json:"type"`
+}
+
 // PrintConfig informs instruct the code generator on how to sort kubebuilder
 // printcolumn marker coments.
 type PrintConfig struct {
@@ -334,6 +340,10 @@ type PrintConfig struct {
 	AddSyncedColumn *bool `json:"add_synced_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
+
+	// AdditionalColumns can be used to add arbitrary extra columns to a Resource's output
+	// if present, should be a list of objects, each containing: name, json_path, and type
+	AdditionalColumns []AdditionalColumnConfig `json:"additional_columns,omitempty"`
 }
 
 // ReconcileConfig describes options for controlling the reconciliation

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -318,18 +318,18 @@ type UpdateOperationConfig struct {
 }
 
 // AdditionalConfig can be used to specify additional printer columns to be included
-// in a Resource's output from kubectl
+// in a Resource's output from kubectl.
 type AdditionalColumnConfig struct {
-	// the name to display in the column's output
+	// Name is the thing to display in the column's output.
 	Name string `json:"name"`
-	// the JSONPath definining the source of the output
+	// JSONPath defines the source of the output.
 	JSONPath string `json:"json_path"`
-	// the OpenAPI type of the output
+	// Type is the OpenAPI type of the output.
 	// c.f., https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
 	Type string `json:"type"`
-	// the priority of the column in the resource's output
+	// Priority of the column in the resource's output.
 	Priority int `json:"priority,omitempty"`
-	// the zero-based index of the position at which to display the column in output
+	// Index is the zero-based index of the position at which to display the column in output.
 	Index int `json:"index,omitempty"`
 }
 

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -566,9 +566,7 @@ func (r *CRD) PrintSyncedColumn() bool {
 	return r.cfg.ResourceDisplaysSyncedColumn(r.Names.Camel)
 }
 
-func (r *CRD) setAdditionalPrinterColumns(additionalColumns []*ackgenconfig.AdditionalColumnConfig) {
-	r.additionalPrinterColumns = []*PrinterColumn{}
-
+func (r *CRD) addAdditionalPrinterColumns(additionalColumns []*ackgenconfig.AdditionalColumnConfig) {
 	for _, additionalColumn := range additionalColumns {
 		printerColumn := &PrinterColumn{}
 		printerColumn.Name = additionalColumn.Name

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -566,6 +566,20 @@ func (r *CRD) PrintSyncedColumn() bool {
 	return r.cfg.ResourceDisplaysSyncedColumn(r.Names.Camel)
 }
 
+func (r *CRD) setAdditionalPrinterColumns(additionalColumns []*ackgenconfig.AdditionalColumnConfig) {
+	r.additionalPrinterColumns = []*PrinterColumn{}
+
+	for _, additionalColumn := range additionalColumns {
+		printerColumn := &PrinterColumn{}
+		printerColumn.Name = additionalColumn.Name
+		printerColumn.JSONPath = additionalColumn.JSONPath
+		printerColumn.Type = additionalColumn.Type
+		printerColumn.Priority = additionalColumn.Priority
+		printerColumn.Index = additionalColumn.Index
+		r.additionalPrinterColumns = append(r.additionalPrinterColumns, printerColumn)
+	}
+}
+
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue
 // the custom resource as int
 func (r *CRD) ReconcileRequeuOnSuccessSeconds() int {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -284,6 +284,16 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			crd.AddStatusField(memberNames, memberShapeRef)
 		}
 
+		// Now add the additional printer columns that have been defined explicitly
+		// in additional_columns
+		for _, additionalColumn := range m.cfg.GetAdditionalColumns(crdName) {
+			printerColumn := &PrinterColumn{}
+			printerColumn.Name = additionalColumn.Name
+			printerColumn.JSONPath = additionalColumn.JSONPath
+			printerColumn.Type = additionalColumn.Type
+			crd.additionalPrinterColumns = append(crd.additionalPrinterColumns, printerColumn)
+		}
+
 		crds = append(crds, crd)
 	}
 	sort.Slice(crds, func(i, j int) bool {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -286,7 +286,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now add the additional printer columns that have been defined explicitly
 		// in additional_columns
-		crd.setAdditionalPrinterColumns(m.cfg.GetAdditionalColumns(crdName))
+		crd.addAdditionalPrinterColumns(m.cfg.GetAdditionalColumns(crdName))
 
 		crds = append(crds, crd)
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -286,13 +286,7 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 
 		// Now add the additional printer columns that have been defined explicitly
 		// in additional_columns
-		for _, additionalColumn := range m.cfg.GetAdditionalColumns(crdName) {
-			printerColumn := &PrinterColumn{}
-			printerColumn.Name = additionalColumn.Name
-			printerColumn.JSONPath = additionalColumn.JSONPath
-			printerColumn.Type = additionalColumn.Type
-			crd.additionalPrinterColumns = append(crd.additionalPrinterColumns, printerColumn)
-		}
+		crd.setAdditionalPrinterColumns(m.cfg.GetAdditionalColumns(crdName))
 
 		crds = append(crds, crd)
 	}


### PR DESCRIPTION
Issue #, if available:  [1281](https://github.com/aws-controllers-k8s/community/issues/1281)

Description of changes:

We want to have the option to include additional printer columns in the output of `kubectl`.  This change allow the author to specify an arbitrary number of those per Resource, for each specifying the name, type, and JSON path of the field to produce.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
