### PR TITLE
Add `custom find_operation` support

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -44,6 +44,7 @@ var (
 	controllerIncludePaths = []string{
 		"boilerplate.go.tpl",
 		"pkg/resource/references_read_referenced_resource.go.tpl",
+		"pkg/resource/sdk_find_custom.go.tpl",
 		"pkg/resource/sdk_find_read_one.go.tpl",
 		"pkg/resource/sdk_find_get_attributes.go.tpl",
 		"pkg/resource/sdk_find_read_many.go.tpl",

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -962,6 +962,8 @@ func SetResourceIdentifiers(
 		case r.Ops.ReadMany != nil:
 			// If single lookups can only be done using ReadMany
 			op = r.Ops.ReadMany
+		default:
+			return ""
 		}
 	}
 	inputShape := op.InputRef.Shape

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -639,6 +639,10 @@ func (r *CRD) CustomUpdateMethodName() string {
 	return r.cfg.GetCustomUpdateMethodName(r.Names.Original)
 }
 
+func (r *CRD) CustomFindMethodName() string {
+	return r.cfg.GetCustomFindMethodName(r.Names.Original)
+}
+
 // ListOpMatchFieldNames returns a slice of strings representing the field
 // names in the List operation's Output shape's element Shape that we should
 // check a corresponding value in the target Spec exists.

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -39,7 +39,9 @@ var (
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
-{{ if .CRD.Ops.ReadOne }}
+{{ if .CRD.CustomFindMethodName }}
+	{{- template "sdk_find_custom" . }}
+{{- else if .CRD.Ops.ReadOne }}
 	{{- template "sdk_find_read_one" . }}
 {{- else if .CRD.Ops.GetAttributes }}
 	{{- template "sdk_find_get_attributes" . }}

--- a/templates/pkg/resource/sdk_find_custom.go.tpl
+++ b/templates/pkg/resource/sdk_find_custom.go.tpl
@@ -1,0 +1,8 @@
+{{- define "sdk_find_custom" -}}
+func (rm *resourceManager) sdkFind(
+	ctx context.Context,
+	r *resource,
+) (*resource, error) {
+	return rm.{{ .CRD.CustomFindMethodName }}(ctx, r)
+}
+{{- end -}}


### PR DESCRIPTION
Issue: aws-controllers-k8s/community#1827

Description of changes:
This change allow to implement custom find function. The name of the function could be written in generator.yaml as 'find_operation: <name-of-function>' similar to update_operation. And generated code for sdkFind() would call this custom find function. The find function itself could be written in hooks.go.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

