### PR TITLE
Allow manual setting of AWS client struct and interface names

### DIFF
--- a/cmd/ack-generate/command/common.go
+++ b/cmd/ack-generate/command/common.go
@@ -45,7 +45,7 @@ func loadModel(svcAlias string, apiVersion string, apiGroup string, defaultCfg a
 		return nil, err
 	}
 
-	modelName := strings.ToLower(cfg.ModelName)
+	modelName := strings.ToLower(cfg.SDKNames.Model)
 	if modelName == "" {
 		modelName = svcAlias
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,12 +39,28 @@ type Config struct {
 	// SetManyOutput function fails with NotFound error.
 	// Default is "return nil, ackerr.NotFound"
 	SetManyOutputNotFoundErrReturn string `json:"set_many_output_notfound_err_return,omitempty"`
+	// SDKNames lets you specify SDK object names. This configuration field was
+	// introduces when we learned that the EventBridgePipes service renamed, not
+	// only the service model name, but also the iface name to `PipesAPI`. See
+	// https://github.com/aws/aws-sdk-go/blob/main/service/pipes/pipesiface/interface.go#L62
+	SDKNames SDKNames `json:"sdk_names"`
+}
+
+// SDKNames contains information on the SDK Client package. More precisely
+// it holds information on how to correctly import the {service}/iface main
+// interface and client structs.
+type SDKNames struct {
 	// ModelName lets you specify the path used to identify the AWS service API
 	// in the aws-sdk-go's models/apis/ directory. This field is optional and
 	// only needed for services such as the opensearchservice service where the
 	// model name is `opensearch` and the service package is called
 	// `opensearchservice`.
-	ModelName string `json:"model_name,omitempty"`
+	Model string `json:"model_name,omitempty"`
+	// ClientInterface is the name of the interface that defines the "shape" of
+	// the a sdk service client. e.g PipesAPI, LambdaAPI, etc...
+	ClientInterface string `json:"client_interface,omitempty"`
+	// ClientStruct is the name of the service client struct. e.g Lambda, Pipes, etc...
+	ClientStruct string `json:"client_struct,omitempty"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to

--- a/pkg/generate/templateset/vars.go
+++ b/pkg/generate/templateset/vars.go
@@ -35,9 +35,12 @@ type MetaVars struct {
 	// for custom resources, e.g. "sns.services.k8s.aws" or
 	// "sfn.services.k8s.aws"
 	APIGroup string
-	// APIInterfaceTypeName is the name of the interface type used by the
+	// ClientInterfaceTypeName is the name of the interface type used by the
 	// aws-sdk-go services/$SERVICE/api.go file
-	APIInterfaceTypeName string
+	ClientInterfaceTypeName string
+	// ClientStructTypeName is the name of the struct type defining the service
+	// sdk client.
+	ClientStructTypeName string
 	//CRDNames contains all crds names lowercased and in plural
 	CRDNames []string
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -52,13 +52,14 @@ type Model struct {
 // service API
 func (m *Model) MetaVars() templateset.MetaVars {
 	return templateset.MetaVars{
-		ServicePackageName:   m.servicePackageName,
-		ServiceID:            m.SDKAPI.ServiceID(),
-		ServiceModelName:     m.cfg.ModelName,
-		APIGroup:             m.APIGroup(),
-		APIVersion:           m.apiVersion,
-		APIInterfaceTypeName: m.SDKAPI.APIInterfaceTypeName(),
-		CRDNames:             m.crdNames(),
+		ServicePackageName:      m.servicePackageName,
+		ServiceID:               m.SDKAPI.ServiceID(),
+		ServiceModelName:        m.cfg.SDKNames.Model,
+		APIGroup:                m.APIGroup(),
+		APIVersion:              m.apiVersion,
+		ClientInterfaceTypeName: m.ClientInterfaceTypeName(),
+		ClientStructTypeName:    m.ClientStructTypeName(),
+		CRDNames:                m.crdNames(),
 	}
 }
 
@@ -864,6 +865,24 @@ func (m *Model) APIGroup() string {
 		suffix = m.SDKAPI.APIGroupSuffix
 	}
 	return fmt.Sprintf("%s.%s", m.servicePackageName, suffix)
+}
+
+// ClientInterfaceTypeName returns the name of the aws-sdk-go primary API
+// interface type name.
+func (m *Model) ClientInterfaceTypeName() string {
+	if m.cfg.SDKNames.ClientInterface != "" {
+		return m.cfg.SDKNames.ClientInterface
+	}
+	return m.SDKAPI.ClientInterfaceTypeName()
+}
+
+// ClientStructTypeName returns the name of the aws-sdk-go primary client
+// struct type name.
+func (m *Model) ClientStructTypeName() string {
+	if m.cfg.SDKNames.ClientStruct != "" {
+		return m.cfg.SDKNames.ClientStruct
+	}
+	return m.SDKAPI.ClientStructTypeName()
 }
 
 // New returns a new Model struct for a supplied API model.

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -327,9 +327,18 @@ func (a *SDKAPI) GetServiceFullName() string {
 	return a.API.Metadata.ServiceFullName
 }
 
-// APIInterfaceTypeName returns the name of the aws-sdk-go primary API
+// ClientInterfaceTypeName returns the name of the aws-sdk-go primary API
 // interface type name.
-func (a *SDKAPI) APIInterfaceTypeName() string {
+func (a *SDKAPI) ClientInterfaceTypeName() string {
+	if a == nil || a.API == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s%s", a.API.StructName(), "API")
+}
+
+// ClientStructTypeName returns the name of the aws-sdk-go primary API
+// struct type name.
+func (a *SDKAPI) ClientStructTypeName() string {
 	if a == nil || a.API == nil {
 		return ""
 	}

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -177,7 +177,7 @@ func (e *external) Delete(ctx context.Context, mg cpresource.Managed) error {
 
 type option func(*external)
 
-func newExternal(kube client.Client, client svcsdkapi.{{ .APIInterfaceTypeName }}API, opts []option) *external {
+func newExternal(kube client.Client, client svcsdkapi.{{ .ClientInterfaceTypeName }}, opts []option) *external {
 	e := &external{
 		kube:           kube,
 		client:         client,
@@ -223,7 +223,7 @@ func newExternal(kube client.Client, client svcsdkapi.{{ .APIInterfaceTypeName }
 
 type external struct {
 	kube        client.Client
-	client      svcsdkapi.{{ .APIInterfaceTypeName }}API
+	client      svcsdkapi.{{ .ClientInterfaceTypeName }}
 	{{- if .CRD.Ops.ReadOne }}
 	preObserve  func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}) error
 	postObserve func(context.Context, *svcapitypes.{{ .CRD.Names.Camel }}, *svcsdk.{{ .CRD.Ops.ReadOne.OutputRef.Shape.ShapeName }}, managed.ExternalObservation, error) (managed.ExternalObservation, error)

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -65,7 +65,7 @@ type resourceManager struct {
 	sess *session.Session
 	// sdk is a pointer to the AWS service API interface exposed by the
 	// aws-sdk-go/services/{alias}/{alias}iface package.
-	sdkapi svcsdkapi.{{ .APIInterfaceTypeName }}API
+	sdkapi svcsdkapi.{{ .ClientInterfaceTypeName }}
 }
 
 // concreteResource returns a pointer to a resource from the supplied

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -28,7 +28,7 @@ var (
 	_ = &metav1.Time{}
 	_ = strings.ToLower("")
 	_ = &aws.JSONValue{}
-	_ = &svcsdk.{{ .APIInterfaceTypeName}}{}
+	_ = &svcsdk.{{ .ClientStructTypeName }}{}
 	_ = &svcapitypes.{{ .CRD.Names.Camel }}{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound


### PR DESCRIPTION
While developing the ACK pipes-controller, we encountered an issue where
the generated code didn't compile mainly because the code-generator
assumed that the AWS SDK client/interface/import-paths always followed
the same naming conventions. However, we discovered that Pipes was the
exception as they renamed the model, import path, and client
struct/interface.

This patch introduces a new feature that enables users to manually set
the client struct and interface names in the `generator.yaml` file.
This update allows for greater flexibility in the AWS client naming
within pipes-controller and possibly other controllers in the future.

In this patch, we've also introduced a breaking change by renaming
`model_name` to `sdk_names.model`. Mainly to keep all the SDK-related
naming conventions in the same place.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
