### PR TITLE
chore: Support multi-arch containers build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # Base image to use at runtime
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 
+ARG TARGETARCH=amd64
+
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang
 
-# Version of Golang 
+# Version of Golang
 ARG golang_version
 
 # Build the manager binary
@@ -15,14 +17,13 @@ ARG service_alias
 ARG service_controller_git_version
 ARG service_controller_git_commit
 ARG build_date
-ARG go_arch=amd64
 # The directory within the builder container into which we will copy our
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$go_arch
+ENV GOARCH=$TARGETARCH
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Base image to use at runtime
 ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 
-ARG TARGETARCH=amd64
+ARG target_arch=amd64
 
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang
@@ -23,7 +23,7 @@ ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$TARGETARCH
+ENV GOARCH=$target_arch
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -15,14 +15,14 @@ ARG service_alias
 ARG service_controller_git_version
 ARG service_controller_git_commit
 ARG build_date
-ARG TARGETARCH=amd64
+ARG target_arch=amd64
 # The directory within the builder container into which we will copy our
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$TARGETARCH
+ENV GOARCH=$target_arch
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -4,7 +4,7 @@ ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-n
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang
 
-# Version of Golang 
+# Version of Golang
 ARG golang_version
 
 # Build the manager binary
@@ -15,14 +15,14 @@ ARG service_alias
 ARG service_controller_git_version
 ARG service_controller_git_commit
 ARG build_date
-ARG go_arch=amd64
+ARG TARGETARCH=amd64
 # The directory within the builder container into which we will copy our
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$go_arch
+ENV GOARCH=$TARGETARCH
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -12,6 +12,10 @@ metadata:
     createdAt: {{.CreatedAt}}
     support: {{.Annotations.Support}}
     certified: {{.Annotations.IsCertified}}
+  labels:
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
   name: ack-{{.ServicePackageName }}-controller.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
I have tried to start several controllers of aws-controllers-k8s on an ARM EC2 on AWS, but I get the following error.

```
exec ./bin/controller: exec format error
```

To determine the binary format in the Dockerfile, we decided to use TARGETARCH instead of go_arch to facilitate multi-platform build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
