### PR TITLE
QIL improvement to common.sh: check for null return status from ECR call

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -154,7 +154,7 @@ is_public_ecr_logged_in() {
     [ -z "$auth_string" ] && return 1
     [ "$auth_string" = "null" ] && return 1
 
-    expiration_time=$(jq -r --arg url $public_ecr_url '.auths[$url].auth' ~/.docker/config.json | base64 -d | cut -d":" -f2 | base64 -d | jq -r ".expiration")
+    expiration_time=$(echo $auth_string | base64 -d | cut -d":" -f2 | base64 -d | jq -r ".expiration")
 
     # If any part of this doesn't exist, the user isn't logged in
     [ -z "$expiration_time" ] && return 1

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -149,6 +149,11 @@ is_public_ecr_logged_in() {
     # Base64 decode it
     # Read the "expiration" value
     local expiration_time
+    auth_string=$(jq -r --arg url $public_ecr_url '.auths[$url].auth' ~/.docker/config.json)
+
+    [ -z "$auth_string" ] && return 1
+    [ "$auth_string" = "null" ] && return 1
+
     expiration_time=$(jq -r --arg url $public_ecr_url '.auths[$url].auth' ~/.docker/config.json | base64 -d | cut -d":" -f2 | base64 -d | jq -r ".expiration")
 
     # If any part of this doesn't exist, the user isn't logged in


### PR DESCRIPTION
Issue #, if available:

Description of changes:
A small quality-of-life improvement for e2e testing workflow when running on a Mac.  Currently, when one isn't logged into `public.ecr.aws`, you get the following when trying to run `make kind-test`:

```
10:36 $ make kind-test                                                                                                                                                                                                                                                    
2023-03-14T10:36:45 [DEBUG] Debug mode enabled                                                                                                                                                                                                                            
...
2023-03-14T10:36:47 [INFO] Building controller image ...                                                                                                                                                                                                                  
cut: stdin: Illegal byte sequence 
```

This change breaks one command pipeline (`jq` + `base64` + `cut` + `base64` + `jq`) into two chunks so that we can check the value returned by the first `jq` call to see if it's `null`, and `exit 1` if so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
