### PR TITLE
Fix default value of `--reconcile-resource` flag in deployment.yaml

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -70,10 +70,6 @@ spec:
           value: "info"
         - name: ACK_RESOURCE_TAGS
           value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
-        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
-          value: "0"
-        - name: RECONCILE_RESOURCE_RESYNC_SECONDS
-          value: ""
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false


### PR DESCRIPTION
The runtime expects `--reconcile-resource-resync-seconds` to be an array
of string values. While in deployment.yaml we pass an empty string which
is invalid for `runtime/pkg/config`.

This patch fixes this issue by removing the
`--reconcile-resource-resync-seconds` value
Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
