### PR TITLE
Fix Helm template for AWS credentials secretName

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       volumes:
-      {{- if .Values.aws.credentials.secretName -}}
+      {{- if .Values.aws.credentials.secretName }}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}


### PR DESCRIPTION
Issue #, if available: [#1913](https://github.com/aws-controllers-k8s/community/issues/1913)

Description of changes:
This PR addresses an issue with the Helm template that generates improper YAML when AWS credentials are provided.

Removed the hyphen `-` in the conditional check for `.Values.aws.credentials.secretName` in the Helm template.

The original template had `{{- if .Values.aws.credentials.secretName -}}`, where the trailing hyphen after the if statement was causing whitespace control issues. This led to improper YAML indentation being generated when `.Values.aws.credentials.secretName` was provided.

The corrected template uses `{{- if .Values.aws.credentials.secretName }}` without the trailing hyphen after the conditional, ensuring that the YAML is generated correctly with the right indentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
