### PR TITLE
ensure attribute fields have a ShapeRef

### DIFF
--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -25,6 +25,14 @@ import (
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
 
+// simpleStringShapeRef is used for attribute fields and fields where there was
+// no found ShapeRef
+var simpleStringShapeRef *awssdkmodel.ShapeRef = &awssdkmodel.ShapeRef{
+	Shape: &awssdkmodel.Shape{
+		Type: "string",
+	},
+}
+
 // Field represents a single field in the CRD's Spec or Status objects. The
 // field may be a direct field of the Spec or Status object or may be a field
 // of a list or struct-type field of the Spec or Status object. We call these
@@ -323,6 +331,7 @@ func newFieldRecurse(
 		gte = "string"
 		gt = "*string"
 		gtwp = "*string"
+		shapeRef = simpleStringShapeRef
 	}
 
 	return &Field{

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -15,13 +15,14 @@ import (
 
 {{ .CRD.Documentation }}
 type {{ .CRD.Kind }}Spec struct {
-	{{- range $fieldName, $field := .CRD.SpecFields }}
-	{{- if $field.ShapeRef }}
-	{{ $field.ShapeRef.Documentation }}
-	{{- end }}
-	{{ if and ($field.IsRequired) (not $field.HasReference) }} // +kubebuilder:validation:Required
-	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }}"`
-	{{- else }} {{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"` {{ end }}
+{{ range $fieldName, $field := .CRD.SpecFields }}
+{{ if $field.ShapeRef.Documentation -}}
+    {{ $field.ShapeRef.Documentation }}
+{{ end -}}
+{{- if and ($field.IsRequired) (not $field.HasReference) -}}
+    // +kubebuilder:validation:Required
+{{ end -}}
+    {{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }}{{- if or (not $field.IsRequired) ($field.HasReference) }},omitempty{{- end -}}"`
 {{- end }}
 }
 
@@ -39,7 +40,7 @@ type {{ .CRD.Kind }}Status struct {
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
-	{{- if $field.ShapeRef }}
+	{{- if $field.ShapeRef.Documentation }}
 	{{ $field.ShapeRef.Documentation }}
 	{{- end }}
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
When attempting to generate the SNS controller, I was getting the following failure:

```
[jaypipes@thelio code-generator]$ make build-controller SERVICE=sns
building ack-generate ... ok.
==== building sns-controller ====
Copying common custom resource definitions into sns
Building Kubernetes API objects for sns
Generating deepcopy code for sns
Generating custom resource definitions for sns
Building service controller for sns
Error: template: /home/jaypipes/go/src/github.com/aws-controllers-k8s/code-generator/templates/pkg/resource/delta.go.tpl:34:3: executing "/home/jaypipes/go/src/github.com/aws-controllers-k8s/code-generator/templates/pkg/resource/delta.go.tpl" at <GoCodeCompare .CRD "delta" "a.ko" "b.ko" 1>: error calling GoCodeCompare: runtime error: invalid memory address or nil pointer dereference
make: *** [Makefile:41: build-controller] Error 1
```

This failure turned out to be due to attribute-based API fields that do not have a `type: XXX` generator.yaml configuration option specified (as they do in the sqs-controller's generator.yaml) would end up getting a `pkg/model.Field` object created that had a `nil` ShapeRef. This caused problems in certain Go code generator functions (such as `pkg/generate/code.CompareResource`) that rely on `Field.ShapeRef` being non-nil.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
