### PR TITLE
Fixes for resource reference resolution templates

### DIFF
--- a/pkg/generate/code/resource_reference.go
+++ b/pkg/generate/code/resource_reference.go
@@ -196,7 +196,7 @@ func ReferenceFieldsPresent(
 //		if ko.Spec.JWTConfiguration.IssuerRef != nil && ko.Spec.JWTConfiguration.IssuerRef.From != nil {
 //			arr := ko.Spec.JWTConfiguration.IssuerRef.From
 //			if arr == nil || arr.Name == nil || *arr.Name == "" {
-//				return fmt.Errorf("provided resource reference is nil or empty: \"JWTConfiguration.IssuerRef"\")
+//				return fmt.Errorf("provided resource reference is nil or empty: JWTConfiguration.IssuerRef")
 //			}
 //			obj := &svcapitypes.API{}
 //			if err := getReferencedResourceState_API(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
@@ -254,7 +254,7 @@ func ResolveReferencesForField(field *model.Field, sourceVarName string, indentL
 			fieldAccessPrefix = iterVarName
 			outPrefix += fmt.Sprintf("%s\tarr := %s.From\n", indent, fieldAccessPrefix)
 			outPrefix += fmt.Sprintf("%s\tif arr == nil || arr.Name == nil || *arr.Name == \"\" {\n", indent)
-			outPrefix += fmt.Sprintf("%s\t\treturn fmt.Errorf(\"provided resource reference is nil or empty: \\%q\\\")\n", indent, field.ReferenceFieldPath())
+			outPrefix += fmt.Sprintf("%s\t\treturn fmt.Errorf(\"provided resource reference is nil or empty: %s\")\n", indent, field.ReferenceFieldPath())
 			outPrefix += fmt.Sprintf("%s\t}\n", indent)
 
 			outPrefix += fmt.Sprintf("%s\tif err := getReferencedResourceState_%s(ctx, apiReader, obj, *arr.Name, namespace); err != nil {\n", indent, field.FieldConfig.References.Resource)
@@ -271,7 +271,7 @@ func ResolveReferencesForField(field *model.Field, sourceVarName string, indentL
 			outPrefix += fmt.Sprintf("%sif %s != nil && %s.From != nil {\n", indent, fieldAccessPrefix, fieldAccessPrefix)
 			outPrefix += fmt.Sprintf("%s\tarr := %s.From\n", indent, fieldAccessPrefix)
 			outPrefix += fmt.Sprintf("%s\tif arr == nil || arr.Name == nil || *arr.Name == \"\" {\n", indent)
-			outPrefix += fmt.Sprintf("%s\t\treturn fmt.Errorf(\"provided resource reference is nil or empty: \\%q\\\")\n", indent, field.ReferenceFieldPath())
+			outPrefix += fmt.Sprintf("%s\t\treturn fmt.Errorf(\"provided resource reference is nil or empty: %s\")\n", indent, field.ReferenceFieldPath())
 			outPrefix += fmt.Sprintf("%s\t}\n", indent)
 
 			if field.FieldConfig.References.ServiceName == "" {


### PR DESCRIPTION
Fix for code originally in:  https://github.com/aws-controllers-k8s/code-generator/pull/401

Description of changes:
There were some syntax errors in generated controller code for resource reference resolution.  See [here](https://prow.ack.aws.dev/view/s3/ack-prow-logs/logs/auto-generate-controllers/1623784341903511552) for some examples of compilation errors

Fixes here:
- correct use of double-quotes in error messages

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
