### PR TITLE
fix CRD Go struct generation for SNS and Lambda

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -16,7 +16,7 @@ import (
 {{ .CRD.Documentation }}
 type {{ .CRD.Kind }}Spec struct {
 {{ range $fieldName, $field := .CRD.SpecFields }}
-{{ if $field.ShapeRef -}}
+{{ if and ($field.ShapeRef) ($field.ShapeRef.Documentation) -}}
     {{ $field.ShapeRef.Documentation }}
 {{ end -}}
 {{- if and ($field.IsRequired) (not $field.HasReference) -}}
@@ -40,7 +40,7 @@ type {{ .CRD.Kind }}Status struct {
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
-	{{- if $field.ShapeRef.Documentation }}
+	{{- if and ($field.ShapeRef) ($field.ShapeRef.Documentation) }}
 	{{ $field.ShapeRef.Documentation }}
 	{{- end }}
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
aws-controllers-k8s/code-generator#383 fixed generation of CRD Go structs for SNS and SQS. Unfortunately, that PR broke Lambda, which has some fields that do not have `ShapeRef` attributes.

aws-controllers-k8s/code-generato#384 fixed Lambda but subsequently re-broke SNS and SQS generation, with `make build-controller SERVICE=sns` producing erroneous whitespace-different CRD Go structs:

```diff
[jaypipes@thelio sns-controller]$ git diff
diff --git a/apis/v1alpha1/ack-generate-metadata.yaml b/apis/v1alpha1/ack-generate-metadata.yaml
index 81fbab0..a894215 100755
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2022-12-16T20:24:15Z"
-  build_hash: e661ce95afc39b380653ca655503daebf1e1831b
+  build_date: "2022-12-19T18:13:35Z"
+  build_hash: 8d843f48df4504e3d19712c0e27dbb388ff40cc0
   go_version: go1.18.1
-  version: v0.21.0-5-ge661ce9
-api_directory_checksum: a0c05230761bda067a0f03b794041014296b8bcb
+  version: v0.21.0-6-g8d843f4
+api_directory_checksum: b10135ae96fc0459ddaa92c9ea9429424b052424
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
diff --git a/apis/v1alpha1/platform_application.go b/apis/v1alpha1/platform_application.go
index e0402de..9e757fe 100644
--- a/apis/v1alpha1/platform_application.go
+++ b/apis/v1alpha1/platform_application.go
@@ -24,10 +24,14 @@ import (
 //
 // Platform application object.
 type PlatformApplicationSpec struct {
-       EventDeliveryFailure   *string `json:"eventDeliveryFailure,omitempty"`
-       EventEndpointCreated   *string `json:"eventEndpointCreated,omitempty"`
-       EventEndpointDeleted   *string `json:"eventEndpointDeleted,omitempty"`
-       EventEndpointUpdated   *string `json:"eventEndpointUpdated,omitempty"`
+       EventDeliveryFailure *string `json:"eventDeliveryFailure,omitempty"`
+
+       EventEndpointCreated *string `json:"eventEndpointCreated,omitempty"`
+
+       EventEndpointDeleted *string `json:"eventEndpointDeleted,omitempty"`
+
+       EventEndpointUpdated *string `json:"eventEndpointUpdated,omitempty"`
+
        FailureFeedbackRoleARN *string `json:"failureFeedbackRoleARN,omitempty"`
        // Application names must be made up of only uppercase and lowercase ASCII letters,
        // numbers, underscores, hyphens, and periods, and must be between 1 and 256
@@ -38,10 +42,14 @@ type PlatformApplicationSpec struct {
        // (Apple Push Notification Service), APNS_SANDBOX, and GCM (Firebase Cloud
        // Messaging).
        // +kubebuilder:validation:Required
-       Platform                  *string `json:"platform"`
-       PlatformCredential        *string `json:"platformCredential,omitempty"`
-       PlatformPrincipal         *string `json:"platformPrincipal,omitempty"`
-       SuccessFeedbackRoleARN    *string `json:"successFeedbackRoleARN,omitempty"`
+       Platform *string `json:"platform"`
+
+       PlatformCredential *string `json:"platformCredential,omitempty"`
+
+       PlatformPrincipal *string `json:"platformPrincipal,omitempty"`
+
+       SuccessFeedbackRoleARN *string `json:"successFeedbackRoleARN,omitempty"`
+
        SuccessFeedbackSampleRate *string `json:"successFeedbackSampleRate,omitempty"`
 }

diff --git a/apis/v1alpha1/platform_endpoint.go b/apis/v1alpha1/platform_endpoint.go
index e24fd42..b809a73 100644
--- a/apis/v1alpha1/platform_endpoint.go
+++ b/apis/v1alpha1/platform_endpoint.go
@@ -23,12 +23,14 @@ import (
 // PlatformEndpointSpec defines the desired state of PlatformEndpoint.
 type PlatformEndpointSpec struct {
        CustomUserData *string `json:"customUserData,omitempty"`
-       Enabled        *string `json:"enabled,omitempty"`
+
+       Enabled *string `json:"enabled,omitempty"`
        // PlatformApplicationArn returned from CreatePlatformApplication is used to
        // create a an endpoint.
        // +kubebuilder:validation:Required
        PlatformApplicationARN *string `json:"platformApplicationARN"`
-       Token                  *string `json:"token,omitempty"`
+
+       Token *string `json:"token,omitempty"`
 }

 // PlatformEndpointStatus defines the observed state of PlatformEndpoint
diff --git a/apis/v1alpha1/topic.go b/apis/v1alpha1/topic.go
index 31d1506..87b35f7 100644
--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -34,9 +34,12 @@ type TopicSpec struct {
        //
        // Length Constraints: Maximum length of 30,720.
        DataProtectionPolicy *string `json:"dataProtectionPolicy,omitempty"`
-       DeliveryPolicy       *string `json:"deliveryPolicy,omitempty"`
-       DisplayName          *string `json:"displayName,omitempty"`
-       KMSMasterKeyID       *string `json:"kmsMasterKeyID,omitempty"`
+
+       DeliveryPolicy *string `json:"deliveryPolicy,omitempty"`
+
+       DisplayName *string `json:"displayName,omitempty"`
+
+       KMSMasterKeyID *string `json:"kmsMasterKeyID,omitempty"`
        // The name of the topic you want to create.
        //
        // Constraints: Topic names must be made up of only uppercase and lowercase
@@ -45,7 +48,8 @@ type TopicSpec struct {
        //
        // For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix.
        // +kubebuilder:validation:Required
-       Name   *string `json:"name"`
+       Name *string `json:"name"`
+
        Policy *string `json:"policy,omitempty"`
```

This patch fixes the issue once and for all by checking both `$field.ShapeRef` for existence as well as
`$field.ShapeRef.Documentation` for a non-zero length.

Issue aws-controllers-k8s/community#1600

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
