### PR TITLE
support field custom documentation strings

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -13,7 +13,9 @@
 
 package config
 
-import "strings"
+import (
+	"strings"
+)
 
 // SourceFieldConfig instructs the code generator how to handle a field in the
 // Resource's SpecFields/StatusFields collection that takes its value from an
@@ -49,23 +51,23 @@ import "strings"
 // CreateFunction API call, which has a `Code` member of its Input shape that
 // looks like this:
 //
-// "Code": {
-//   "ImageUri": "string",
-//   "S3Bucket": "string",
-//   "S3Key": "string",
-//   "S3ObjectVersion": "string",
-//   "ZipFile": blob
-// },
+//	"Code": {
+//	  "ImageUri": "string",
+//	  "S3Bucket": "string",
+//	  "S3Key": "string",
+//	  "S3ObjectVersion": "string",
+//	  "ZipFile": blob
+//	},
 //
 // The GetFunction API call's Output shape has a same-named field called
 // `Code` in it, but this field looks like this:
 //
-// "Code": {
-//   "ImageUri": "string",
-//   "Location": "string",
-//   "RepositoryType": "string",
-//   "ResolvedImageUri": "string"
-// },
+//	"Code": {
+//	  "ImageUri": "string",
+//	  "Location": "string",
+//	  "RepositoryType": "string",
+//	  "ResolvedImageUri": "string"
+//	},
 //
 // This presents a conundrum to the ACK code generator, which, as noted above,
 // assumes the data types of same-named fields in the Create Operation's Input
@@ -80,23 +82,24 @@ import "strings"
 // ReadOne Operation's Output shape:
 //
 // resources:
-//   Function:
-//     fields:
-//       CodeLocation:
-//         is_read_only: true
-//         from:
-//           operation: GetFunction
-//           path: Code.Location
-//       CodeRepositoryType:
-//         is_read_only: true
-//         from:
-//           operation: GetFunction
-//           path: Code.RepositoryType
-//       CodeRegisteredImageURI:
-//         is_read_only: true
-//         from:
-//           operation: GetFunction
-//           path: Code.RegisteredImageUri
+//
+//	Function:
+//	  fields:
+//	    CodeLocation:
+//	      is_read_only: true
+//	      from:
+//	        operation: GetFunction
+//	        path: Code.Location
+//	    CodeRepositoryType:
+//	      is_read_only: true
+//	      from:
+//	        operation: GetFunction
+//	        path: Code.RepositoryType
+//	    CodeRegisteredImageURI:
+//	      is_read_only: true
+//	      from:
+//	        operation: GetFunction
+//	        path: Code.RegisteredImageUri
 type SourceFieldConfig struct {
 	// Operation refers to the ID of the API Operation where we will
 	// determine the field's Go type.
@@ -135,17 +138,20 @@ type SourceFieldConfig struct {
 // the SetResource generator:
 //
 // ```go
-// if resp.DBInstance.DBSecurityGroups != nil {
-//     f17 := []*string{}
-//     for _, f17iter := range resp.DBInstance.DBSecurityGroups {
-//         var f17elem string
-//         f17elem = *f17iter.DBSecurityGroupName
-//         f17 = append(f17, &f17elem)
-//     }
-//     ko.Spec.DBSecurityGroupNames = f17
-// } else {
-//     ko.Spec.DBSecurityGroupNames = nil
-// }
+//
+//	if resp.DBInstance.DBSecurityGroups != nil {
+//	    f17 := []*string{}
+//	    for _, f17iter := range resp.DBInstance.DBSecurityGroups {
+//	        var f17elem string
+//	        f17elem = *f17iter.DBSecurityGroupName
+//	        f17 = append(f17, &f17elem)
+//	    }
+//	    ko.Spec.DBSecurityGroupNames = f17
+//	} else {
+//
+//	    ko.Spec.DBSecurityGroupNames = nil
+//	}
+//
 // ```
 //
 // [0] https://github.com/aws/aws-sdk-go/blob/0a01aef9caf16d869c7340e729080205760dc2a2/models/apis/rds/2014-10-31/api-2.json#L2985
@@ -274,12 +280,14 @@ type LateInitializeConfig struct {
 // Example:
 // ```
 // Integration:
-//    fields:
-//      ApiId:
-//        references:
-//          resource: API
-//          path: Status.APIID
-//```
+//
+//	fields:
+//	  ApiId:
+//	    references:
+//	      resource: API
+//	      path: Status.APIID
+//
+// ```
 // The above configuration will result in generation of a new field 'APIRef'
 // of type 'AWSResourceReference' for ApiGatewayv2-Integration crd.
 // When 'APIRef' field is present in custom resource manifest, reconciler will
@@ -384,10 +392,15 @@ type FieldConfig struct {
 	// TODO(jaypipes,crtbry): Figure out if we can roll the CustomShape stuff
 	// into this type override...
 	Type *string `json:"type,omitempty"`
+	// Documentation is a string that is added *in addition to* any existing
+	// field documentation derived from the field's doc-2.json contents. For
+	// custom fields, this allows you to add custom documentation for the
+	// field.
+	Documentation *string `json:"documentation,omitempty"`
 }
 
 // GetFieldConfigs returns all FieldConfigs for a given resource as a map.
-// The map is keyed by the resource's field names after applying renames, if applicable.
+// The map is keyed by the resource's field paths
 func (c *Config) GetFieldConfigs(resourceName string) map[string]*FieldConfig {
 	if c == nil {
 		return map[string]*FieldConfig{}

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-doc-overrides.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-doc-overrides.yaml
@@ -1,0 +1,66 @@
+ignore:
+  resource_names:
+    - AccountAttribute
+    - CapacityReservation
+    - CarrierGateway
+    - ClientVpnEndpoint
+    - ClientVpnRoute
+    - CustomerGateway
+    - DefaultSubnet
+    - DefaultVpc
+    - DhcpOptions
+    - EgressOnlyInternetGateway
+    - Fleet
+    - FpgaImage
+    - Image
+    - Instance
+    - InstanceExportTask
+    - InternetGateway
+    - KeyPair
+    - LaunchTemplateVersion
+    #- LaunchTemplate
+    - LocalGatewayRouteTableVpcAssociation
+    - LocalGatewayRoute
+    - ManagedPrefixList
+    - NatGateway
+    - NetworkAclEntry
+    - NetworkAcl
+    - NetworkInsightsPath
+    - NetworkInterfacePermission
+    - NetworkInterface
+    - PlacementGroup
+    - ReservedInstancesListing
+    - RouteTable
+    - Route
+    - SecurityGroup
+    - Snapshot
+    - SpotDatafeedSubscription
+    - Subnet
+    - TrafficMirrorFilterRule
+    - TrafficMirrorFilter
+    - TrafficMirrorSession
+    - TrafficMirrorTarget
+    - TransitGatewayConnectPeer
+    - TransitGatewayConnect
+    - TransitGatewayMulticastDomain
+    - TransitGatewayPeeringAttachment
+    - TransitGatewayPrefixListReference
+    - TransitGatewayRouteTable
+    - TransitGatewayRoute
+    - TransitGatewayVpcAttachment
+    - TransitGateway
+    - Volume
+    - VpcEndpointConnectionNotification
+    - VpcEndpointServiceConfiguration
+    - VpcEndpoint
+    - Vpc
+    - VpcCidrBlock
+    - VpcPeeringConnection
+    - VpnConnectionRoute
+    - VpnConnection
+    - VpnGateway
+resources:
+  LaunchTemplate:
+    fields:
+      LaunchTemplateData.HibernationOptions.Configured:
+        documentation: XXX extended docs XXX

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -16,8 +16,8 @@ import (
 {{ .CRD.Documentation }}
 type {{ .CRD.Kind }}Spec struct {
 {{ range $fieldName, $field := .CRD.SpecFields }}
-{{ if and ($field.ShapeRef) ($field.ShapeRef.Documentation) -}}
-    {{ $field.ShapeRef.Documentation }}
+{{ if $field.GetDocumentation -}}
+    {{ $field.GetDocumentation }}
 {{ end -}}
 {{- if and ($field.IsRequired) (not $field.HasReference) -}}
     // +kubebuilder:validation:Required
@@ -40,8 +40,8 @@ type {{ .CRD.Kind }}Status struct {
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
-	{{- if and ($field.ShapeRef) ($field.ShapeRef.Documentation) }}
-	{{ $field.ShapeRef.Documentation }}
+	{{- if $field.GetDocumentation }}
+	{{ $field.GetDocumentation }}
 	{{- end }}
 	// +kubebuilder:validation:Optional
 	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`


### PR DESCRIPTION
Adds support for extending the documentation strings for fields and setting docstrings for custom fields.

A new `FieldConfig.Documentation` configuration option is now supported. When present, this string *extends* any documentation provided for the existing field by the doc-2.json files. If no such documentation is provided by the existing field OR if the field is a custom field, the `FieldConfig.Documentation` configuration option is used for the field's docstring in the Go type files.

Example usage for an existing nested field (from a hypothetical ec2 generator.yaml file). The
`LaunchTemplateData.HibernationOptions.Configured` field has a docstring already that contains the following:

```
// If you set this parameter to true, the instance is enabled for hibernation.
//
// Default: false
```

Setting the `generator.yaml` file to the following:

```yaml
resources:
  LaunchTemplate:
    fields:
      LaunchTemplateData.HibernationOptions.Configured:
        documentation: XXX extended docs XXX
```

would cause the field's Documentation string to look like this:

```
// If you set this parameter to true, the instance is enabled for hibernation.
//
// Default: false
//
// XXX extended docs XXX",
```

Issue aws-controllers-k8s/community#1223

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
