### PR TITLE
Deterministic result order in `GetImmutableFieldPaths`

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -346,6 +346,8 @@ func (r *CRD) GetImmutableFieldPaths() []string {
 		}
 	}
 
+	// We need a deterministic order to traverse the immutable fields
+	sort.Strings(immutableFields)
 	return immutableFields
 }
 


### PR DESCRIPTION
This patch addresses the issue of non-deterministic result order in the
`GetImmutableFieldPath` function.

In Go, maps and hashmaps access their elements randomly, which resulted
in non-deterministic return arrays from `GetImmutableFieldPaths`. This
patch leverages `sort.Strings` to ensure deterministic result order,
ensuring deterministic behaviour in generated code.
Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
