### PR TITLE
Complete support for resource-specific resync periods and default drift remediation period

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -37,6 +37,10 @@ spec:
         - "$(ACK_RESOURCE_TAGS)"
         - --watch-namespace
         - "$(ACK_WATCH_NAMESPACE)"
+        - --reconcile-default-resync-seconds
+        - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
+        - --reconcile-resource-resync-seconds
+        - "$(RECONCILE_RESOUCRE_RESYNC_SECONDS)"
         image: controller:latest
         name: controller
         ports:
@@ -66,6 +70,10 @@ spec:
           value: "info"
         - name: ACK_RESOURCE_TAGS
           value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
+        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
+          value: "0"
+        - name: RECONCILE_RESOUCRE_RESYNC_SECONDS
+          value: ""
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -40,7 +40,7 @@ spec:
         - --reconcile-default-resync-seconds
         - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
         - --reconcile-resource-resync-seconds
-        - "$(RECONCILE_RESOUCRE_RESYNC_SECONDS)"
+        - "$(RECONCILE_RESOURCE_RESYNC_SECONDS)"
         image: controller:latest
         name: controller
         ports:
@@ -72,7 +72,7 @@ spec:
           value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
         - name: RECONCILE_DEFAULT_RESYNC_SECONDS
           value: "0"
-        - name: RECONCILE_RESOUCRE_RESYNC_SECONDS
+        - name: RECONCILE_RESOURCE_RESYNC_SECONDS
           value: ""
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -56,6 +56,14 @@ spec:
         - "$(ACK_WATCH_NAMESPACE)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
+{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
+        - --reconcile-default-resync-seconds
+        - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
+{{- end }}
+{{- range $key, $value := .Values.reconcile.resourceResyncPeriod }}
+        - --reconcile-resource-resync-seconds
+        - "$(RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }})"
+{{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller
@@ -88,6 +96,14 @@ spec:
           value: {{ include "aws.credentials.path" . }}
         - name: AWS_PROFILE
           value: {{ .Values.aws.credentials.profile }}
+{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
+        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
+          value: {{ .Values.reconcile.defaultResyncPeriod }}
+{{- end }}
+{{- range $key, $value := .Values.reconcile.resourceResyncPeriod }}
+        - name: RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }}
+          value: {{ $key }}={{ $value }}
+{{- end }}
         volumeMounts:
           - name: {{ .Values.aws.credentials.secretName }}
             mountPath: {{ include "aws.credentials.secret_mount_path" . }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - --reconcile-default-resync-seconds
         - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
 {{- end }}
-{{- range $key, $value := .Values.reconcile.resourceResyncPeriod }}
+{{- range $key, $value := .Values.reconcile.resourceResyncPeriods }}
         - --reconcile-resource-resync-seconds
         - "$(RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }})"
 {{- end }}
@@ -91,19 +91,19 @@ spec:
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
+{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
+        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
+          value: {{ .Values.reconcile.defaultResyncPeriod | quote }}
+{{- end }}
+{{- range $key, $value := .Values.reconcile.resourceResyncPeriods }}
+        - name: RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }}
+          value: {{ $key }}={{ $value }}
+{{- end }}
         {{- if .Values.aws.credentials.secretName }}
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: {{ include "aws.credentials.path" . }}
         - name: AWS_PROFILE
           value: {{ .Values.aws.credentials.profile }}
-{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
-        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
-          value: {{ .Values.reconcile.defaultResyncPeriod }}
-{{- end }}
-{{- range $key, $value := .Values.reconcile.resourceResyncPeriod }}
-        - name: RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }}
-          value: {{ $key }}={{ $value }}
-{{- end }}
         volumeMounts:
           - name: {{ .Values.aws.credentials.secretName }}
             mountPath: {{ include "aws.credentials.secret_mount_path" . }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -207,6 +207,18 @@
       "type": "string",
       "enum": ["delete", "retain"]
     },
+    "reconcile": {
+      "description": "Reconcile resync settings. Parameters to tune the controller's drift remediation period.",
+      "properties": {
+        "defaultResyncPeriod": {
+          "type": "number"
+        },
+        "resourceResyncPeriod": {
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "serviceAccount": {
       "description": "ServiceAccount settings",
       "properties": {

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -213,7 +213,7 @@
         "defaultResyncPeriod": {
           "type": "number"
         },
-        "resourceResyncPeriod": {
+        "resourceResyncPeriods": {
           "type": "object"
         }
       },

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -83,6 +83,13 @@ resourceTags:
 # before the K8s resource is removed.
 deletionPolicy: delete
 
+# controller reconciliation configurations
+reconcile:
+  # The default duration, in seconds, to wait before resyncing desired state of custom resources.
+  defaultResyncPeriod: 0
+  # An object representing the reconcile resync configuration for each specific resource.
+  resourceResyncPeriods: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/1367
Follow-up of https://github.com/aws-controllers-k8s/runtime/pull/106

This patch completes the implementation of support for resource-specific
resync periods and a default drift remediation period made in runtime
repository. The resync period for each reconciler is determined by trying
to retrieve it from the following sources, in this order:

1. A resource-specific period specified in the drift remediation configuration.
2. A resource-specific requeue on success period specified by the resource manager factory.
3. The default drift remediation period specified in the controller configuration.
4. The default resync period defined in the ACK runtime package.

This allows users to customize the drift remediation behavior for different
resources as needed, while still providing a fallback option for resources
that do not have a specific period specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
