### PR TITLE
Add new `$field.set[].To` configuration

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -191,6 +191,19 @@ type SetFieldConfig struct {
 	// f17elem = *f17iter.DBSecurityGroupName
 	// ```
 	From *string `json:"from,omitempty"`
+	// To instructs the code generator to output Go code that sets the value of
+	// an Input sdkField with the content of a CR field.
+	//
+	// ```yaml
+	// resources:
+	//   User:
+	//     fields:
+	//       URL:
+	//         set:
+	//           - method: Update
+	//             to: NewURL
+	// ```
+	To *string `json:"to,omitempty"`
 	// Ignore instructs the code generator to ignore this field in the Output
 	// shape when setting the value of the resource's field in the Spec. This
 	// is useful when we know that, for example, the returned value of field in

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
 
-// SetResource returns the Go code that sets a CRD's field value to the value
+// SetResource returns the Go code that sets a CRD's field value from the value
 // of an output shape's member fields.  Status fields are always updated.
 //
 // Assume a CRD called Repository that looks like this pseudo-schema:

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -222,6 +222,15 @@ func SetSDK(
 			op.ExportedName,
 			memberName,
 		)
+
+		// Check if we have any configurations instructing the code
+		// generator to set an SDK input field from this specific
+		// field path.
+		fallbackFieldName := r.GetMatchingInputShapeFieldName(opType, fieldName)
+		if fallbackFieldName != "" {
+			fieldName = fallbackFieldName
+		}
+
 		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
 		if inSpec {
 			sourceAdaptedVarName += cfg.PrefixConfig.SpecField

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -2164,3 +2164,27 @@ func Test_SetSDK_ECR_Repository_newListRequestPayload(t *testing.T) {
 		code.SetSDK(crd.Config(), crd, model.OpTypeList, "r.ko", "res", 1),
 	)
 }
+
+func TestSetSDK_IAM_User_NewPath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "iam", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-user-newpath.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "User")
+	require.NotNil(crd)
+	expected := `
+	if r.ko.Spec.Path != nil {
+		res.SetNewPath(*r.ko.Spec.Path)
+	}
+	if r.ko.Spec.UserName != nil {
+		res.SetUserName(*r.ko.Spec.UserName)
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1),
+	)
+}

--- a/pkg/testdata/models/apis/iam/0000-00-00/generator-user-newpath.yaml
+++ b/pkg/testdata/models/apis/iam/0000-00-00/generator-user-newpath.yaml
@@ -1,0 +1,23 @@
+ignore:
+  resource_names:
+   - AccessKey
+   - AccountAlias
+   - Group
+   - InstanceProfile
+   - LoginProfile
+   - OpenIDConnectProvider
+   - Policy
+   - PolicyVersion
+   - Role
+   - SAMLProvider
+   - ServiceLinkedRole
+   - ServiceSpecificCredential
+   # User
+   - VirtualMFADevice
+resources:
+  User:
+    fields:
+      Path:
+        set:
+        - method: Update
+          to: NewPath


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/1775

- Add new generator config to allow setting an `sdkField` from a specific CR field

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
