### PR TITLE
updating olm kustomize files, due to kuztomize deprecations

### DIFF
--- a/templates/config/controller/olm-kustomization.yaml.tpl
+++ b/templates/config/controller/olm-kustomization.yaml.tpl
@@ -1,22 +1,20 @@
 {{ template "controller_kustomization" . }}
 
-patchesJson6902:
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: ack-{{ .ServicePackageName }}-controller
-    patch: |-
-        - op: replace
-          path: '/spec/template/spec/containers/0/env'
-          value: []
-        - op: add
-          path: '/spec/template/spec/containers/0/env/0'
-          value:
-            name: ACK_SYSTEM_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-
-patchesStrategicMerge:
-  - user-env.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: '/spec/template/spec/containers/0/env'
+      value: []
+    - op: add
+      path: '/spec/template/spec/containers/0/env/0'
+      value:
+        name: ACK_SYSTEM_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+  target:
+    group: apps
+    kind: Deployment
+    name: ack-{{ .ServicePackageName }}-controller
+    version: v1
+- path: user-env.yaml

--- a/templates/config/scorecard/kustomization.yaml
+++ b/templates/config/scorecard/kustomization.yaml
@@ -1,16 +1,17 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
-    version: v1alpha3
     kind: Configuration
     name: config
+    version: v1alpha3
 - path: patches/olm.config.yaml
   target:
     group: scorecard.operatorframework.io
-    version: v1alpha3
     kind: Configuration
     name: config
-# +kubebuilder:scaffold:patchesJson6902
+    version: v1alpha3


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Updating olm kustomize files using `kustomize edit fix` since some of the methods we were using were marked for deprecation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
