### PR TITLE
Add error message for  cloning sdk timeout

### DIFF
--- a/pkg/sdk/repo.go
+++ b/pkg/sdk/repo.go
@@ -119,6 +119,7 @@ func EnsureRepo(
 		defer cancel()
 		err = util.CloneRepository(ctx, sdkDir, sdkRepoURL)
 		if err != nil {
+			// See https://github.com/aws-controllers-k8s/community/issues/1642
 			if errors.Is(err, context.DeadlineExceeded) {
 				err = fmt.Errorf("%w: take too long to clone aws sdk repo, "+
 					"please consider manually 'git clone %s' to cache dir %s", err, sdkRepoURL, sdkDir)

--- a/pkg/sdk/repo.go
+++ b/pkg/sdk/repo.go
@@ -25,9 +25,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/mod/modfile"
-
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -119,10 +118,10 @@ func EnsureRepo(
 		ctx, cancel := context.WithTimeout(ctx, defaultGitCloneTimeout)
 		defer cancel()
 		err = util.CloneRepository(ctx, sdkDir, sdkRepoURL)
-		fmt.Println("sdkDir: ", sdkDir)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				err = fmt.Errorf("take too long to clone aws sdk repo, please consider 'git clone %s' into cache dir %s", sdkRepoURL, sdkDir)
+				err = fmt.Errorf("%w: take too long to clone aws sdk repo, "+
+					"please consider manually 'git clone %s' to cache dir %s", err, sdkRepoURL, sdkDir)
 			}
 			return "", fmt.Errorf("cannot clone repository: %v", err)
 		}


### PR DESCRIPTION
Issue [#1642](https://github.com/aws-controllers-k8s/community/issues/1642):

Description of changes:
add message to remind user to clone aws-go-sdk when timeout due to bad network speed 

```shell
// original
➜  code-generator git:(main) make build-controller SERVICE=ecr
building ack-generate ... ok.
==== building ecr-controller ====
Copying common custom resource definitions into ecr
Building Kubernetes API objects for ecr
Error: canot clone repository: context deadline exceeded
make: *** [build-controller] Error 1

// with new error message
➜  code-generator git:(main) ✗ make build-controller SERVICE=ecr
building ack-generate ... ok.
==== building ecr-controller ====
Copying common custom resource definitions into ecr
Building Kubernetes API objects for ecr
Error: cannot clone repository: take too long to clone sdk repo, please consider run 'git clone https://github.com/aws/aws-sdk-go' into cache dir /Users/julian/.cache/aws-controllers-k8s/src/aws-sdk-go
make: *** [build-controller] Error 1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
