### PR TITLE
Set `defaultResyncPeriod` helm value to 36000

### DIFF
--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -110,7 +110,7 @@ deletionPolicy: delete
 # controller reconciliation configurations
 reconcile:
   # The default duration, in seconds, to wait before resyncing desired state of custom resources.
-  defaultResyncPeriod: 0
+  defaultResyncPeriod: 36000 # 10 Hours
   # An object representing the reconcile resync configuration for each specific resource.
   resourceResyncPeriods: {}
 


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1671

The 0 value of `defaultResyncPeriod` causes the controller to use 10
hours as a `resyncPeriod` .. which is a very confusing.

This patch sets the default value to 36000 (10 hours in seconds) to
match the expected default behaviour.

See https://github.com/aws-controllers-k8s/runtime/blob/main/pkg/runtime/reconciler.go#L48-L51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
