### PR TITLE
Fix `ENABLE_LEADER_ELECTION` env variable name

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           value: {{ include "watch-namespace" . }}
         - name: DELETION_POLICY
           value: {{ .Values.deletionPolicy }}
-        - name: ENABLED_LEADER_ELECTION
+        - name: ENABLE_LEADER_ELECTION
           value: {{ .Values.leaderElection.enabled | quote }}
         - name: LEADER_ELECTION_NAMESPACE
           value: {{ .Values.leaderElection.namespace | quote }}


### PR DESCRIPTION
Description of changes:

This fixes that setting and use of env variable had different names.
Without this fix leader election is always enabled in controller, but permissions might not be given.

So if leader election isn't enabled in the values you get constant messages like:

`E0911 06:54:26.919325       1 leaderelection.go:330] error retrieving resource lock alb-ingress/ack-acm.services.k8s.aws: leases.coordination.k8s.io "ack-acm.services.k8s.aws" is forbidden: User "system:serviceaccount:alb-ingress:ack-acm-controller" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "alb-ingress"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
