### PR TITLE
add hooks for set identifiers

### DIFF
--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -69,6 +69,8 @@ code paths:
 * convert_tags_post_to_ack_tags
 * convert_tags_pre_from_ack_tags
 * convert_tags_post_from_ack_tags
+* pre_set_resource_identifiers
+* post_set_resource_identifiers
 
 The "pre_build_request" hooks are called BEFORE the call to construct
 the Input shape that is used in the API operation and therefore BEFORE
@@ -143,6 +145,12 @@ tags into K8s resource tags
 
 The "convert_tags_post_from_ack_tags" are called after converting the ACK
 tags into K8s resource tags
+
+The "pre_set_resource_identifiers" hook is called before the generated code
+that sets the resource identifiers to uniquely identify a resource
+
+The "post_set_resource_identifiers" hook is called after the generated code
+that sets the resource identifiers to uniquely identify a resource
 */
 
 // ResourceHookCode returns a string with custom callback code for a resource

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -72,7 +72,13 @@ func (r *resource) SetStatus(desired acktypes.AWSResource) {
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+{{- if $hookCode := Hook .CRD "pre_set_resource_identifiers" }}
+{{ $hookCode }}
+{{- end }}
 {{- GoCodeSetResourceIdentifiers .CRD "identifier" "r.ko" 1}}
+{{- if $hookCode := Hook .CRD "post_set_resource_identifiers" }}
+{{ $hookCode }}
+{{- end }}
 	return nil
 }
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1871

Description of changes:
PolicyName field in Describe and Put APIs for ScalingPolicy has a different name and shape.
| API      |  Field name | Shape |
| ----------- | ----------- | ----------- |
| PutScalingPolicy | PolicyName | String
| DescribeScalingPolicies   | PolicyNames | List of strings

Because of difference in names, the code gen [skips adding it to additional resource identifier for SetIndentifiers](https://github.com/aws-controllers-k8s/code-generator/blob/main/pkg/generate/code/set_resource.go#L1068). Hesitant to use rename because the shape type is different in both APIs (string vs list of string). Adding hooks to unblock

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.