### PR TITLE
kustomize: use 'resources' instead of deprecated 'bases'

### DIFF
--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -107,8 +107,7 @@ trap "clean_up" EXIT
 mkdir -p "$TMP_DIR"
 cp -a "$SERVICE_CONTROLLER_SOURCE_PATH/config" "$TMP_DIR"
 
-# remove crd/common from bases to prevent inclusion of AdoptedResource CRD from being generated in the bundle directory
-sed -i.orig '/^bases:$/d' "$tmp_kustomize_config_dir/crd/kustomization.yaml"
+# remove crd/common from resources to prevent inclusion of AdoptedResource CRD from being generated in the bundle directory
 sed -i.orig '/- common$/d' "$tmp_kustomize_config_dir/crd/kustomization.yaml"
 
 # prepare bundle generate arguments

--- a/templates/config/crd/kustomization.yaml.tpl
+++ b/templates/config/crd/kustomization.yaml.tpl
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - common
 resources:
+  - common
 {{- range .CRDNames }}
   - bases/{{ $.APIGroup }}_{{ . }}.yaml 
 {{- end }}

--- a/templates/config/default/kustomization.yaml.tpl
+++ b/templates/config/default/kustomization.yaml.tpl
@@ -12,7 +12,7 @@
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../controller


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1690

Description of changes:

Migration away from deprecated kustomize feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
