### PR TITLE
check for nil Name field in attr APIs

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -438,14 +438,18 @@ func SetSDKGetAttributes(
 				"%s\t%s.Set%s(string(*%s.Status.ACKResourceMetadata.ARN))\n",
 				indent, targetVarName, memberName, sourceVarName,
 			)
-			out += fmt.Sprintf(
-				"%s} else {\n", indent,
-			)
-			nameField := *r.SpecIdentifierField()
-			out += fmt.Sprintf(
-				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
-				indent, targetVarName, memberName, sourceVarName, nameField,
-			)
+			nameField := r.SpecIdentifierField()
+			if nameField != nil {
+				// There is no name or ID field for the resource, so don't try
+				// to set an ARN from a name. Example: Subscription from SNS...
+				out += fmt.Sprintf(
+					"%s} else {\n", indent,
+				)
+				out += fmt.Sprintf(
+					"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
+					indent, targetVarName, memberName, sourceVarName, *nameField,
+				)
+			}
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)
@@ -617,14 +621,18 @@ func SetSDKSetAttributes(
 				"%s\t%s.Set%s(string(*%s.Status.ACKResourceMetadata.ARN))\n",
 				indent, targetVarName, memberName, sourceVarName,
 			)
-			out += fmt.Sprintf(
-				"%s} else {\n", indent,
-			)
-			nameField := *r.SpecIdentifierField()
-			out += fmt.Sprintf(
-				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
-				indent, targetVarName, memberName, sourceVarName, nameField,
-			)
+			nameField := r.SpecIdentifierField()
+			if nameField != nil {
+				// There is no name or ID field for the resource, so don't try
+				// to set an ARN from a name. Example: Subscription from SNS...
+				out += fmt.Sprintf(
+					"%s} else {\n", indent,
+				)
+				out += fmt.Sprintf(
+					"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
+					indent, targetVarName, memberName, sourceVarName, *nameField,
+				)
+			}
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)


### PR DESCRIPTION
The code which builds the input shapes for the GET_ATTRIBUTES and SET_ATTRIBUTES operations for attribute-based APIs was checking for a Name or ID field in order to set the value for ARN fields in the input shapes. However, some resources, like SNS' Subscription resources, do not have a Name or ID field.

This resulted in nil pointer dereferencing and panics when building the controller for SNS Subscriptions.

This patch simply double-checks that the `*string` returned from the `CRD.SpecIdentifierField()` method is not nil before adding in the Go code that constructs an ARN from a Name or ID field.

Related: aws-controllers-k8s/community#1491

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
