### PR TITLE
Add Helm overrides for env vars, volumes and volume mounts

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -18,10 +18,12 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+{{- if .Values.deployment.annotations }}
       annotations:
       {{- range $key, $value := .Values.deployment.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "app.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -104,10 +106,18 @@ spec:
           value: {{ include "aws.credentials.path" . }}
         - name: AWS_PROFILE
           value: {{ .Values.aws.credentials.profile }}
+        {{- end }}
+        {{- if .Values.deployment.extraEnvVars -}}
+          {{ toYaml .Values.deployment.extraEnvVars | nindent 8 }}
+        {{- end }}
         volumeMounts:
+        {{- if .Values.aws.credentials.secretName }}
           - name: {{ .Values.aws.credentials.secretName }}
             mountPath: {{ include "aws.credentials.secret_mount_path" . }}
             readOnly: true
+        {{- end }}
+        {{- if .Values.deployment.extraVolumeMounts -}}
+          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -133,9 +143,12 @@ spec:
       hostIPC: false
       hostNetwork: false
       hostPID: false
-      {{ if .Values.aws.credentials.secretName -}}
       volumes:
+      {{- if .Values.aws.credentials.secretName -}}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}
       {{ end -}}
+{{- if .Values.deployment.extraVolumes }}
+{{ toYaml .Values.deployment.extraVolumes | indent 8}}
+{{- end }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -58,6 +58,15 @@
         },
         "priorityClassName": {
           "type": "string"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "extraEnvVars": {
+          "type": "array"
         }
       },
       "required": [

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -28,6 +28,26 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Additional server container environment variables
+  #
+  # You specify this manually like you would a raw deployment manifest.
+  # This means you can bind in environment variables from secrets.
+  #
+  # e.g. static environment variable:
+  #  - name: DEMO_GREETING
+  #    value: "Hello from the environment"
+  #
+  # e.g. secret environment variable:
+  # - name: USERNAME
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret
+  #       key: username
+  extraEnvVars: []
+
 
 # If "installScope: cluster" then these labels will be applied to ClusterRole
 role:


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/919

Description of changes:
Adds additional Helm chart value overrides for deployment environment variables, volumes and volume mounts.

When deploying the `s3-controller` with the following `values.yaml` overrides:
```yaml
deployment:
  extraVolumes:
    - name: test-volume
      secret:
        secretName: test-secret
  extraVolumeMounts:
    - name: test-volume-mount
      mountPath: /root/
  extraEnvVars: 
    - name: SOMEVAR
      value: somevalue
    - name: PASSWORD
      valueFrom:
        secretKeyRef:
          name: mysecret
          key: password
          optional: false
```

`helm template` produces the following output:
```yaml
# Source: s3-chart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-s3-chart
  namespace: default
  labels:
    app.kubernetes.io/name: s3-chart
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "1.0.4"
    k8s-app: s3-chart
    helm.sh/chart: s3-chart-1.0.4
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: s3-chart
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: s3-chart
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        k8s-app: s3-chart
    spec:
      serviceAccountName: ack-s3-controller
      containers:
      - command:
        - ./bin/controller
        args:
        - --aws-region
        - "$(AWS_REGION)"
        - --aws-endpoint-url
        - "$(AWS_ENDPOINT_URL)"
        - --enable-development-logging
        - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
        - --log-level
        - "$(ACK_LOG_LEVEL)"
        - --resource-tags
        - "$(ACK_RESOURCE_TAGS)"
        - --watch-namespace
        - "$(ACK_WATCH_NAMESPACE)"
        - --deletion-policy
        - "$(DELETION_POLICY)"
        image: public.ecr.aws/aws-controllers-k8s/s3-controller:1.0.4
        imagePullPolicy: IfNotPresent
        name: controller
        ports:
          - name: http
            containerPort: 8080
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
        env:
        - name: ACK_SYSTEM_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: AWS_REGION
          value:
        - name: AWS_ENDPOINT_URL
          value: ""
        - name: ACK_WATCH_NAMESPACE
          value:
        - name: DELETION_POLICY
          value: delete
        - name: ACK_ENABLE_DEVELOPMENT_LOGGING
          value: "false"
        - name: ACK_LOG_LEVEL
          value: "info"
        - name: ACK_RESOURCE_TAGS
          value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
        - name: SOMEVAR
          value: somevalue
        - name: PASSWORD
          valueFrom:
            secretKeyRef:
              key: password
              name: mysecret
              optional: false
        volumeMounts:
            - mountPath: /root/
              name: test-volume-mount
        securityContext:
          allowPrivilegeEscalation: false
          privileged: false
          runAsNonRoot: true
          capabilities:
            drop:
              - ALL
      securityContext:
        seccompProfile:
          type: RuntimeDefault
      terminationGracePeriodSeconds: 10
      nodeSelector:
        kubernetes.io/os: linux
      hostIPC: false
      hostNetwork: false
      hostPID: false
      volumes:
        - name: test-volume
          secret:
            secretName: test-secret
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
