### PR TITLE
Revert "Correct the generated code for nested parent field reference."

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -143,16 +143,6 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
 	}
 	return nil
 }
-{{ else if not $isList -}}
-    if ko.Spec.{{ $field.ReferenceFieldPath }} != nil &&
-        ko.Spec.{{ $field.ReferenceFieldPath }}.From != nil  {
-        arr := ko.Spec.{{ $field.ReferenceFieldPath }}.From
-{{ template "read_referenced_resource_and_validate" $field }}
-            referencedValue := string(*obj.{{ $field.FieldConfig.References.Path }})
-            ko.Spec.{{ $field.Path }} = &referencedValue
-    }
-    return nil
-}
 {{ else }}
 {{ $parentField := index .CRD.Fields $fp.String }}
 {{ if eq $parentField.ShapeRef.Shape.Type "list" -}}


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1653
Reverts aws-controllers-k8s/code-generator#369

This pull request introduced a change to the way lists of references were accessed, but incorrectly falls back on a conditional that will treat a list of references as a struct. This breaks the `ec2` and `rds` controllers.