### PR TITLE
Bump base `golang` Docker image version to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 # Build the manager binary
 # TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
-# supports golang 1.17
-FROM public.ecr.aws/bitnami/golang:1.17 as builder
+# supports golang 1.19
+FROM public.ecr.aws/bitnami/golang:1.19 as builder
 
 ARG service_alias
 # The tuple of controller image version information

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,8 +2,8 @@
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 # Build the manager binary
 # TODO(vijtrip2) move this builder image to public.ecr.aws/eks-distro-build-tooling/builder-base, when builder-base
-# supports golang 1.17
-FROM public.ecr.aws/bitnami/golang:1.17 as builder
+# supports golang 1.19
+FROM public.ecr.aws/bitnami/golang:1.19 as builder
 
 ARG service_alias
 # The tuple of controller image version information


### PR DESCRIPTION
Issue #, if available:

Description of changes:

When trying to run e2e tests in `rds-controller` with a recent change, I encountered errors like the following:

```
...
# k8s.io/apimachinery/third_party/forked/golang/reflect                                                                                                                                                                                                                                                                                         
/go/pkg/mod/k8s.io/apimachinery@v0.26.1/third_party/forked/golang/reflect/deep_equal.go:376:7: undefined: reflect.Pointer                                                                                                                                                                                                                       
note: module requires Go 1.19   
...
```

This change bumps the base Docker image from `public.ecr.aws/bitnami/golang:1.17` to `public.ecr.aws/bitnami/golang:1.19`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
