### PR TITLE
Fixing compatibility between aws.credentials and deployment.extraVolumes

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
             readOnly: true
         {{- end }}
         {{- if .Values.deployment.extraVolumeMounts -}}
-          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
+          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 10 }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -151,11 +151,11 @@ spec:
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       volumes:
-      {{- if .Values.aws.credentials.secretName -}}
+      {{- if .Values.aws.credentials.secretName }}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}
-      {{ end -}}
+      {{- end }}
 {{- if .Values.deployment.extraVolumes }}
 {{ toYaml .Values.deployment.extraVolumes | indent 8}}
 {{- end }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

`{{ toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}`
was not aligned with the one created above

`{{- if .Values.aws.credentials.secretName -}}`
removed some indent on the next line when `.Values.aws.credentials.secretName` existed

`{{ end -}}`
let an empty line

Using 
```
aws:
  credentials:
    secretName: "aws-creds"
    secretKey: "credentials-file"
    profile: "default"
  region: "us-east-1"

deployment:
  extraVolumes:
    - name: test-volume
      secret:
        secretName: test-secret
  extraVolumeMounts:
    - name: test-volume-mount
      mountPath: /root/
  extraEnvVars: 
    - name: SOMEVAR
      value: somevalue
    - name: PASSWORD
      valueFrom:
        secretKeyRef:
          name: mysecret
          key: password
          optional: false
```
as a values file I get:
```
# Source: iam-chart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ack-iam-controller-iam-chart
  namespace: ack-iam-system
  labels:
    app.kubernetes.io/name: iam-chart
    app.kubernetes.io/instance: ack-iam-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "1.2.6"
    k8s-app: iam-chart
    helm.sh/chart: iam-chart-1.2.6
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: iam-chart
      app.kubernetes.io/instance: ack-iam-controller
  template:
    metadata:
      labels:
        app.kubernetes.io/name: iam-chart
        app.kubernetes.io/instance: ack-iam-controller
        app.kubernetes.io/managed-by: Helm
        k8s-app: iam-chart
    spec:
      serviceAccountName: ack-iam-controller
      containers:
      - command:
        - ./bin/controller
        args:
        - --aws-region
        - "$(AWS_REGION)"
        - --aws-endpoint-url
        - "$(AWS_ENDPOINT_URL)"
        - --log-level
        - "$(ACK_LOG_LEVEL)"
        - --resource-tags
        - "$(ACK_RESOURCE_TAGS)"
        - --watch-namespace
        - "$(ACK_WATCH_NAMESPACE)"
        - --deletion-policy
        - "$(DELETION_POLICY)"
        - --reconcile-default-resync-seconds
        - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
        image: public.ecr.aws/aws-controllers-k8s/iam-controller:1.2.6
        imagePullPolicy: IfNotPresent
        name: controller
        ports:
          - name: http
            containerPort: 8080
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
        env:
        - name: ACK_SYSTEM_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: AWS_REGION
          value: us-east-1
        - name: AWS_ENDPOINT_URL
          value: ""
        - name: ACK_WATCH_NAMESPACE
          value:
        - name: DELETION_POLICY
          value: delete
        - name: LEADER_ELECTION_NAMESPACE
          value: ""
        - name: ACK_LOG_LEVEL
          value: "info"
        - name: ACK_RESOURCE_TAGS
          value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
        - name: RECONCILE_DEFAULT_RESYNC_SECONDS
          value: "36000"
        - name: AWS_SHARED_CREDENTIALS_FILE
          value: /var/run/secrets/aws/credentials-file
        - name: AWS_PROFILE
          value: default
        - name: SOMEVAR
          value: somevalue
        - name: PASSWORD
          valueFrom:
            secretKeyRef:
              key: password
              name: mysecret
              optional: false
        volumeMounts:
          - name: aws-creds
            mountPath: /var/run/secrets/aws
            readOnly: true
          - mountPath: /root/
            name: test-volume-mount
        securityContext:
          allowPrivilegeEscalation: false
          privileged: false
          runAsNonRoot: true
          capabilities:
            drop:
              - ALL
      securityContext:
        seccompProfile:
          type: RuntimeDefault
      terminationGracePeriodSeconds: 10
      nodeSelector:
        kubernetes.io/os: linux
      hostIPC: false
      hostPID: false
      hostNetwork: false
      dnsPolicy: ClusterFirst
      volumes:
        - name: aws-creds
          secret:
            secretName: aws-creds
        - name: test-volume
          secret:
            secretName: test-secret
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
