### PR TITLE
Trim possible `v` prefixes in release code

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -77,7 +77,7 @@ func Release(
 	releaseVars := &templateReleaseVars{
 		metaVars,
 		ImageReleaseVars{
-			ReleaseVersion:  releaseVersion,
+			ReleaseVersion:  strings.TrimPrefix(releaseVersion, "v"),
 			ImageRepository: imageRepository,
 		},
 		metadata,

--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -59,13 +59,15 @@ func BundleAssets(
 		return nil, err
 	}
 
-	olmVersion := strings.TrimLeft(releaseVersion, "v")
+	// Remove any `v` index that may have been included
+	strippedVersion := strings.TrimPrefix(releaseVersion, "v")
+
 	olmVars := templateOLMVars{
 		ackgenerate.ImageReleaseVars{
-			ReleaseVersion:  releaseVersion,
+			ReleaseVersion:  strippedVersion,
 			ImageRepository: imageRepository,
 		},
-		olmVersion,
+		strippedVersion,
 		time.Now().Format("2006-01-02 15:04:05"),
 		m.MetaVars(),
 		commonMeta,


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1715

Description of changes:
This pull request updates the release Go code paths and ensures that all `ReleaseVersion` template variables do not contain the `v` prefix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
