### PR TITLE
fix: ensure boolean flags are only passed when their corresponding Helm chart value is true

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -48,8 +48,9 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
+{{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
-        - "$(ENABLE_DEVELOPMENT_LOGGING)"
+{{- end }}
         - --log-level
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
@@ -58,10 +59,11 @@ spec:
         - "$(ACK_WATCH_NAMESPACE)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
+{{- if .Values.leaderElection.enabled }}
         - --enable-leader-election
-        - "$(ENABLE_LEADER_ELECTION)"
         - --leader-election-namespace
         - "$(LEADER_ELECTION_NAMESPACE)"
+{{- end }}
 {{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
         - --reconcile-default-resync-seconds
         - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
@@ -91,12 +93,8 @@ spec:
           value: {{ include "watch-namespace" . }}
         - name: DELETION_POLICY
           value: {{ .Values.deletionPolicy }}
-        - name: ENABLE_LEADER_ELECTION
-          value: {{ .Values.leaderElection.enabled | quote }}
         - name: LEADER_ELECTION_NAMESPACE
           value: {{ .Values.leaderElection.namespace | quote }}
-        - name: ACK_ENABLE_DEVELOPMENT_LOGGING
-          value: {{ .Values.log.enable_development_logging | quote }}
         - name: ACK_LOG_LEVEL
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/1893

In this commit, we address the issue of passing boolean flags in a more
solid way. 

We've observed an odd obehaviour when a user attempts to
disabled a feature (e.g `leaderElection/developmentLogging`), which
causes the flag to be enabled instead.

The main root cause of this issue was, using environment vairables with
the `pflag` library, combined with the fact that `spf13/cobra` library
conciders passed boolean flags with no values (no `=<value>`) as `true`

The fix consists of
1. Avoid using environment variables for boolean flags.
2. Updating the helm template to only pass boolean flags when their
   respctive helm chat values are present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
