### PR TITLE
fixing boolean flag in deployment args to be on a single line

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -29,8 +29,7 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
-        - --enable-development-logging
-        - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
+        - --enable-development-logging=$(ACK_ENABLE_DEVELOPMENT_LOGGING)
         - --log-level
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Fixing deployment `args` to have boolean values on a single line. This is needed since the presence of the flag itself is a `truthy` statement, and the next line for the `env` is ignored. See [this](https://github.com/aws-controllers-k8s/code-generator/pull/455#discussion_r1282157936) comment on `leader-elect` PR for more info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
