### PR TITLE
Fix panic in code generator when generating lambda controller

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -16,7 +16,7 @@ import (
 {{ .CRD.Documentation }}
 type {{ .CRD.Kind }}Spec struct {
 {{ range $fieldName, $field := .CRD.SpecFields }}
-{{ if $field.ShapeRef.Documentation -}}
+{{ if $field.ShapeRef -}}
     {{ $field.ShapeRef.Documentation }}
 {{ end -}}
 {{- if and ($field.IsRequired) (not $field.HasReference) -}}


### PR DESCRIPTION
The recent patch ([PR 383](https://github.com/aws-controllers-k8s/code-generator/pull/383)) introduced a regression that caused the
code generator to panic when generating the lambda controller.
This commit addresses the issue by adding a check to ensure that
the shapeRef reference is not nil before accessing the
Documentation field. This prevents the panic from occurring and
allows the code generator to function correctly.

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
