### PR TITLE
fix check for nested field in reference template

### DIFF
--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -117,7 +117,7 @@ func resolveReferenceFor{{ $field.FieldPathWithUnderscore }}(
 
 {{- $fp := ConstructFieldPath $field.Path -}}
 {{ $_ := $fp.Pop -}}
-{{ $isNested := gt $fp.Size 0 -}}
+{{ $isNested := gt $fp.Size 1 -}}
 {{ $isList := eq $field.ShapeRef.Shape.Type "list" -}}
 {{ if and (not $isList) (not $isNested) -}}
 	if ko.Spec.{{ $field.ReferenceFieldPath }} != nil &&


### PR DESCRIPTION
The `isNested` variable was being set to true when the fieldpath's size was greater than 0. This is wrong. A nested field is where the fieldpath's size is greater than 1.

Corrected this and lambda controller generates successfully with proper compilation.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
