### PR TITLE
Generate code for custom status field

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -277,6 +277,13 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 					)
 					panic(msg)
 				}
+			} else if fieldConfig.Type != nil {
+				// We have a custom field that has a type override and has not
+				// been inferred via the normal Create Input shape or via the
+				// SourceFieldConfig. Manually construct the field and its
+				// shape reference here.
+				typeOverride := *fieldConfig.Type
+				memberShapeRef = m.SDKAPI.GetShapeRefFromType(typeOverride)
 			} else {
 				// Status field is not well defined
 				continue


### PR DESCRIPTION
Generate code for a custom status field that has a type override and has not been inferred via the normal Create Input shape or via the SourceFieldConfig. Manually construct the field and its shape reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
