### PR TITLE
fix Attribute-based delta comparisons

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -121,11 +121,6 @@ func CompareResource(
 			compareConfig = fieldConfig.Compare
 		}
 
-		if fieldConfig != nil && fieldConfig.IsAttribute {
-			// NOTE(jaypipes): We compare the Attributes collection
-			// specially...
-			continue
-		}
 		if compareConfig != nil && compareConfig.IsIgnored {
 			continue
 		}


### PR DESCRIPTION
I had erroneously removed the delta comparison logic for attribute-based API fields. This adds them back to the compare.go generators.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
