### PR TITLE
only call SetAttributes() when attrMap not empty

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -137,7 +137,9 @@ func SetSDK(
 		// attrMap["DisplayName"} = r.ko.Spec.DisplayName
 		// attrMap["KmsMasterKeyId"] = r.ko.Spec.KMSMasterKeyID
 		// attrMap["Policy"] = r.ko.Spec.Policy
-		// res.SetAttributes(attrMap)
+		// if len(attrMap) > 0 {
+		//     res.SetAttributes(attrMap)
+		// }
 		fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
 		out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
 		sortedAttrFieldNames := []string{}
@@ -165,7 +167,13 @@ func SetSDK(
 				)
 			}
 		}
-		out += fmt.Sprintf("%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
+		out += fmt.Sprintf(
+			"%sif len(attrMap) > 0 {\n", indent,
+		)
+		out += fmt.Sprintf("\t%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
 	}
 
 	opConfig, override := cfg.GetOverrideValues(op.ExportedName)

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -1779,7 +1779,9 @@ func TestSetSDK_SNS_Topic_Create(t *testing.T) {
 	if r.ko.Spec.Policy != nil {
 		attrMap["Policy"] = r.ko.Spec.Policy
 	}
-	res.SetAttributes(attrMap)
+	if len(attrMap) > 0 {
+		res.SetAttributes(attrMap)
+	}
 	if r.ko.Spec.Name != nil {
 		res.SetName(*r.ko.Spec.Name)
 	}
@@ -1874,7 +1876,9 @@ func TestSetSDK_SQS_Queue_Create(t *testing.T) {
 	if r.ko.Spec.VisibilityTimeout != nil {
 		attrMap["VisibilityTimeout"] = r.ko.Spec.VisibilityTimeout
 	}
-	res.SetAttributes(attrMap)
+	if len(attrMap) > 0 {
+		res.SetAttributes(attrMap)
+	}
 	if r.ko.Spec.QueueName != nil {
 		res.SetQueueName(*r.ko.Spec.QueueName)
 	}


### PR DESCRIPTION
For SQS's `CreateQueue` API, if you pass an empty map to the `CreateQueueInput.SetAttributes()` method, everything succeeds however the service will return the following cryptic error message:

`MalformedInput: End of list found where not expected`

This patch updates the generated code for attribute-based APIs to only call `SetAttributes()` on the input shape when there are attributes to set.

Issue aws-controllers-k8s/community#1695

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
