### PR TITLE
Fix mocks for upcoming `AWSResourceDescriptor` changes

### DIFF
--- a/pkg/generate/ack/runtime_test.go
+++ b/pkg/generate/ack/runtime_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,8 +53,8 @@ func (ids *fakeIdentifiers) Region() *ackv1alpha1.AWSRegion {
 
 type fakeDescriptor struct{}
 
-func (fd *fakeDescriptor) GroupKind() *metav1.GroupKind {
-	return nil
+func (fd *fakeDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
 }
 
 func (fd *fakeDescriptor) EmptyRuntimeObject() rtclient.Object {


### PR DESCRIPTION
Description of changes:
Fixes the mocks for the `AWSResourceDescriptor` to use the new `GroupVersionKind` method

**Breaking Changes**: These changes will intentionally break the unit testing, since they are not compatible with runtime `v0.24.x` but are required to upgrade to `v0.25.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
