### PR TITLE
Add OCI labels to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,10 @@ FROM $base_image
 ARG base_image
 LABEL org.opencontainers.image.base.name=$base_image
 ARG service_alias
+ARG service_controller_git_version
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller
+LABEL org.opencontainers.image.version=$service_controller_git_version
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
 # Make this image non-root by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
 FROM $base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
 # Make this image non-root by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN GIT_VERSION=$service_controller_git_version && \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 
 FROM $base_image
+ARG base_image
+LABEL org.opencontainers.image.base.name=$base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -62,6 +62,8 @@ RUN GIT_VERSION=$service_controller_git_version && \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 
 FROM $base_image
+ARG base_image
+LABEL org.opencontainers.image.base.name=$base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -65,8 +65,10 @@ FROM $base_image
 ARG base_image
 LABEL org.opencontainers.image.base.name=$base_image
 ARG service_alias
+ARG service_controller_git_version
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller
+LABEL org.opencontainers.image.version=$service_controller_git_version
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
 USER 1000

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -64,6 +64,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
 FROM $base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+LABEL org.opencontainers.image.source=https://github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /
 COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
 USER 1000


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/1758

Description of changes:

Add some OCI labels to docker images
The labels are documented at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
Importantly to me, `org.opencontainers.image.source` is used by renovate's changelog support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.