### PR TITLE
Add `404: ResourceError` handling in sdkFind

### DIFF
--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -34,6 +34,9 @@ func (rm *resourceManager) sdkFind(
 {{- end }}
 	rm.metrics.RecordAPICall("READ_ONE", "{{ .CRD.Ops.ReadOne.ExportedName }}", err)
 	if err != nil {
+		if reqErr, ok := ackerr.AWSRequestFailure(err); ok && reqErr.StatusCode() == 404 {
+			return nil, ackerr.NotFound
+        }
 		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {{ GoCodeSetExceptionMessageCheck .CRD 404 }}{
 			return nil, ackerr.NotFound
 		}


### PR DESCRIPTION
In the `Pipes` service controller we noticed that the error returned from the API is of type [`RequestFailure`](https://docs.aws.amazon.com/sdk-for-go/api/aws/awserr/#RequestFailure). A workaround is to set `code: ""` in `generator.yaml` or for those not aware of this issue fallback using this new type assertion in `READ_ONE`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
