### PR TITLE
Pin ACK runtime to `v0.25.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.4
-	github.com/aws-controllers-k8s/runtime v0.24.0
+	github.com/aws-controllers-k8s/runtime v0.25.0
 	github.com/aws/aws-sdk-go v1.44.93
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.4 h1:fQX18NZZG6eVKdG3WWp/oE7QJgFe7Dz/Ublu+ua4PW8=
 github.com/aws-controllers-k8s/pkg v0.0.4/go.mod h1:LC/9DlYrXu8FWNwLquZLq1WhcyRo7qXb7upRLAEosQk=
-github.com/aws-controllers-k8s/runtime v0.24.0 h1:F53HtC1YDHXcjtlRl2Q1xU0/7TRFvy9IlMFp0rTYeWE=
-github.com/aws-controllers-k8s/runtime v0.24.0/go.mod h1:vBfkfwxAIULdvjHCfJNi6Pj3/QJJCrh+8uH3/ZfewVU=
+github.com/aws-controllers-k8s/runtime v0.25.0 h1:6SYa8qmbw+Yil5/LodF7LmIGxBhpjz4QEIvNjpeRuoc=
+github.com/aws-controllers-k8s/runtime v0.25.0/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
 github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=
 github.com/aws/aws-sdk-go v1.44.93/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
Description of changes:
Updates the ACK runtime version in `go.mod` to `v0.25.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
