### PR TITLE
Adding functionality to assign whole object to a field

### DIFF
--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -220,6 +220,9 @@ func (a *SDKAPI) GetInputShapeRef(
 	if !ok {
 		return nil, false
 	}
+	if path == "." {
+		return &op.InputRef, true
+	}
 	return getMemberByPath(op.InputRef.Shape, path)
 }
 


### PR DESCRIPTION
Issue #, if available:
This PR is created to support the code-generation for `FunctionEventInvokeConfig` feature in lambda-controller. [PR#92](https://github.com/aws-controllers-k8s/lambda-controller/pull/92) 

Description of changes:
This PR adds functionality to assign whole object to a field, instead of assigning a particular parameter of it. To clarify it further, in the below code, we created a new field `LayerStatuses` which stores the value of `Configuration.Layers` parameter taken from `GetFunction` operation.
```
LayerStatuses:
        from:
          operation: GetFunction
          path: Configuration.Layers
```
In our case we needed to add `FunctionEventInvokeConfig` as an inline property to `Function` resource, for which we needed to assign the whole object returned by `PutFunctionEventInvokeConfig` operation to field `FunctionEventInvokeConfig`. To make this work we added a new condition for it by passing `path` value  as `.` , shown below:
```
FunctionEventInvokeConfig:
        from:
          operation: PutFunctionEventInvokeConfig 
          path: .
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
