### PR TITLE
Lint all scripts with shellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_CMD_LOCAL_FLAGS=-modfile=go.local.mod $(GO_CMD_FLAGS)
 
 .PHONY: all local-build-ack-generate build-ack-generate local-build-controller \
 	build-controller test local-test build-controller-image \
-	local-build-controller-image
+	local-build-controller-image lint
 
 all: test
 
@@ -57,6 +57,9 @@ test: 				## Run code tests
 
 local-test:			## Run code tests using the local go.mod
 	go test ${GO_CMD_LOCAL_FLAGS} ./...
+
+lint-shell:	## Run linters against all of the bash scripts
+	@find . -type f -name "*.sh" | xargs shellcheck -e SC1091
 
 help:           	## Show this help.
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_CMD_LOCAL_FLAGS=-modfile=go.local.mod $(GO_CMD_FLAGS)
 
 .PHONY: all local-build-ack-generate build-ack-generate local-build-controller \
 	build-controller test local-test build-controller-image \
-	local-build-controller-image lint
+	local-build-controller-image lint-shell
 
 all: test
 

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -14,7 +14,7 @@ QUIET=${QUIET:-"false"}
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 
-source $SCRIPTS_DIR/lib/common.sh
+source "$SCRIPTS_DIR/lib/common.sh"
 
 check_is_installed docker
 
@@ -59,10 +59,10 @@ if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     exit 1
 fi
 
-pushd $SERVICE_CONTROLLER_SOURCE_PATH 1>/dev/null
+pushd "$SERVICE_CONTROLLER_SOURCE_PATH" 1>/dev/null
 
-SERVICE_CONTROLLER_GIT_VERSION=`git describe --tags --always --dirty || echo "unknown"`
-SERVICE_CONTROLLER_GIT_COMMIT=`git rev-parse HEAD`
+SERVICE_CONTROLLER_GIT_VERSION=$(git describe --tags --always --dirty || echo "unknown")
+SERVICE_CONTROLLER_GIT_COMMIT=$(git rev-parse HEAD)
 
 popd 1>/dev/null
 
@@ -86,16 +86,14 @@ if [[ "$LOCAL_MODULES" = "true" ]]; then
   DOCKERFILE="${ROOT_DIR}"/Dockerfile.local
 fi
 
-docker build \
-  --quiet=${QUIET} \
+if ! docker build \
+  --quiet="${QUIET}" \
   -t "${AWS_SERVICE_DOCKER_IMG}" \
   -f "${DOCKERFILE}" \
-  --build-arg service_alias=${AWS_SERVICE} \
+  --build-arg service_alias="${AWS_SERVICE}" \
   --build-arg service_controller_git_version="$SERVICE_CONTROLLER_GIT_VERSION" \
   --build-arg service_controller_git_commit="$SERVICE_CONTROLLER_GIT_COMMIT" \
   --build-arg build_date="$BUILD_DATE" \
-  "${DOCKER_BUILD_CONTEXT}"
-
-if [ $? -ne 0 ]; then
+  "${DOCKER_BUILD_CONTEXT}"; then
   exit 2
 fi

--- a/scripts/construct-metadata.sh
+++ b/scripts/construct-metadata.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRIPTS_DIR=$DIR
 ROOT_DIR=$DIR/..
 
-source $SCRIPTS_DIR/lib/metadata.sh
+source "$SCRIPTS_DIR/lib/metadata.sh"
 
 USAGE="
 Usage:
@@ -52,17 +52,17 @@ echo "🧙 Welcome to the service metadata setup wizard"
 echo "⚠️ WARNING: This script will overwrite the metadata.yaml file in your service controller path"
 
 echo -n "Enter the service's full name [e.g. Amazon Elastic Kubernetes Service]: "
-read full_name
+read -r full_name
 
 echo -n "Enter the service's acronym [e.g. EKS, S3, EC2]: "
-read short_name
+read -r short_name
 
 echo -n "Enter the URL for the service homepage [e.g. https://aws.amazon.com/eks/]: "
-read link
+read -r link
 
 echo -n "Enter the URL for the service's documentation [e.g. https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html]: "
-read documentation
+read -r documentation
 
 echo -n "Generating metadata ... "
-write_new_metadata $METADATA_TEMPLATE_PATH $METADATA_OUTPUT_PATH "$full_name" "$short_name" "$link" "$documentation"
+write_new_metadata "$METADATA_TEMPLATE_PATH" "$METADATA_OUTPUT_PATH" "$full_name" "$short_name" "$link" "$documentation"
 echo "Success!"

--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -18,7 +18,6 @@
 set -eo pipefail
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"
 

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -9,7 +9,6 @@
 set -eo pipefail
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"
 

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -9,7 +9,6 @@
 set -eo pipefail
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"
 

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -21,10 +21,10 @@ DEFAULT_OPERATOR_SDK_VERSION="1.19.1"
 source "${SCRIPTS_DIR}/lib/common.sh"
 
 __operator_sdk_version="${1}"
-if [ "x${__operator_sdk_version}" == "x" ]; then
+if [ "${__operator_sdk_version}" == "" ]; then
     __operator_sdk_version=${OPERATOR_SDK_VERSION:-$DEFAULT_OPERATOR_SDK_VERSION}
 fi
-if ! is_installed ${OPERATOR_SDK_BIN_PATH}/operator-sdk; then
+if ! is_installed "${OPERATOR_SDK_BIN_PATH}/operator-sdk"; then
     __platform=$(uname | tr '[:upper:]' '[:lower:]')
     __arch=$(go env GOARCH | tr '[:upper:]' '[:lower:]')
     __tmp_install_dir=$(mktemp -d -t install-operator-sdk-XXX)
@@ -36,8 +36,8 @@ if ! is_installed ${OPERATOR_SDK_BIN_PATH}/operator-sdk; then
     __install_path="$__install_dir/operator-sdk"
 
     echo -n "installing operator-sdk from ${__operator_sdk_url} ... "
-    curl -sq -L ${__operator_sdk_url} --output ${__tmp_install_dir}/operator-sdk_${__platform}_${__arch}
-    chmod +x ${__tmp_install_dir}/operator-sdk_${__platform}_${__arch}
+    curl -sq -L "${__operator_sdk_url}" --output "${__tmp_install_dir}/operator-sdk_${__platform}_${__arch}"
+    chmod +x "${__tmp_install_dir}/operator-sdk_${__platform}_${__arch}"
     sudo mv "${__tmp_install_dir}/operator-sdk_${__platform}_${__arch}" "$__install_path"
     echo "ok."
 fi

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -21,7 +21,10 @@ DEFAULT_AWS_CLI_VERSION="2.0.52"
 # To use a specific version of the AWS CLI, set the ACK_AWS_CLI_IMAGE_VERSION
 # environment variable, otherwise the value of DEFAULT_AWS_CLI_VERSION is used.
 daws() {
-    aws_cli_profile_env=$([ -n "$AWS_PROFILE" ] && echo "--env AWS_PROFILE=$AWS_PROFILE")
+    aws_cli_profile_env=()
+    if [ -n "$AWS_PROFILE" ]; then
+        aws_cli_profile_env=("--env AWS_PROFILE=$AWS_PROFILE")
+    fi
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
     docker run --rm -v ~/.aws:/root/.aws:z "${aws_cli_profile_env[@]}" -v "$(pwd)":/aws "$aws_cli_img" "$@"

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -21,10 +21,10 @@ DEFAULT_AWS_CLI_VERSION="2.0.52"
 # To use a specific version of the AWS CLI, set the ACK_AWS_CLI_IMAGE_VERSION
 # environment variable, otherwise the value of DEFAULT_AWS_CLI_VERSION is used.
 daws() {
-    aws_cli_profile_env=$([ ! -z "$AWS_PROFILE" ] && echo "--env AWS_PROFILE=$AWS_PROFILE")
+    aws_cli_profile_env=$([ -n "$AWS_PROFILE" ] && echo "--env AWS_PROFILE=$AWS_PROFILE")
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
-    docker run --rm -v ~/.aws:/root/.aws:z $(echo $aws_cli_profile_env) -v $(pwd):/aws "$aws_cli_img" "$@"
+    docker run --rm -v ~/.aws:/root/.aws:z "${aws_cli_profile_env[@]}" -v "$(pwd)":/aws "$aws_cli_img" "$@"
 }
 
 # aws_check_credentials() calls the STS::GetCallerIdentity API call and
@@ -32,28 +32,8 @@ daws() {
 aws_check_credentials() {
     echo -n "checking AWS credentials ... "
     daws sts get-caller-identity --query "Account" >/dev/null ||
-        ( echo "\nFATAL: No AWS credentials found. Please run \`aws configure\` to set up the CLI for your credentials." && exit 1)
+        ( printf "\nFATAL: No AWS credentials found. Please run \`aws configure\` to set up the CLI for your credentials." && exit 1)
     echo "ok."
-}
-
-# generate_aws_temp_creds function will generate temporary AWS CREDENTIALS which are valid for 900 seconds
-aws_generate_temp_creds() {
-    __uuid=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
-
-    if [ -z "$AWS_ROLE_ARN" ]; then
-        printf "Missing input Role ARN, exiting...\n"
-        exit 1
-    fi
-
-    JSON=$(daws sts assume-role \
-           --role-arn "$AWS_ROLE_ARN"  \
-           --role-session-name tmp-role-"$__uuid" \
-           --duration-seconds 900 \
-           --output json || exit 1)
-
-    AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
-    AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
-    AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
 }
 
 aws_account_id() {

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-CONTROLLER_TOOLS_VERSION="v0.9.2"
-export CONTROLLER_TOOLS_VERSION
-HELM_VERSION="v3.7"
-export HELM_VERSION
+export CONTROLLER_TOOLS_VERSION="v0.9.2"
+export HELM_VERSION="v3.7"
 
 # setting the -x option if debugging is true
 if [[ "${DEBUG:-"false"}" = "true" ]]; then

--- a/scripts/lib/metadata.sh
+++ b/scripts/lib/metadata.sh
@@ -33,8 +33,8 @@ get_service_short_name() {
 
   local __service_name="$1"
 
-  metadata="$(get_service_metadata $__service_name)"
-  yq eval '.service.short_name' $metadata
+  metadata="$(get_service_metadata "$__service_name")"
+  yq eval '.service.short_name' "$metadata"
 }
 
 # get_service_full_name returns the full name for a given service
@@ -48,8 +48,8 @@ get_service_full_name() {
 
   local __service_name="$1"
 
-  metadata="$(get_service_metadata $__service_name)"
-  yq eval '.service.full_name' $metadata
+  metadata="$(get_service_metadata "$__service_name")"
+  yq eval '.service.full_name' "$metadata"
 }
 
 # get_service_versions returns the list of api versions supported by the given
@@ -64,8 +64,8 @@ get_service_versions() {
 
   local __service_name="$1"
 
-  metadata="$(get_service_metadata $__service_name)"
-  yq eval '.versions[].api_version' $metadata
+  metadata="$(get_service_metadata "$__service_name")"
+  yq eval '.versions[].api_version' "$metadata"
 }
 
 # get_latest_version returns the latest api version supported by the given
@@ -80,8 +80,8 @@ get_latest_version() {
 
   local __service_name="$1"
 
-  metadata="$(get_service_metadata $__service_name)"
-  yq eval '[.versions[].api_version] | .[-1]' $metadata
+  metadata="$(get_service_metadata "$__service_name")"
+  yq eval '[.versions[].api_version] | .[-1]' "$metadata"
 }
 
 # write_new_metadata will write all fields of a new metadata to file 
@@ -107,8 +107,8 @@ write_new_metadata() {
 
   cp "$__template_path" "$__output_path"
 
-  yq e '.service.full_name=env(__full_name)' -i $__output_path
-  yq e '.service.short_name=env(__short_name)' -i $__output_path
-  yq e '.service.link=env(__link)' -i $__output_path
-  yq e '.service.documentation=env(__documentation)' -i $__output_path
+  yq e '.service.full_name=env(__full_name)' -i "$__output_path"
+  yq e '.service.short_name=env(__short_name)' -i "$__output_path"
+  yq e '.service.link=env(__link)' -i "$__output_path"
+  yq e '.service.documentation=env(__documentation)' -i "$__output_path"
 }

--- a/scripts/olm-build-bundle-image.sh
+++ b/scripts/olm-build-bundle-image.sh
@@ -12,7 +12,7 @@ DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 
-source $SCRIPTS_DIR/lib/common.sh
+source "$SCRIPTS_DIR/lib/common.sh"
 
 check_is_installed docker
 
@@ -101,7 +101,7 @@ BUNDLE_DOCKERFILE_DIR=${BUNDLE_DOCKERFILE_DIR:-$DEFAULT_BUNDLE_DOCKERFILE_DIR}
 BUNDLE_DOCKERFILE="$BUNDLE_DOCKERFILE_DIR/bundle.Dockerfile"
 
 # stop if the dockerfile was not found
-if [ ! -f $BUNDLE_DOCKERFILE ]; then
+if [ ! -f "$BUNDLE_DOCKERFILE" ]; then
   echo "The bundle.Dockerfile was not found at expected path $BUNDLE_DOCKERFILE."
   exit 1
 fi
@@ -110,22 +110,19 @@ DEFAULT_BUNDLE_DOCKER_IMG_TAG="$AWS_SERVICE-bundle-$BUNDLE_VERSION"
 BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
 BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
 
-build_args="--quiet=${QUIET} -t ${BUNDLE_DOCKER_IMG} -f ${BUNDLE_DOCKERFILE} --build-arg build_date=\"$BUILD_DATE\""
+build_args=("--quiet=${QUIET}" -t "${BUNDLE_DOCKER_IMG}" -f "${BUNDLE_DOCKERFILE}" --build-arg build_date=\""$BUILD_DATE"\")
 
 if [[ $ADD_RH_CERTIFICATION_LABELS = "true" ]]; then 
   # add additional labels with values for certification purposes.
-  build_args="$build_args --label=$cert_label_openshift_supported_version=$SUPPORTED_OPENSHIFT_VERSIONS --label=$cert_label_deliver_backport=$RED_HAT_DELIVER_BACKPORT --label=$cert_label_operator_bundle_delivery=$RED_HAT_DELIVERY_BUNDLE"
+  build_args=("${build_args[@]}" "--label=$cert_label_openshift_supported_version=$SUPPORTED_OPENSHIFT_VERSIONS" "--label=$cert_label_deliver_backport=$RED_HAT_DELIVER_BACKPORT" "--label=$cert_label_operator_bundle_delivery=$RED_HAT_DELIVERY_BUNDLE")
 fi
 
 if [[ $QUIET = "false" ]]; then
     echo "building '$AWS_SERVICE' OLM bundle container image with tag: ${BUNDLE_DOCKER_IMG}"
 fi
 
-pushd $BUNDLE_DOCKERFILE_DIR 1>/dev/null
-docker build $build_args .
-
-if [ $? -ne 0 ]; then
+pushd "$BUNDLE_DOCKERFILE_DIR" 1>/dev/null
+if ! docker build "${build_args[@]}" .; then
   exit 2
 fi
-
 popd 1>/dev/null

--- a/scripts/olm-publish-bundle-image.sh
+++ b/scripts/olm-publish-bundle-image.sh
@@ -7,7 +7,7 @@ SCRIPTS_DIR=$DIR
 DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
 
-source $SCRIPTS_DIR/lib/common.sh
+source "$SCRIPTS_DIR/lib/common.sh"
 
 check_is_installed docker
 
@@ -17,7 +17,7 @@ Usage:
 
 Publishes the Docker image for an ACK service OLM bundle. By default, the
 repository will be $DEFAULT_DOCKER_REPOSITORY and the image tag for the
-specific ACK service controller will be ":\$SERVICE-bundle-\$VERSION".
+specific ACK service controller will be \":\$SERVICE-bundle-\$VERSION\".
 
 <AWS_SERVICE> AWS Service name (ecr, sns, sqs)
 <BUNDLE_VERSION> OLM bundle version in SemVer (0.0.1, 1.0.0)
@@ -51,12 +51,10 @@ BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
 BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
 
 export BUNDLE_DOCKER_IMG
-${SCRIPTS_DIR}/olm-build-bundle-image.sh ${AWS_SERVICE} ${BUNDLE_VERSION}
+"${SCRIPTS_DIR}"/olm-build-bundle-image.sh "${AWS_SERVICE}" "${BUNDLE_VERSION}"
 
 echo "Pushing '$AWS_SERVICE' operator lifecycle manager bundle image with tag: ${BUNDLE_DOCKER_IMG_TAG}"
 
-docker push ${BUNDLE_DOCKER_IMG}
-
-if [ $? -ne 0 ]; then
+if ! docker push "${BUNDLE_DOCKER_IMG}"; then
   exit 2
 fi


### PR DESCRIPTION
Description of changes:
Used the output of the `shellcheck` tool to make style changes to all of the shell scripts within the repository. Added a new `make` target for `lint-shell` which lints all of the scripts and excludes SC1091, which fails because we `source` other scripts using path variables (a known limitation of `shellcheck`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
