### PR TITLE
Update template to support watch namespace

### DIFF
--- a/templates/helm/templates/_helpers.tpl
+++ b/templates/helm/templates/_helpers.tpl
@@ -33,7 +33,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "watch-namespace" -}}
 {{- if eq .Values.installScope "namespace" -}}
-{{- .Release.Namespace -}}
+{{ .Values.watchNamespace | default .Release.Namespace }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -196,6 +196,9 @@
       "type": "string",
       "enum": ["cluster", "namespace"]
     },
+    "watchNamespace": {
+      "type": "string"
+    },    
     "resourceTags": {
       "type": "array",
       "items": {

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -72,6 +72,10 @@ log:
 # cluster wide.
 installScope: cluster
 
+# Set the value of the "namespace" to be watched by the controller
+# This would only work if installScope is set to "namespace". If left empty it would watch the release namespace by default.
+watchNamespace: ""
+
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on
   # resources that it manages.

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -73,7 +73,7 @@ log:
 installScope: cluster
 
 # Set the value of the "namespace" to be watched by the controller
-# This would only work if installScope is set to "namespace". If left empty it would watch the release namespace by default.
+# This value is only used when the `installScope` is set to "namespace". If left empty, the default value is the release namespace for the chart.
 watchNamespace: ""
 
 resourceTags:


### PR DESCRIPTION
As the controller runtime supports watching namespaces, we would need to add a support to watch namespaces other than where the controller is deployed. This is a common use case for multi-tenant K8s environments. This PR introduces a `watchNamespace` flag which lets user define the namespaces to be watched by the controller. If left blank, it would take the release namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
