### PR TITLE
Remove all the `--reconcile-*` flags

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -37,10 +37,6 @@ spec:
         - "$(ACK_RESOURCE_TAGS)"
         - --watch-namespace
         - "$(ACK_WATCH_NAMESPACE)"
-        - --reconcile-default-resync-seconds
-        - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
-        - --reconcile-resource-resync-seconds
-        - "$(RECONCILE_RESOURCE_RESYNC_SECONDS)"
         image: controller:latest
         name: controller
         ports:


### PR DESCRIPTION
In the previous commit, we removed the environment variables
not the flags...

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
