### PR TITLE
include Spec fields in GetAttributes SetResource

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -793,7 +793,6 @@ func SetResourceGetAttributes(
 
 	out := "\n"
 	indent := strings.Repeat("\t", indentLevel)
-	adaptiveTargetVarName := targetVarName + cfg.PrefixConfig.StatusField
 
 	// did we output an ACKResourceMetadata guard and constructor snippet?
 	mdGuardOut := false
@@ -806,6 +805,7 @@ func SetResourceGetAttributes(
 	}
 	sort.Strings(sortedAttrFieldNames)
 	for _, fieldName := range sortedAttrFieldNames {
+		adaptiveTargetVarName := targetVarName + cfg.PrefixConfig.StatusField
 		if r.IsPrimaryARNField(fieldName) {
 			if !mdGuardOut {
 				out += ackResourceMetadataGuardConstructor(
@@ -850,16 +850,17 @@ func SetResourceGetAttributes(
 		}
 
 		fieldNames := names.New(fieldName)
-		if fieldConfig.IsReadOnly {
-			out += fmt.Sprintf(
-				"%s%s.%s = %s.Attributes[\"%s\"]\n",
-				indent,
-				adaptiveTargetVarName,
-				fieldNames.Camel,
-				sourceVarName,
-				fieldName,
-			)
+		if !fieldConfig.IsReadOnly {
+			adaptiveTargetVarName = targetVarName + cfg.PrefixConfig.SpecField
 		}
+		out += fmt.Sprintf(
+			"%s%s.%s = %s.Attributes[\"%s\"]\n",
+			indent,
+			adaptiveTargetVarName,
+			fieldNames.Camel,
+			sourceVarName,
+			fieldName,
+		)
 	}
 	return out
 }

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -2712,12 +2712,16 @@ func TestSetResource_SNS_Topic_GetAttributes(t *testing.T) {
 	// (and thus in the Spec fields). Two of them are the tesource's ARN and
 	// AWS Owner account ID, both of which are handled specially.
 	expected := `
+	ko.Spec.DeliveryPolicy = resp.Attributes["DeliveryPolicy"]
+	ko.Spec.DisplayName = resp.Attributes["DisplayName"]
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
+	ko.Spec.KMSMasterKeyID = resp.Attributes["KmsMasterKeyId"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
 	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
 	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
+	ko.Spec.Policy = resp.Attributes["Policy"]
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["TopicArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 `
@@ -2766,13 +2770,24 @@ func TestSetResource_SQS_Queue_GetAttributes(t *testing.T) {
 	// (and thus in the Spec fields). One of them is the resource's ARN which
 	// is handled specially.
 	expected := `
+	ko.Spec.ContentBasedDeduplication = resp.Attributes["ContentBasedDeduplication"]
 	ko.Status.CreatedTimestamp = resp.Attributes["CreatedTimestamp"]
+	ko.Spec.DelaySeconds = resp.Attributes["DelaySeconds"]
+	ko.Spec.FifoQueue = resp.Attributes["FifoQueue"]
+	ko.Spec.KMSDataKeyReusePeriodSeconds = resp.Attributes["KmsDataKeyReusePeriodSeconds"]
+	ko.Spec.KMSMasterKeyID = resp.Attributes["KmsMasterKeyId"]
 	ko.Status.LastModifiedTimestamp = resp.Attributes["LastModifiedTimestamp"]
+	ko.Spec.MaximumMessageSize = resp.Attributes["MaximumMessageSize"]
+	ko.Spec.MessageRetentionPeriod = resp.Attributes["MessageRetentionPeriod"]
+	ko.Spec.Policy = resp.Attributes["Policy"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["QueueArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
+	ko.Spec.ReceiveMessageWaitTimeSeconds = resp.Attributes["ReceiveMessageWaitTimeSeconds"]
+	ko.Spec.RedrivePolicy = resp.Attributes["RedrivePolicy"]
+	ko.Spec.VisibilityTimeout = resp.Attributes["VisibilityTimeout"]
 `
 	assert.Equal(
 		expected,

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -5,6 +5,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
+	var err error
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkUpdate")
 	defer func() {


### PR DESCRIPTION
Attempting to generate the SNS controller with code-generator <=
v0.21.0 results in various `make test` failures that look like this:

```
[jaypipes@thelio sns-controller]$ make test
go test -v ./...
?   	github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1	[no test files]
pkg/resource/topic/sdk.go:225:8: undefined: err
pkg/resource/platform_application/sdk.go:75:6: resp declared but not used
pkg/resource/platform_application/sdk.go:217:8: undefined: err
pkg/resource/platform_endpoint/sdk.go:75:6: resp declared but not used
pkg/resource/platform_endpoint/sdk.go:113:48: r.ko.Spec.EndpointARN undefined (type "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1".PlatformEndpointSpec has no field or method EndpointARN)
pkg/resource/platform_endpoint/sdk.go:202:8: undefined: err
pkg/resource/platform_endpoint/sdk.go:270:48: r.ko.Spec.EndpointARN undefined (type "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1".PlatformEndpointSpec has no field or method EndpointARN)
make: *** [Makefile:19: test] Error 2
```

We were not including Spec fields in the processing of
SetResourceGetAttributes, which resulted in a bunch of `resp variable
declared and not used` compile-time failures. This patch fixes that by
pulling attributes from the resulting Attributes map into Spec fields
when the field is_read_only=false.

In addition, fixes the template for sdk_update_set_attributes to declare
an `err` variable before referencing it.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
