### PR TITLE
Remove optGenVersion from api path for goimports

### DIFF
--- a/cmd/ack-generate/command/crossplane.go
+++ b/cmd/ack-generate/command/crossplane.go
@@ -87,7 +87,7 @@ func generateCrossplane(_ *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	apiPath := filepath.Join(optOutputPath, "apis", svcAlias, optGenVersion)
+	apiPath := filepath.Join(optOutputPath, "apis", svcAlias)
 	controllerPath := filepath.Join(optOutputPath, "pkg", "controller", svcAlias)
 	// TODO(muvaf): goimports don't allow to be included as a library. Make sure
 	// goimports binary exists.


### PR DESCRIPTION
Description of changes:

`ack-generate crossplane` fails if there is no `apis/_service_/v1alpha1 directory`. The code includes optGenVersion in the apiPath for goimports which causes an error when the directory doesn't exist.

Removing optGenVersion from the apiPath causes `goimports` to run on all files/directorys under` apis/<service>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
