### PR TITLE
Adding functionality to assign one API to multiple resources

### DIFF
--- a/pkg/config/operation.go
+++ b/pkg/config/operation.go
@@ -40,7 +40,7 @@ type OperationConfig struct {
 	OutputWrapperFieldPath string `json:"output_wrapper_field_path,omitempty"`
 	// Override for resource name in case of heuristic failure
 	// An example of this is correcting stutter when the resource logic doesn't properly determine the resource name
-	ResourceName string `json:"resource_name"`
+	ResourceName StringArray `json:"resource_name"`
 	// Override for operation type in case of heuristic failure
 	// An example of this is `Put...` or `Register...` API operations not being correctly classified as `Create` op type
 	// OperationType []string `json:"operation_type"`
@@ -59,8 +59,8 @@ func (c *Config) OperationIsIgnored(operation *awssdkmodel.Operation) bool {
 	return util.InStrings(operation.ExportedName, c.Ignore.Operations)
 }
 
-// UnmarshalJSON parses input for a either a string or
-// or a list and returns a StringArray.
+// UnmarshalJSON parses input for either a string or
+// a list and returns a StringArray.
 func (a *StringArray) UnmarshalJSON(b []byte) error {
 	var multi []string
 	err := json.Unmarshal(b, &multi)


### PR DESCRIPTION
Fixes [#1917](https://github.com/aws-controllers-k8s/community/issues/1917)

**Description:**
The PR adds functionality to use same API for an operation on multiple resources. This allows `ResourceName` to be a list so that same API for an `OperationType` can map to multiple resources. This is required in certain cases where the same API, for same operation is used for multiple resources.

The solution this PR applies is to pass multiple resources for same API.

This supports following cases cases:

1. One API -> One Resource
```
PublishVersion:
    operation_type:
      - Create
    resource_name: 
      - Version
```

2. One API -> Multiple Resource
```
DeleteFunction:
    operation_type:
      - Delete
    resource_name:
      - Function
      - Version
```      
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
