### PR TITLE
use `Operation.ExportedName` not `Operation.Name`

### DIFF
--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -56,7 +56,7 @@ func (c *Config) OperationIsIgnored(operation *awssdkmodel.Operation) bool {
 	if operation == nil {
 		return true
 	}
-	return util.InStrings(operation.Name, c.Ignore.Operations)
+	return util.InStrings(operation.ExportedName, c.Ignore.Operations)
 }
 
 // UnmarshalJSON parses input for a either a string or
@@ -88,7 +88,7 @@ func (c *Config) GetOutputWrapperFieldPath(
 	if c == nil {
 		return nil
 	}
-	opConfig, found := c.Operations[op.Name]
+	opConfig, found := c.Operations[op.ExportedName]
 	if !found {
 		return nil
 	}
@@ -111,7 +111,7 @@ func (c *Config) GetSetOutputCustomMethodName(
 	if c == nil {
 		return nil
 	}
-	opConfig, found := c.Operations[op.Name]
+	opConfig, found := c.Operations[op.ExportedName]
 	if !found {
 		return nil
 	}
@@ -132,7 +132,7 @@ func (c *Config) GetCustomImplementation(
 		return ""
 	}
 
-	operationConfig, found := c.Operations[op.Name]
+	operationConfig, found := c.Operations[op.ExportedName]
 	if !found {
 		return ""
 	}
@@ -150,7 +150,7 @@ func (c *Config) GetCustomCheckRequiredFieldsMissingMethod(
 		return ""
 	}
 
-	operationConfig, found := c.Operations[op.Name]
+	operationConfig, found := c.Operations[op.ExportedName]
 	if !found {
 		return ""
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -672,7 +672,7 @@ func (c *Config) GetAllRenames(
 	opRenameConfigs := resourceConfig.Renames.Operations
 	for opName, opRenameConfigs := range opRenameConfigs {
 		for _, op := range operations {
-			if opName != op.Name {
+			if opName != op.ExportedName {
 				continue
 			}
 			for old, new := range opRenameConfigs.InputFields {

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -53,7 +53,7 @@ func FindIdentifiersInShape(
 	}
 
 	// Handles field renames
-	opType, _ := model.GetOpTypeAndResourceNameFromOpID(op.Name, r.Config())
+	opType, _ := model.GetOpTypeAndResourceNameFromOpID(op.ExportedName, r.Config())
 	renames := r.GetAllRenames(opType)
 	for _, memberName := range shape.MemberNames() {
 		lookupName := memberName
@@ -115,7 +115,7 @@ func FindPluralizedIdentifiersInShape(
 			// renames, if applicable
 			siRenamed := r.Config().GetResourceFieldName(
 				r.Names.Original,
-				op.Name,
+				op.ExportedName,
 				pluralize.Singular(si),
 			)
 			if strings.EqualFold(
@@ -188,14 +188,14 @@ func FindPrimaryIdentifierFieldNames(
 	}
 
 	if crField == "" {
-		if inSpec, inStat := r.HasMember(shapeField, op.Name); !inSpec && !inStat {
+		if inSpec, inStat := r.HasMember(shapeField, op.ExportedName); !inSpec && !inStat {
 			panic("Could not find corresponding spec or status field " +
 				"for primary identifier " + shapeField)
 		}
 		// Fetch field name from config to apply renames, if applicable
 		crField = cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			shapeField,
 		)
 	}

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -210,10 +210,10 @@ func SetResource(
 		// Handles field renames, if applicable
 		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			memberName,
 		)
-		inSpec, inStatus := r.HasMember(fieldName, op.Name)
+		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
 		if inSpec {
 			targetAdaptedVarName += cfg.PrefixConfig.SpecField
 			f = r.SpecFields[fieldName]
@@ -499,7 +499,7 @@ func setResourceReadMany(
 	matchFieldNames := r.ListOpMatchFieldNames()
 
 	for _, mfName := range matchFieldNames {
-		if inSpec, inStat := r.HasMember(mfName, op.Name); !inSpec && !inStat {
+		if inSpec, inStat := r.HasMember(mfName, op.ExportedName); !inSpec && !inStat {
 			msg := fmt.Sprintf(
 				"Match field name %s is not in %s Spec or Status fields",
 				mfName, r.Names.Camel,
@@ -569,10 +569,10 @@ func setResourceReadMany(
 		// Handles field renames, if applicable
 		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			memberName,
 		)
-		inSpec, inStatus := r.HasMember(fieldName, op.Name)
+		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
 		if inSpec {
 			targetAdaptedVarName += cfg.PrefixConfig.SpecField
 			f = r.SpecFields[fieldName]
@@ -1045,7 +1045,7 @@ func SetResourceIdentifiers(
 		// Handles field renames, if applicable
 		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			memberName,
 		)
 

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -168,7 +168,7 @@ func SetSDK(
 		out += fmt.Sprintf("%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
 	}
 
-	opConfig, override := cfg.GetOverrideValues(op.Name)
+	opConfig, override := cfg.GetOverrideValues(op.ExportedName)
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
@@ -219,10 +219,10 @@ func SetSDK(
 		// Handles field renames, if applicable
 		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			memberName,
 		)
-		inSpec, inStatus := r.HasMember(fieldName, op.Name)
+		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
 		if inSpec {
 			sourceAdaptedVarName += cfg.PrefixConfig.SpecField
 			f = r.SpecFields[fieldName]
@@ -792,7 +792,7 @@ func setSDKReadMany(
 	indent := strings.Repeat("\t", indentLevel)
 
 	resVarPath := ""
-	opConfig, override := cfg.GetOverrideValues(op.Name)
+	opConfig, override := cfg.GetOverrideValues(op.ExportedName)
 	var err error
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if override {
@@ -817,7 +817,7 @@ func setSDKReadMany(
 		// Handles field renames, if applicable
 		fieldName := cfg.GetResourceFieldName(
 			r.Names.Original,
-			op.Name,
+			op.ExportedName,
 			memberName,
 		)
 		resVarPath, err = r.GetSanitizedMemberPath(memberName, op, sourceVarName)

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -668,13 +668,13 @@ func (r *CRD) GetSanitizedMemberPath(
 	// Handles field renames, if applicable
 	fieldName := cfg.GetResourceFieldName(
 		r.Names.Original,
-		op.Name,
+		op.ExportedName,
 		memberName,
 	)
 	cleanFieldNames := names.New(fieldName)
 	pathFieldName := cleanFieldNames.Camel
 
-	inSpec, inStatus := r.HasMember(fieldName, op.Name)
+	inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
 	if inSpec {
 		resVarPath = resVarPath + cfg.PrefixConfig.SpecField + "." + pathFieldName
 	} else if inStatus {

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -160,8 +160,8 @@ func (rm *resourceManager) sdkDelete(
 {{ $hookCode }}
 {{- end }}
 	var resp {{ .CRD.GetOutputShapeGoType .CRD.Ops.Delete }}; _ = resp;
-	resp, err = rm.sdkapi.{{ .CRD.Ops.Delete.Name }}WithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "{{ .CRD.Ops.Delete.Name }}", err)
+	resp, err = rm.sdkapi.{{ .CRD.Ops.Delete.ExportedName }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "{{ .CRD.Ops.Delete.ExportedName }}", err)
 {{- if $hookCode := Hook .CRD "sdk_delete_post_request" }}
 {{ $hookCode }}
 {{- end }}


### PR DESCRIPTION
This was a nasty issue to troubleshoot. :( Turns out that for REST+XML-based APIs (such as CloudFront), the aws-sdk-go `private/model/api.Operation` objects have a `Name` field that contains crap like this: "CreateCachePolicy2020_05_31". What this means is that when looking up things like output wrapper field paths by the `Operation.Name` of "CreateCachePolicy" (from the `generator.yaml` file's `operations` map), things were failing because the `private/model/api.API:Operations` map is actually keyed by `Operation.ExportedName`, not `Operation.Name`. `Operation.ExportedName` for REST+XML APIs like CloudFront contain the proper string "CreateCachePolicy" without the date suffix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
