### PR TITLE
Pass registered resource names to `config.Validate`

### DIFF
--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -12,6 +12,7 @@ import (
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	ackrtwebhook "github.com/aws-controllers-k8s/runtime/pkg/webhook"
 	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlrt "sigs.k8s.io/controller-runtime"
@@ -62,7 +63,13 @@ func main() {
 	flag.Parse()
 	ackCfg.SetupLogger()
 
-	if err := ackCfg.Validate(); err != nil {
+	managerFactories := svcresource.GetManagerFactories()
+	resourceGVKs := make([]schema.GroupVersionKind, 0, len(managerFactories))
+	for _, mf := range managerFactories {
+		resourceGVKs = append(resourceGVKs, mf.ResourceDescriptor().GroupVersionKind())
+	}
+
+	if err := ackCfg.Validate(ackcfg.WithGVKs(resourceGVKs)); err != nil {
 		setupLog.Error(
 			err, "Unable to create controller manager",
 			"aws.service", awsServiceAlias,


### PR DESCRIPTION
[fixes https://github.com/aws-controllers-k8s/community/issues/1647]

Completes https://github.com/aws-controllers-k8s/runtime/pull/117

This patch adds a tiny modification to the controllers `main.go` that
passes the resource names to `ackCfg.Validate` method.

Needs a new runtime release.
/hold

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
