### PR TITLE
Code generator change for member of type list

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -874,9 +874,15 @@ func setSDKReadMany(
 				indentLevel+1,
 			)
 
-			//  f0 = append(f0, sourceVarName)
-			out += fmt.Sprintf("%s\t%s = append(%s, %s)\n", indent,
-				memberVarName, memberVarName, resVarPath)
+			if r.IsMemberAList(memberName, op) {
+				//  f0 = append(f0, sourceVarName...)
+				out += fmt.Sprintf("%s\t%s = append(%s, %s...)\n", indent,
+					memberVarName, memberVarName, resVarPath)
+			} else {
+				//  f0 = append(f0, sourceVarName)
+				out += fmt.Sprintf("%s\t%s = append(%s, %s)\n", indent,
+					memberVarName, memberVarName, resVarPath)
+			}
 
 			// res.SetIds(f0)
 			out += setSDKForScalar(

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -686,6 +686,28 @@ func (r *CRD) GetIdentifiers() []string {
 	return identifiers
 }
 
+func (r *CRD) IsMemberAList(
+	memberName string,
+	op *awssdkmodel.Operation) bool {
+	cfg := r.Config()
+
+	// Handles field renames, if applicable
+	fieldName := cfg.GetResourceFieldName(
+		r.Names.Original,
+		op.ExportedName,
+		memberName,
+	)
+	cleanFieldNames := names.New(fieldName)
+	pathFieldName := cleanFieldNames.Camel
+
+	if _, ok := r.Fields[pathFieldName]; ok {
+		if strings.Contains(r.Fields[pathFieldName].GoType, "[]") {
+			return true
+		}
+	}
+	return false
+}
+
 // GetSanitizedMemberPath takes a shape member field, checks for renames, checks
 // for existence in Spec and Status, then constructs and returns the var path.
 // Returns error if memberName is not present in either Spec or Status.


### PR DESCRIPTION
Currently code generator assumes the type of 'member' as scalar. But if the member is a list, the generated code needs to be as per that type.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
