### PR TITLE
Functionality to make `ignore` work

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -14,6 +14,8 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
@@ -557,6 +559,14 @@ func (c *Config) GetResourceFieldName(
 	if !ok {
 		return origFieldName
 	}
+
+	if resourceName == "Function" {
+		if origFieldName == "Code" {
+			t, _ := json.Marshal(rConfig.Renames)
+			fmt.Println("rConfig.Renames", string(t))
+		}
+	}
+
 	if rConfig.Renames == nil {
 		return origFieldName
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -14,8 +14,6 @@
 package config
 
 import (
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
@@ -559,14 +557,6 @@ func (c *Config) GetResourceFieldName(
 	if !ok {
 		return origFieldName
 	}
-
-	if resourceName == "Function" {
-		if origFieldName == "Code" {
-			t, _ := json.Marshal(rConfig.Renames)
-			fmt.Println("rConfig.Renames", string(t))
-		}
-	}
-
 	if rConfig.Renames == nil {
 		return origFieldName
 	}

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -135,7 +135,7 @@ var (
 			if ok {
 				setCfg = f.GetSetterConfig(ackmodel.OpTypeList)
 			}
-			if setCfg != nil && setCfg.Ignore {
+			if setCfg != nil && setCfg.IgnoreResourceSetter() {
 				return ""
 			}
 			return code.SetResourceForStruct(r.Config(), r, targetVarName, targetShapeRef, setCfg, sourceVarName, sourceShapeRef, "", model.OpTypeList, indentLevel)

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -122,7 +122,7 @@ var (
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
 		"GoCodeSetSDKForStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceFieldPath string, sourceVarName string, indentLevel int) string {
-			return code.SetSDKForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceFieldPath, sourceVarName, indentLevel)
+			return code.SetSDKForStruct(r.Config(), r, targetFieldName, targetVarName, targetShapeRef, sourceFieldPath, sourceVarName, model.OpTypeList, indentLevel)
 		},
 		"GoCodeSetResourceForStruct": func(r *ackmodel.CRD, targetFieldName string, targetVarName string, targetShapeRef *awssdkmodel.ShapeRef, sourceVarName string, sourceShapeRef *awssdkmodel.ShapeRef, indentLevel int) string {
 			var setCfg *ackgenconfig.SetFieldConfig = nil

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -231,7 +231,7 @@ func SetResource(
 		// field value...
 		setCfg := f.GetSetterConfig(opType)
 
-		if setCfg != nil && setCfg.Ignore {
+		if setCfg != nil && setCfg.IgnoreResourceSetter() {
 			continue
 		}
 
@@ -588,7 +588,7 @@ func setResourceReadMany(
 		// field value...
 		setCfg := f.GetSetterConfig(model.OpTypeList)
 
-		if setCfg != nil && setCfg.Ignore {
+		if setCfg != nil && setCfg.IgnoreResourceSetter() {
 			continue
 		}
 

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -328,23 +328,6 @@ func SetSDK(
 			indent = "\t" + indent
 		}
 
-		//check ignore
-		// fieldConfigs := cfg.GetFieldConfigs(r.Names.Original)
-		flag := false
-		if f.FieldConfig != nil {
-			if f.FieldConfig.Set != nil {
-				set := f.FieldConfig.Set
-				for _, value := range set {
-					if value.Ignore == true {
-						flag = true
-					}
-				}
-			}
-		}
-		if flag {
-			continue
-		}
-
 		out += fmt.Sprintf(
 			"%sif %s != nil {\n", indent, sourceAdaptedVarName,
 		)
@@ -1117,37 +1100,26 @@ func SetSDKForStruct(
 		sourceAdaptedVarName := sourceVarName + "." + cleanMemberName
 		memberFieldPath := sourceFieldPath + "." + cleanMemberName
 
-		// flag := false
-		// if r.Fields[targetFieldName] != nil {
-		// 	if r.Fields[targetFieldName].MemberFields[memberName] != nil {
-		// 		if r.Fields[targetFieldName].MemberFields[memberName].FieldConfig != nil {
-		// 			if r.Fields[targetFieldName].MemberFields[memberName].FieldConfig.Set != nil {
-		// 				set := r.Fields[targetFieldName].MemberFields[memberName].FieldConfig.Set
-		// 				for _, value := range set {
-		// 					if value.Ignore == true {
-		// 						flag = true
-		// 					}
-		// 				}
-		// 			}
-		// 		}
-		// 	}
-		// }
-		// if r.Fields[memberName] != nil {
-		// 	if r.Fields[memberName].FieldConfig != nil {
-		// 		if r.Fields[memberName].FieldConfig.Set != nil {
-		// 			set := r.Fields[memberName].FieldConfig.Set
-		// 			for _, value := range set {
-		// 				if value.Ignore == true {
-		// 					flag = true
-		// 				}
-		// 			}
-		// 		}
-		// 	}
-		// }
+		// todo: To make `ignore` functionality work for all fields that has `ignore` set to `true`,
+		// we need to add the below logic inside `SetSDK` function.
 
-		// if flag {
-		// 	continue
-		// }
+		// To check if the field member has `ignore` set to `true`.
+		// This condition currently applies only for members of a field whose shape is `structure`
+		if r.Fields[targetFieldName] != nil {
+			memberField := r.Fields[targetFieldName].MemberFields[memberName]
+			if memberField != nil && memberField.FieldConfig != nil && memberField.FieldConfig.Set != nil {
+				set := memberField.FieldConfig.Set
+				shouldIgnore := false
+				for _, value := range set {
+					if value.Ignore == true {
+						shouldIgnore = true
+					}
+				}
+				if shouldIgnore {
+					continue
+				}
+			}
+		}
 
 		out += fmt.Sprintf(
 			"%sif %s != nil {\n", indent, sourceAdaptedVarName,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1113,11 +1113,16 @@ func SetSDKForStruct(
 			mf, ok := f.MemberFields[memberName]
 			if ok {
 				setCfg = mf.GetSetterConfig(op)
-				if setCfg != nil && setCfg.Ignore {
+				if setCfg != nil && setCfg.IgnoreSDKSetter() {
 					continue
 				}
 			}
 
+		}
+
+		fallBackName := r.GetMatchingInputShapeFieldName(op, targetFieldName)
+		if fallBackName == memberName {
+			// TODO: implement @AmineHilaly
 		}
 
 		out += fmt.Sprintf(

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -113,7 +113,6 @@ func SetSDK(
 		return ""
 	}
 	inputShape := op.InputRef.Shape
-
 	if inputShape == nil {
 		return ""
 	}
@@ -178,8 +177,6 @@ func SetSDK(
 	}
 
 	opConfig, override := cfg.GetOverrideValues(op.ExportedName)
-
-	// for create op: Member Names have Code
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
@@ -243,7 +240,6 @@ func SetSDK(
 		}
 
 		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
-
 		if inSpec {
 			sourceAdaptedVarName += cfg.PrefixConfig.SpecField
 			f = r.SpecFields[fieldName]
@@ -254,11 +250,6 @@ func SetSDK(
 			// TODO(jaypipes): check generator config for exceptions?
 			continue
 		}
-
-		// setCfg := f.GetSetterConfig(opType)
-		// if setCfg != nil && setCfg.Ignore {
-		// 	continue
-		// }
 
 		sourceAdaptedVarName += "." + f.Names.Camel
 		sourceFieldPath := f.Names.Camel
@@ -1128,22 +1119,6 @@ func SetSDKForStruct(
 			}
 
 		}
-
-		// if r.Fields[targetFieldName] != nil {
-		// 	memberField := r.Fields[targetFieldName].MemberFields[memberName]
-		// 	if memberField != nil && memberField.FieldConfig != nil && memberField.FieldConfig.Set != nil {
-		// 		set := memberField.FieldConfig.Set
-		// 		shouldIgnore := false
-		// 		for _, value := range set {
-		// 			if value.Ignore == true {
-		// 				shouldIgnore = true
-		// 			}
-		// 		}
-		// 		if shouldIgnore {
-		// 			continue
-		// 		}
-		// 	}
-		// }
 
 		out += fmt.Sprintf(
 			"%sif %s != nil {\n", indent, sourceAdaptedVarName,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -14,6 +14,7 @@
 package code
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -113,6 +114,18 @@ func SetSDK(
 		return ""
 	}
 	inputShape := op.InputRef.Shape
+
+	if r.Names.Camel == "Function" {
+		_, ok := r.SpecFields["Code"]
+		if ok {
+			// k, _ := json.Marshal(op.InputRef.Shape)
+			// fmt.Println("InputRef.Shape", string(k)) // createFunction, getFunction, deleteFunction
+
+			i, _ := json.Marshal(op.InputRef.Shape.MemberRefs["Attributes"])
+			fmt.Println("InputRef.Shape.MemeberRefs[Attributes]", string(i)) // null
+		}
+	}
+
 	if inputShape == nil {
 		return ""
 	}
@@ -177,6 +190,20 @@ func SetSDK(
 	}
 
 	opConfig, override := cfg.GetOverrideValues(op.ExportedName)
+
+	if r.Names.Camel == "Function" {
+		_, ok := r.SpecFields["Code"]
+		if ok {
+			opConfig, override := cfg.GetOverrideValues(op.ExportedName)
+
+			fmt.Println("opConfig is", opConfig) // map[]
+			fmt.Println("override is", override) // false
+
+			fmt.Println("Member names are", inputShape.MemberNames())
+		}
+	}
+
+	// for create op: Member Names have Code
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
@@ -240,6 +267,21 @@ func SetSDK(
 		}
 
 		inSpec, inStatus := r.HasMember(fieldName, op.ExportedName)
+		if r.Names.Camel == "Function" {
+			_, ok := r.SpecFields["Code"]
+			// d, _ := json.Marshal(r.SpecFields["Code"])
+			// fmt.Println("Fields are", string(d))
+
+			if ok {
+				_, ok2 := r.SpecFields["Code"].MemberFields["S3SHA256"]
+				if ok2 {
+					fmt.Println("spec status", inSpec, inStatus)
+				}
+				fmt.Println("spec status", inSpec, inStatus)
+			}
+
+		}
+
 		if inSpec {
 			sourceAdaptedVarName += cfg.PrefixConfig.SpecField
 			f = r.SpecFields[fieldName]

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -2190,3 +2190,180 @@ func TestSetSDK_IAM_User_NewPath(t *testing.T) {
 		code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1),
 	)
 }
+
+func TestSetSDK_Lambda_Ignore_Code_SHA256(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-lambda-ignore-code-sha256.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Spec.Code != nil {
+		f0 := &svcsdk.FunctionCode{}
+		if r.ko.Spec.Code.ImageURI != nil {
+			f0.SetImageUri(*r.ko.Spec.Code.ImageURI)
+		}
+		if r.ko.Spec.Code.S3Bucket != nil {
+			f0.SetS3Bucket(*r.ko.Spec.Code.S3Bucket)
+		}
+		if r.ko.Spec.Code.S3Key != nil {
+			f0.SetS3Key(*r.ko.Spec.Code.S3Key)
+		}
+		if r.ko.Spec.Code.S3ObjectVersion != nil {
+			f0.SetS3ObjectVersion(*r.ko.Spec.Code.S3ObjectVersion)
+		}
+		if r.ko.Spec.Code.ZipFile != nil {
+			f0.SetZipFile(r.ko.Spec.Code.ZipFile)
+		}
+		res.SetCode(f0)
+	}
+	if r.ko.Spec.CodeSigningConfigARN != nil {
+		res.SetCodeSigningConfigArn(*r.ko.Spec.CodeSigningConfigARN)
+	}
+	if r.ko.Spec.DeadLetterConfig != nil {
+		f2 := &svcsdk.DeadLetterConfig{}
+		if r.ko.Spec.DeadLetterConfig.TargetARN != nil {
+			f2.SetTargetArn(*r.ko.Spec.DeadLetterConfig.TargetARN)
+		}
+		res.SetDeadLetterConfig(f2)
+	}
+	if r.ko.Spec.Description != nil {
+		res.SetDescription(*r.ko.Spec.Description)
+	}
+	if r.ko.Spec.Environment != nil {
+		f4 := &svcsdk.Environment{}
+		if r.ko.Spec.Environment.Variables != nil {
+			f4f0 := map[string]*string{}
+			for f4f0key, f4f0valiter := range r.ko.Spec.Environment.Variables {
+				var f4f0val string
+				f4f0val = *f4f0valiter
+				f4f0[f4f0key] = &f4f0val
+			}
+			f4.SetVariables(f4f0)
+		}
+		res.SetEnvironment(f4)
+	}
+	if r.ko.Spec.FileSystemConfigs != nil {
+		f5 := []*svcsdk.FileSystemConfig{}
+		for _, f5iter := range r.ko.Spec.FileSystemConfigs {
+			f5elem := &svcsdk.FileSystemConfig{}
+			if f5iter.ARN != nil {
+				f5elem.SetArn(*f5iter.ARN)
+			}
+			if f5iter.LocalMountPath != nil {
+				f5elem.SetLocalMountPath(*f5iter.LocalMountPath)
+			}
+			f5 = append(f5, f5elem)
+		}
+		res.SetFileSystemConfigs(f5)
+	}
+	if r.ko.Spec.FunctionName != nil {
+		res.SetFunctionName(*r.ko.Spec.FunctionName)
+	}
+	if r.ko.Spec.Handler != nil {
+		res.SetHandler(*r.ko.Spec.Handler)
+	}
+	if r.ko.Spec.ImageConfig != nil {
+		f8 := &svcsdk.ImageConfig{}
+		if r.ko.Spec.ImageConfig.Command != nil {
+			f8f0 := []*string{}
+			for _, f8f0iter := range r.ko.Spec.ImageConfig.Command {
+				var f8f0elem string
+				f8f0elem = *f8f0iter
+				f8f0 = append(f8f0, &f8f0elem)
+			}
+			f8.SetCommand(f8f0)
+		}
+		if r.ko.Spec.ImageConfig.EntryPoint != nil {
+			f8f1 := []*string{}
+			for _, f8f1iter := range r.ko.Spec.ImageConfig.EntryPoint {
+				var f8f1elem string
+				f8f1elem = *f8f1iter
+				f8f1 = append(f8f1, &f8f1elem)
+			}
+			f8.SetEntryPoint(f8f1)
+		}
+		if r.ko.Spec.ImageConfig.WorkingDirectory != nil {
+			f8.SetWorkingDirectory(*r.ko.Spec.ImageConfig.WorkingDirectory)
+		}
+		res.SetImageConfig(f8)
+	}
+	if r.ko.Spec.KMSKeyARN != nil {
+		res.SetKMSKeyArn(*r.ko.Spec.KMSKeyARN)
+	}
+	if r.ko.Spec.Layers != nil {
+		f10 := []*string{}
+		for _, f10iter := range r.ko.Spec.Layers {
+			var f10elem string
+			f10elem = *f10iter
+			f10 = append(f10, &f10elem)
+		}
+		res.SetLayers(f10)
+	}
+	if r.ko.Spec.MemorySize != nil {
+		res.SetMemorySize(*r.ko.Spec.MemorySize)
+	}
+	if r.ko.Spec.PackageType != nil {
+		res.SetPackageType(*r.ko.Spec.PackageType)
+	}
+	if r.ko.Spec.Publish != nil {
+		res.SetPublish(*r.ko.Spec.Publish)
+	}
+	if r.ko.Spec.Role != nil {
+		res.SetRole(*r.ko.Spec.Role)
+	}
+	if r.ko.Spec.Runtime != nil {
+		res.SetRuntime(*r.ko.Spec.Runtime)
+	}
+	if r.ko.Spec.Tags != nil {
+		f16 := map[string]*string{}
+		for f16key, f16valiter := range r.ko.Spec.Tags {
+			var f16val string
+			f16val = *f16valiter
+			f16[f16key] = &f16val
+		}
+		res.SetTags(f16)
+	}
+	if r.ko.Spec.Timeout != nil {
+		res.SetTimeout(*r.ko.Spec.Timeout)
+	}
+	if r.ko.Spec.TracingConfig != nil {
+		f18 := &svcsdk.TracingConfig{}
+		if r.ko.Spec.TracingConfig.Mode != nil {
+			f18.SetMode(*r.ko.Spec.TracingConfig.Mode)
+		}
+		res.SetTracingConfig(f18)
+	}
+	if r.ko.Spec.VPCConfig != nil {
+		f19 := &svcsdk.VpcConfig{}
+		if r.ko.Spec.VPCConfig.SecurityGroupIDs != nil {
+			f19f0 := []*string{}
+			for _, f19f0iter := range r.ko.Spec.VPCConfig.SecurityGroupIDs {
+				var f19f0elem string
+				f19f0elem = *f19f0iter
+				f19f0 = append(f19f0, &f19f0elem)
+			}
+			f19.SetSecurityGroupIds(f19f0)
+		}
+		if r.ko.Spec.VPCConfig.SubnetIDs != nil {
+			f19f1 := []*string{}
+			for _, f19f1iter := range r.ko.Spec.VPCConfig.SubnetIDs {
+				var f19f1elem string
+				f19f1elem = *f19f1iter
+				f19f1 = append(f19f1, &f19f1elem)
+			}
+			f19.SetSubnetIds(f19f1)
+		}
+		res.SetVpcConfig(f19)
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1),
+	)
+}

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -426,14 +426,6 @@ func (r *CRD) GetMatchingInputShapeFieldName(opType OpType, sdkField string) str
 		if f.FieldConfig == nil {
 			continue
 		}
-		if r.Names.Camel == "Function" && f.Names.Camel == "Code" {
-			// a, _ := json.Marshal(f.FieldConfig)
-			// fmt.Println("f.Fieldconfig", string(a))
-
-			// b, _ := json.Marshal(f.FieldConfig.Set)
-			// fmt.Println("f.fieldConfig.Set", string(b))
-
-		}
 		rmMethod := ResourceManagerMethodFromOpType(opType)
 		for _, setCfg := range f.FieldConfig.Set {
 			if setCfg == nil {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -426,6 +426,14 @@ func (r *CRD) GetMatchingInputShapeFieldName(opType OpType, sdkField string) str
 		if f.FieldConfig == nil {
 			continue
 		}
+		if r.Names.Camel == "Function" && f.Names.Camel == "Code" {
+			// a, _ := json.Marshal(f.FieldConfig)
+			// fmt.Println("f.Fieldconfig", string(a))
+
+			// b, _ := json.Marshal(f.FieldConfig.Set)
+			// fmt.Println("f.fieldConfig.Set", string(b))
+
+		}
 		rmMethod := ResourceManagerMethodFromOpType(opType)
 		for _, setCfg := range f.FieldConfig.Set {
 			if setCfg == nil {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -428,10 +428,7 @@ func (r *CRD) GetMatchingInputShapeFieldName(opType OpType, sdkField string) str
 		}
 		rmMethod := ResourceManagerMethodFromOpType(opType)
 		for _, setCfg := range f.FieldConfig.Set {
-			if setCfg == nil {
-				continue
-			}
-			if setCfg.Ignore == true || setCfg.To == nil {
+			if setCfg == nil || setCfg.IgnoreSDKSetter() {
 				continue
 			}
 			// If the Method attribute is nil, that means the setter config applies to

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -196,6 +196,15 @@ func (f *Field) GetSetterConfig(opType OpType) *ackgenconfig.SetFieldConfig {
 	}
 	rmMethod := ResourceManagerMethodFromOpType(opType)
 	for _, setCfg := range f.FieldConfig.Set {
+		if setCfg == nil {
+			continue
+		}
+		if setCfg.Ignore == true {
+			return setCfg
+		}
+		if setCfg.Ignore == true || setCfg.To == nil {
+			continue
+		}
 		// If the Method attribute is nil, that means the setter config applies to
 		// all resource manager methods for this field.
 		if setCfg.Method == nil || strings.EqualFold(rmMethod, *setCfg.Method) {

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -199,12 +199,6 @@ func (f *Field) GetSetterConfig(opType OpType) *ackgenconfig.SetFieldConfig {
 		if setCfg == nil {
 			continue
 		}
-		if setCfg.Ignore == true {
-			return setCfg
-		}
-		if setCfg.Ignore == true || setCfg.To == nil {
-			continue
-		}
 		// If the Method attribute is nil, that means the setter config applies to
 		// all resource manager methods for this field.
 		if setCfg.Method == nil || strings.EqualFold(rmMethod, *setCfg.Method) {

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-lambda-ignore-code-sha256.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-lambda-ignore-code-sha256.yaml
@@ -1,0 +1,8 @@
+resources:
+  Function:
+    fields:
+      Code.S3SHA256:
+        type: string
+        set:
+        - ignore: "to"
+          method: Create

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-with-custom-nested-types.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-with-custom-nested-types.yaml
@@ -9,6 +9,9 @@ resources:
         type: string
         compare:
           is_ignored: true
+        set:
+        - ignore: true
+          method: Create
       ImageConfigResponse.Error.New:
         is_read_only: true
         type: string


### PR DESCRIPTION
**Issue** 
This PR is related to fix the issue generating after executing PR #462 

**Summary**
To disregard fields marked with `set: ignore` for nested fields. This PR also enhances the functionality of `set:ignore` to support the exclusion of fields from `set_sdk`.

**Description**

The PR  fixes the issue coming after a new custom field is created and has `set.ignore` set to `true` for it. Even after setting the field to ignore, the field is getting used to set the SDK fields. In this case particularly, the new field was defined as shown below:

```
Code.S3SHA256:
        type: string
        set:  
          - method: Create
            ignore: true
```
And the issue it is causing is under `sdk.go/newCreateRequestPayload` function, where it is being set, as shown below:
```
if r.ko.Spec.Code.S3SHA256 != nil {
	f1.SetS3SHA256(*r.ko.Spec.Code.S3SHA256)
}
```
The goal is to ignore this particular line of code. And also to improve the basic functionality of `set.ignore`. 

The `set.ignore` functionality was till now supporting exclusion of fields only when the field was used to set for the resource. 

This PR checks the `set.ignore` for field and ignores the following code that creates request payload if it is set to `true`. 

**Limitations**
Currently this PR checks the `set.ignore` field only for members of the field whose type is `structure`. 

**Acknowledgment**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
