### PR TITLE
Correct number of parameters to `GoCodeResolveReference`

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -115,7 +115,7 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
     }
 {{ end -}}
 
-{{ GoCodeResolveReference .CRD $field "ko" 1 }}
+{{ GoCodeResolveReference $field "ko" 1 }}
 	return nil
 }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Looks like we missed updating the call to `GoCodeResolveReference` after changing the function signature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
