### PR TITLE
bump up `github.com/aws-controllers-k8s/pkg` to `v0.0.6`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.19
 
 require (
-	github.com/aws-controllers-k8s/pkg v0.0.4
+	github.com/aws-controllers-k8s/pkg v0.0.6
 	github.com/aws-controllers-k8s/runtime v0.27.1
 	github.com/aws/aws-sdk-go v1.44.93
 	github.com/dlclark/regexp2 v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.4 h1:fQX18NZZG6eVKdG3WWp/oE7QJgFe7Dz/Ublu+ua4PW8=
 github.com/aws-controllers-k8s/pkg v0.0.4/go.mod h1:LC/9DlYrXu8FWNwLquZLq1WhcyRo7qXb7upRLAEosQk=
+github.com/aws-controllers-k8s/pkg v0.0.6/go.mod h1:CFqOn8ioKf/WAUMR1cFV2Nj1egY9Wvk532e657Nsoa8=
 github.com/aws-controllers-k8s/runtime v0.27.1 h1:tvJRQDioBFkob0kF4DwgS7MsoXZKwkG5QCHWxFEh+2o=
 github.com/aws-controllers-k8s/runtime v0.27.1/go.mod h1:oSCqCzbzJLUrzv+cx4TIxCuSUvL75ABJmhxBc87IRqc=
 github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/pkg v0.0.4 h1:fQX18NZZG6eVKdG3WWp/oE7QJgFe7Dz/Ublu+ua4PW8=
-github.com/aws-controllers-k8s/pkg v0.0.4/go.mod h1:LC/9DlYrXu8FWNwLquZLq1WhcyRo7qXb7upRLAEosQk=
+github.com/aws-controllers-k8s/pkg v0.0.6 h1:wnNqattbNQyzJK7HJ25oYwiogC4ydeEsjKuWFHXrvoo=
 github.com/aws-controllers-k8s/pkg v0.0.6/go.mod h1:CFqOn8ioKf/WAUMR1cFV2Nj1egY9Wvk532e657Nsoa8=
 github.com/aws-controllers-k8s/runtime v0.27.1 h1:tvJRQDioBFkob0kF4DwgS7MsoXZKwkG5QCHWxFEh+2o=
 github.com/aws-controllers-k8s/runtime v0.27.1/go.mod h1:oSCqCzbzJLUrzv+cx4TIxCuSUvL75ABJmhxBc87IRqc=


### PR DESCRIPTION
bump up `github.com/aws-controllers-k8s/pkg` to `v0.0.6`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
