### PR TITLE
add: specific selector for operator

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    app.kubernetes.io/name: ack-system
   name: ack-system
 ---
 apiVersion: apps/v1

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -16,11 +16,13 @@ spec:
   selector:
     matchLabels:
       control-plane: controller
+      name: ack-{{ .ServicePackageName }}-controller
   replicas: 1
   template:
     metadata:
       labels:
         control-plane: controller
+        name: ack-{{ .ServicePackageName }}-controller
     spec:
       containers:
       - command:

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller
-    app.kubernetes.io/name: ack-system 
   name: ack-system
 ---
 apiVersion: apps/v1

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller
+    app.kubernetes.io/name: ack-system 
   name: ack-system
 ---
 apiVersion: apps/v1
@@ -12,18 +13,19 @@ metadata:
   namespace: ack-system
   labels:
     control-plane: controller
-    name: ack-{{ .ServicePackageName }}-controller
+    app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
+    app.kubernetes.io/part-of: ack-system
 spec:
   selector:
     matchLabels:
       control-plane: controller
-      name: ack-{{ .ServicePackageName }}-controller
+      app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
   replicas: 1
   template:
     metadata:
       labels:
         control-plane: controller
-        name: ack-{{ .ServicePackageName }}-controller
+        app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
     spec:
       containers:
       - command:

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller
+    app.kubernetes.io/name: ack-system
   name: ack-system
 ---
 apiVersion: apps/v1
@@ -11,19 +11,16 @@ metadata:
   name: ack-{{ .ServicePackageName }}-controller
   namespace: ack-system
   labels:
-    control-plane: controller
     app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
     app.kubernetes.io/part-of: ack-system
 spec:
   selector:
     matchLabels:
-      control-plane: controller
       app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller
         app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
     spec:
       containers:

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -12,6 +12,7 @@ metadata:
   namespace: ack-system
   labels:
     control-plane: controller
+    name: ack-{{ .ServicePackageName }}-controller
 spec:
   selector:
     matchLabels:

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -6,6 +6,7 @@ metadata:
 spec:
   selector:
     control-plane: controller
+    name: ack-{{ .ServicePackageName }}-controller
   ports:
     - name: metricsport
       port: 8080

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -5,7 +5,6 @@ metadata:
   namespace: ack-system
 spec:
   selector:
-    control-plane: controller
     app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
   ports:
     - name: metricsport

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     control-plane: controller
-    name: ack-{{ .ServicePackageName }}-controller
+    app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
   ports:
     - name: metricsport
       port: 8080

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
-    control-plane: controller
 spec:
   replicas: 1
   selector:

--- a/templates/helm/templates/metrics-service.yaml
+++ b/templates/helm/templates/metrics-service.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
-    control-plane: controller
 spec:
   selector:
     app.kubernetes.io/name: {{ include "app.name" . }}


### PR DESCRIPTION
Issue #, if available: [#1632](https://github.com/aws-controllers-k8s/community/issues/1632)

Description of changes:

Improve label selection for service and deployment association with pods. When multiple operators are deployed you may get inconsistent results on the service.

Related [s3-controller/pull/94](https://github.com/aws-controllers-k8s/s3-controller/pull/94)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
