### PR TITLE
(fix) enable custom names for service accounts

### DIFF
--- a/templates/helm/templates/leader-election-role-binding.yaml.tpl
+++ b/templates/helm/templates/leader-election-role-binding.yaml.tpl
@@ -14,6 +14,6 @@ roleRef:
   name: {{.ServicePackageName}}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "service-account.name" . }}
+  name: {{ "{{ include "service-account.name" . }}" }}
   namespace: {{ "{{ .Release.Namespace }}" }}
 {{- "{{- end }}" }}

--- a/templates/helm/templates/leader-election-role-binding.yaml.tpl
+++ b/templates/helm/templates/leader-election-role-binding.yaml.tpl
@@ -14,6 +14,6 @@ roleRef:
   name: {{.ServicePackageName}}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ "{{ include "service-account.name" . }}" }}
+  name: {{ "{{ include \"service-account.name\" . }}" }}
   namespace: {{ "{{ .Release.Namespace }}" }}
 {{- "{{- end }}" }}

--- a/templates/helm/templates/leader-election-role-binding.yaml.tpl
+++ b/templates/helm/templates/leader-election-role-binding.yaml.tpl
@@ -14,6 +14,6 @@ roleRef:
   name: {{.ServicePackageName}}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{.ServiceAccountName}}
+  name: {{ include "service-account.name" . }}
   namespace: {{ "{{ .Release.Namespace }}" }}
 {{- "{{- end }}" }}


### PR DESCRIPTION
Issue N/A

Allow leaderElection role to be bound to a custom `ServiceAccount` name, similarily to the main cluster role.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
