### PR TITLE
Upgrade ACK controllers runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image to use at runtime
-ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
+ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-08-24-1692903666.2023
 
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 # Base image to use at runtime
-ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
+ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-08-24-1692903666.2023
 
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang


### PR DESCRIPTION
Upgrade `eks-distro-build-tooling/eks-distro-minimal-base-nonroot` image to tag `2023-08-24-1692903666.2023`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
