### PR TITLE
Add Seccomp profile to deployment

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -73,6 +73,9 @@ spec:
           capabilities:
             drop:
               - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ .ServiceAccountName }}
       hostIPC: false

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -116,6 +116,9 @@ spec:
           capabilities:
             drop:
               - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if .Values.deployment.tolerations -}}

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -31,7 +31,7 @@ deployment:
 
 # If "installScope: cluster" then these labels will be applied to ClusterRole
 role:
- labels: {}
+  labels: {}
   
 metrics:
   service:


### PR DESCRIPTION
**Description of changes:**

I have recently tried to leveraging k8s built in [Enforce Pod Security Standards with Namespace Labels](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/) feature.

When I tried to install one of the controllers I noticed warnings on the [restricted](
https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) profile.
This I found strange because I checked beforehand and I saw you were already dropping all the capabilities:

https://github.com/aws-controllers-k8s/code-generator/blob/811e30bb8efe2855f79e6e946039247e23c0d03b/templates/helm/templates/deployment.yaml#L112-L118

And hard setting the host env:
https://github.com/aws-controllers-k8s/code-generator/blob/811e30bb8efe2855f79e6e946039247e23c0d03b/templates/helm/templates/deployment.yaml#L130-L132

It looks like it's just missing the scomp profile!

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
