### PR TITLE
Enhance resource comparison for collections and blobs

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -190,7 +190,7 @@ func CompareResource(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				fieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		case "list":
 			// Returns Go code that compares all the elements of the slice fields...

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -163,29 +163,22 @@ func CompareResource(
 		memberShapeRef := specField.ShapeRef
 		memberShape := memberShapeRef.Shape
 
-		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
-		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
-		// }
-		nilCode := compareNil(
+		// Use len, bytes.Equal and HasNilDifference to fast compare types, and
+		// try to avoid deep comparison as much as possible.
+		fastComparisonOutput, needToCloseBlock := fastCompareTypes(
 			compareConfig,
 			memberShape,
 			deltaVarName,
+			fieldPath,
 			firstResAdaptedVarName,
 			secondResAdaptedVarName,
-			fieldPath,
 			indentLevel,
 		)
-
-		if nilCode != "" {
-			// else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
-			out += fmt.Sprintf(
-				"%s else if %s != nil && %s != nil {\n",
-				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
-			)
-			indentLevel++
-		}
+		out += fastComparisonOutput
 
 		switch memberShape.Type {
+		case "blob":
+			// We already handled the case of blobs above, so we can skip it here.
 		case "structure":
 			// Recurse through all the struct's fields and subfields, building
 			// nested conditionals and calls to `delta.Add()`...
@@ -209,7 +202,7 @@ func CompareResource(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				fieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		case "map":
 			// Returns Go code that compares all the elements of the map fields...
@@ -221,7 +214,7 @@ func CompareResource(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				fieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		default:
 			//   if *a.ko.Spec.Name != *b.ko.Spec.Name) {
@@ -234,15 +227,14 @@ func CompareResource(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				fieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		}
-		if nilCode != "" {
+		if needToCloseBlock {
 			// }
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)
-			indentLevel--
 		}
 	}
 	return out
@@ -285,12 +277,8 @@ func compareNil(
 	indent := strings.Repeat("\t", indentLevel)
 
 	switch shape.Type {
-	case "list", "blob":
-		// for slice types, there is no nilability test. Instead, the normal
-		// value test checks length of slices.
-		return ""
 	case "boolean", "string", "character", "byte", "short", "integer", "long",
-		"float", "double", "timestamp", "structure", "map", "jsonvalue":
+		"float", "double", "timestamp", "structure", "jsonvalue":
 		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		out += fmt.Sprintf(
 			"%sif ackcompare.HasNilDifference(%s, %s) {\n",
@@ -353,11 +341,6 @@ func compareScalar(
 		// if *a.ko.Spec.Name != *b.ko.Spec.Name {
 		out += fmt.Sprintf(
 			"%sif *%s != *%s {\n",
-			indent, firstResVarName, secondResVarName,
-		)
-	case "blob":
-		out += fmt.Sprintf(
-			"%sif !bytes.Equal(%s, %s) {\n",
 			indent, firstResVarName, secondResVarName,
 		)
 	case "timestamp":
@@ -650,29 +633,20 @@ func CompareStruct(
 			continue
 		}
 
-		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name == nil) {
-		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
-		// }
-		nilCode := compareNil(
+		fastComparisonOutput, needToCloseBlock := fastCompareTypes(
 			compareConfig,
 			memberShape,
 			deltaVarName,
+			memberFieldPath,
 			firstResAdaptedVarName,
 			secondResAdaptedVarName,
-			memberFieldPath,
 			indentLevel,
 		)
-
-		if nilCode != "" {
-			// else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
-			out += fmt.Sprintf(
-				"%s else if %s != nil && %s != nil {\n",
-				nilCode, firstResAdaptedVarName, secondResAdaptedVarName,
-			)
-			indentLevel++
-		}
+		out += fastComparisonOutput
 
 		switch memberShape.Type {
+		case "blob":
+			// We already handled the case of blobs above, so we can skip it here.
 		case "structure":
 			// Recurse through all the struct's fields and subfields, building
 			// nested conditionals and calls to `delta.Add()`...
@@ -684,7 +658,7 @@ func CompareStruct(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				memberFieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		case "list":
 			// Returns Go code that compares all the elements of the slice fields...
@@ -696,7 +670,7 @@ func CompareStruct(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				memberFieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		case "map":
 			// Returns Go code that compares all the elements of the map fields...
@@ -708,7 +682,7 @@ func CompareStruct(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				memberFieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		default:
 			//   if *a.ko.Spec.Name != *b.ko.Spec.Name {
@@ -721,16 +695,169 @@ func CompareStruct(
 				firstResAdaptedVarName,
 				secondResAdaptedVarName,
 				memberFieldPath,
-				indentLevel,
+				indentLevel+1,
 			)
 		}
-		if nilCode != "" {
+		if needToCloseBlock {
 			// }
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)
-			indentLevel--
 		}
 	}
 	return out
+}
+
+// fastCompareTypes outputs Go code that fast-compares two objects of the same
+// type, by leveraging nil check comparison and length checks. This is used
+// when we want to quickly determine if two objects are different, but don't
+// need to know the specific differences. For example, when determining if a
+// that an array of structs has changed, we don't need to know which structs
+// have changed, if the size of the array has changed.
+//
+// Generally, we can distinguish between the following cases:
+// 1. Both objects are structures or scalars type pointers.
+// 2. Both objects are collections (slices or  maps).
+// 3. Both objects are blobs.
+//
+// In the case of 1, we can use the HasNilDifference function to
+// eliminate early on the case where one of the objects is nil and other
+// is not.
+//
+// In the case of 2, we can use the built-in len function to eliminate
+// early on the case where the collections have different lengths.
+// The trick here is that len(nil) is 0, so we don't need to check for
+// nils explicitly.
+//
+// In the case of 3, we can use the bytes.Equal function to compare the
+// byte arrays. bytes.Equal works well with nil arrays too.
+// Output code will look something like this:
+//
+//	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+//	  delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+//	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+//	  if *a.ko.Spec.Name != *b.ko.Spec.Name) {
+//	    delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+//	  }
+//	}
+//
+//	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+//	  delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+//	} else if len(a.ko.Spec.Tags) > 0 {
+//	  if !ackcompare.SliceStringPEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+//	    delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+//	  }
+//	}
+func fastCompareTypes(
+	// struct informing code generator how to compare the field values.
+	compareConfig *ackgenconfig.CompareFieldConfig,
+	// AWSSDK Shape describing the type of the field being compared.
+	memberShape *awssdkmodel.Shape,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the json path of the field being compared, e.g.
+	// "Spec.Name".
+	fieldPath string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like "a.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like "b.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, bool) {
+	out := ""
+	needToCloseBlock := false
+	indent := strings.Repeat("\t", indentLevel)
+
+	switch memberShape.Type {
+	case "list", "map":
+		// Note once we eliminate the case of non equal sizes, we can
+		// safely assume that the objects have the same length and we can
+		// we can only iterate over them if they have more than 0 elements.
+		//
+		// if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		//   delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		// } else len(a.ko.Spec.Tags) > 0 {
+		//    ...
+		// }
+		out += fmt.Sprintf(
+			"%sif len(%s) != len(%s) {\n",
+			indent,
+			firstResVarName,
+			secondResVarName,
+		)
+		out += fmt.Sprintf(
+			"%s\t%s.Add(\"%s\", %s, %s)\n",
+			indent,
+			deltaVarName,
+			fieldPath,
+			firstResVarName,
+			secondResVarName,
+		)
+		// For sure we are inside the else block of the nil/size check, so we need
+		// to increase the indentation level.
+		out += fmt.Sprintf(
+			"%s} else if len(%s) > 0 {\n",
+			indent,
+			firstResVarName,
+		)
+		// For sure we are inside the else block of the nil/size check, so we need
+		// to increase the indentation level and ask the caller to close the block.
+		needToCloseBlock = true
+	case "blob":
+		// Blob is a special case because we need to compare the byte arrays
+		// using the bytes.Equal function.
+		//
+		// if !bytes.Equal(a.ko.Spec.Certificate, b.ko.Spec.Certificate) {
+		//   delta.Add("Spec.Certificate", a.ko.Spec.Certificate, b.ko.Spec.Certificate)
+		// }
+		out += fmt.Sprintf(
+			"%sif !bytes.Equal(%s, %s) {\n",
+			indent,
+			firstResVarName,
+			secondResVarName,
+		)
+		out += fmt.Sprintf(
+			"%s\t%s.Add(\"%s\", %s, %s)\n",
+			indent,
+			deltaVarName,
+			fieldPath,
+			firstResVarName,
+			secondResVarName,
+		)
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
+	default:
+		// For any other type, we can use the HasNilDifference function to
+		// eliminate early on the case where one of the objects is nil and
+		// other is not.
+		out += compareNil(
+			compareConfig,
+			memberShape,
+			deltaVarName,
+			firstResVarName,
+			secondResVarName,
+			fieldPath,
+			indentLevel,
+		)
+
+		// if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		// } else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		out += fmt.Sprintf(
+			" else if %s != nil && %s != nil {\n",
+			firstResVarName, secondResVarName,
+		)
+		// For sure we are inside the else block of the nil/size check, so we need
+		// to increase the indentation level and ask the caller to close the block.
+		needToCloseBlock = true
+	}
+	return out, needToCloseBlock
 }

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -94,8 +94,12 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 					delta.Add("Spec.Logging.LoggingEnabled.TargetBucket", a.ko.Spec.Logging.LoggingEnabled.TargetBucket, b.ko.Spec.Logging.LoggingEnabled.TargetBucket)
 				}
 			}
-			if !reflect.DeepEqual(a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants) {
+			if len(a.ko.Spec.Logging.LoggingEnabled.TargetGrants) != len(b.ko.Spec.Logging.LoggingEnabled.TargetGrants) {
 				delta.Add("Spec.Logging.LoggingEnabled.TargetGrants", a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants)
+			} else if len(a.ko.Spec.Logging.LoggingEnabled.TargetGrants) > 0 {
+				if !reflect.DeepEqual(a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants) {
+					delta.Add("Spec.Logging.LoggingEnabled.TargetGrants", a.ko.Spec.Logging.LoggingEnabled.TargetGrants, b.ko.Spec.Logging.LoggingEnabled.TargetGrants)
+				}
 			}
 			if ackcompare.HasNilDifference(a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix) {
 				delta.Add("Spec.Logging.LoggingEnabled.TargetPrefix", a.ko.Spec.Logging.LoggingEnabled.TargetPrefix, b.ko.Spec.Logging.LoggingEnabled.TargetPrefix)
@@ -149,8 +153,12 @@ func TestCompareResource_Lambda_CodeSigningConfig(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
 		delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
 	} else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
+		if len(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) != len(b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
 			delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
+		} else if len(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) > 0 {
+			if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
+				delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
+			}
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CodeSigningPolicies, b.ko.Spec.CodeSigningPolicies) {
@@ -253,16 +261,20 @@ func TestCompareResource_Lambda_Function(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.Environment, b.ko.Spec.Environment) {
 		delta.Add("Spec.Environment", a.ko.Spec.Environment, b.ko.Spec.Environment)
 	} else if a.ko.Spec.Environment != nil && b.ko.Spec.Environment != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.Environment.Variables, b.ko.Spec.Environment.Variables) {
+		if len(a.ko.Spec.Environment.Variables) != len(b.ko.Spec.Environment.Variables) {
 			delta.Add("Spec.Environment.Variables", a.ko.Spec.Environment.Variables, b.ko.Spec.Environment.Variables)
-		} else if a.ko.Spec.Environment.Variables != nil && b.ko.Spec.Environment.Variables != nil {
+		} else if len(a.ko.Spec.Environment.Variables) > 0 {
 			if !ackcompare.MapStringStringPEqual(a.ko.Spec.Environment.Variables, b.ko.Spec.Environment.Variables) {
 				delta.Add("Spec.Environment.Variables", a.ko.Spec.Environment.Variables, b.ko.Spec.Environment.Variables)
 			}
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.FileSystemConfigs, b.ko.Spec.FileSystemConfigs) {
+	if len(a.ko.Spec.FileSystemConfigs) != len(b.ko.Spec.FileSystemConfigs) {
 		delta.Add("Spec.FileSystemConfigs", a.ko.Spec.FileSystemConfigs, b.ko.Spec.FileSystemConfigs)
+	} else if len(a.ko.Spec.FileSystemConfigs) > 0 {
+		if !reflect.DeepEqual(a.ko.Spec.FileSystemConfigs, b.ko.Spec.FileSystemConfigs) {
+			delta.Add("Spec.FileSystemConfigs", a.ko.Spec.FileSystemConfigs, b.ko.Spec.FileSystemConfigs)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FunctionName, b.ko.Spec.FunctionName) {
 		delta.Add("Spec.FunctionName", a.ko.Spec.FunctionName, b.ko.Spec.FunctionName)
@@ -281,11 +293,19 @@ func TestCompareResource_Lambda_Function(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.ImageConfig, b.ko.Spec.ImageConfig) {
 		delta.Add("Spec.ImageConfig", a.ko.Spec.ImageConfig, b.ko.Spec.ImageConfig)
 	} else if a.ko.Spec.ImageConfig != nil && b.ko.Spec.ImageConfig != nil {
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.ImageConfig.Command, b.ko.Spec.ImageConfig.Command) {
+		if len(a.ko.Spec.ImageConfig.Command) != len(b.ko.Spec.ImageConfig.Command) {
 			delta.Add("Spec.ImageConfig.Command", a.ko.Spec.ImageConfig.Command, b.ko.Spec.ImageConfig.Command)
+		} else if len(a.ko.Spec.ImageConfig.Command) > 0 {
+			if !ackcompare.SliceStringPEqual(a.ko.Spec.ImageConfig.Command, b.ko.Spec.ImageConfig.Command) {
+				delta.Add("Spec.ImageConfig.Command", a.ko.Spec.ImageConfig.Command, b.ko.Spec.ImageConfig.Command)
+			}
 		}
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.ImageConfig.EntryPoint, b.ko.Spec.ImageConfig.EntryPoint) {
+		if len(a.ko.Spec.ImageConfig.EntryPoint) != len(b.ko.Spec.ImageConfig.EntryPoint) {
 			delta.Add("Spec.ImageConfig.EntryPoint", a.ko.Spec.ImageConfig.EntryPoint, b.ko.Spec.ImageConfig.EntryPoint)
+		} else if len(a.ko.Spec.ImageConfig.EntryPoint) > 0 {
+			if !ackcompare.SliceStringPEqual(a.ko.Spec.ImageConfig.EntryPoint, b.ko.Spec.ImageConfig.EntryPoint) {
+				delta.Add("Spec.ImageConfig.EntryPoint", a.ko.Spec.ImageConfig.EntryPoint, b.ko.Spec.ImageConfig.EntryPoint)
+			}
 		}
 		if ackcompare.HasNilDifference(a.ko.Spec.ImageConfig.WorkingDirectory, b.ko.Spec.ImageConfig.WorkingDirectory) {
 			delta.Add("Spec.ImageConfig.WorkingDirectory", a.ko.Spec.ImageConfig.WorkingDirectory, b.ko.Spec.ImageConfig.WorkingDirectory)
@@ -302,8 +322,12 @@ func TestCompareResource_Lambda_Function(t *testing.T) {
 			delta.Add("Spec.KMSKeyARN", a.ko.Spec.KMSKeyARN, b.ko.Spec.KMSKeyARN)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.Layers, b.ko.Spec.Layers) {
+	if len(a.ko.Spec.Layers) != len(b.ko.Spec.Layers) {
 		delta.Add("Spec.Layers", a.ko.Spec.Layers, b.ko.Spec.Layers)
+	} else if len(a.ko.Spec.Layers) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.Layers, b.ko.Spec.Layers) {
+			delta.Add("Spec.Layers", a.ko.Spec.Layers, b.ko.Spec.Layers)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MemorySize, b.ko.Spec.MemorySize) {
 		delta.Add("Spec.MemorySize", a.ko.Spec.MemorySize, b.ko.Spec.MemorySize)
@@ -364,11 +388,19 @@ func TestCompareResource_Lambda_Function(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCConfig, b.ko.Spec.VPCConfig) {
 		delta.Add("Spec.VPCConfig", a.ko.Spec.VPCConfig, b.ko.Spec.VPCConfig)
 	} else if a.ko.Spec.VPCConfig != nil && b.ko.Spec.VPCConfig != nil {
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCConfig.SecurityGroupIDs, b.ko.Spec.VPCConfig.SecurityGroupIDs) {
+		if len(a.ko.Spec.VPCConfig.SecurityGroupIDs) != len(b.ko.Spec.VPCConfig.SecurityGroupIDs) {
 			delta.Add("Spec.VPCConfig.SecurityGroupIDs", a.ko.Spec.VPCConfig.SecurityGroupIDs, b.ko.Spec.VPCConfig.SecurityGroupIDs)
+		} else if len(a.ko.Spec.VPCConfig.SecurityGroupIDs) > 0 {
+			if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCConfig.SecurityGroupIDs, b.ko.Spec.VPCConfig.SecurityGroupIDs) {
+				delta.Add("Spec.VPCConfig.SecurityGroupIDs", a.ko.Spec.VPCConfig.SecurityGroupIDs, b.ko.Spec.VPCConfig.SecurityGroupIDs)
+			}
 		}
-		if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCConfig.SubnetIDs, b.ko.Spec.VPCConfig.SubnetIDs) {
+		if len(a.ko.Spec.VPCConfig.SubnetIDs) != len(b.ko.Spec.VPCConfig.SubnetIDs) {
 			delta.Add("Spec.VPCConfig.SubnetIDs", a.ko.Spec.VPCConfig.SubnetIDs, b.ko.Spec.VPCConfig.SubnetIDs)
+		} else if len(a.ko.Spec.VPCConfig.SubnetIDs) > 0 {
+			if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCConfig.SubnetIDs, b.ko.Spec.VPCConfig.SubnetIDs) {
+				delta.Add("Spec.VPCConfig.SubnetIDs", a.ko.Spec.VPCConfig.SubnetIDs, b.ko.Spec.VPCConfig.SubnetIDs)
+			}
 		}
 	}
 `
@@ -404,8 +436,12 @@ func TestCompareResource_APIGatewayv2_Route(t *testing.T) {
 			delta.Add("Spec.APIKeyRequired", a.ko.Spec.APIKeyRequired, b.ko.Spec.APIKeyRequired)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes) {
+	if len(a.ko.Spec.AuthorizationScopes) != len(b.ko.Spec.AuthorizationScopes) {
 		delta.Add("Spec.AuthorizationScopes", a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes)
+	} else if len(a.ko.Spec.AuthorizationScopes) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes) {
+			delta.Add("Spec.AuthorizationScopes", a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.AuthorizationType, b.ko.Spec.AuthorizationType) {
 		delta.Add("Spec.AuthorizationType", a.ko.Spec.AuthorizationType, b.ko.Spec.AuthorizationType)
@@ -435,16 +471,16 @@ func TestCompareResource_APIGatewayv2_Route(t *testing.T) {
 			delta.Add("Spec.OperationName", a.ko.Spec.OperationName, b.ko.Spec.OperationName)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.RequestModels, b.ko.Spec.RequestModels) {
+	if len(a.ko.Spec.RequestModels) != len(b.ko.Spec.RequestModels) {
 		delta.Add("Spec.RequestModels", a.ko.Spec.RequestModels, b.ko.Spec.RequestModels)
-	} else if a.ko.Spec.RequestModels != nil && b.ko.Spec.RequestModels != nil {
+	} else if len(a.ko.Spec.RequestModels) > 0 {
 		if !ackcompare.MapStringStringPEqual(a.ko.Spec.RequestModels, b.ko.Spec.RequestModels) {
 			delta.Add("Spec.RequestModels", a.ko.Spec.RequestModels, b.ko.Spec.RequestModels)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.RequestParameters, b.ko.Spec.RequestParameters) {
+	if len(a.ko.Spec.RequestParameters) != len(b.ko.Spec.RequestParameters) {
 		delta.Add("Spec.RequestParameters", a.ko.Spec.RequestParameters, b.ko.Spec.RequestParameters)
-	} else if a.ko.Spec.RequestParameters != nil && b.ko.Spec.RequestParameters != nil {
+	} else if len(a.ko.Spec.RequestParameters) > 0 {
 		if !reflect.DeepEqual(a.ko.Spec.RequestParameters, b.ko.Spec.RequestParameters) {
 			delta.Add("Spec.RequestParameters", a.ko.Spec.RequestParameters, b.ko.Spec.RequestParameters)
 		}
@@ -490,14 +526,22 @@ func TestCompareResource_IAM_OIDC_URL(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "OpenIDConnectProvider")
 	require.NotNil(crd)
 	expected := `
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList) {
+	if len(a.ko.Spec.ClientIDList) != len(b.ko.Spec.ClientIDList) {
 		delta.Add("Spec.ClientIDList", a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList)
+	} else if len(a.ko.Spec.ClientIDList) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList) {
+			delta.Add("Spec.ClientIDList", a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList)
+		}
 	}
 	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList) {
+	if len(a.ko.Spec.ThumbprintList) != len(b.ko.Spec.ThumbprintList) {
 		delta.Add("Spec.ThumbprintList", a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList)
+	} else if len(a.ko.Spec.ThumbprintList) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList) {
+			delta.Add("Spec.ThumbprintList", a.ko.Spec.ThumbprintList, b.ko.Spec.ThumbprintList)
+		}
 	}
 `
 	assert.Equal(


### PR DESCRIPTION
This update enhances the logic for comparing resources in code
generation, especially for collections (maps and arrays) and blob
types. The previous method used nil checks, but they weren't
helpful for these types.

The revised code introduces a new function, `fastCompareTypes`,
to generate Go code that quickly compares two objects of the same
type. For collections, it uses the built-in `len` function to
swiftly spot length differences before diving into detailed checks.
For blobs, the code now employs the `bytes.Equal` function for
straightforward byte array comparisons.

This enhancement aims to make the generated comparison logic more
direct, readable, and efficient, especially when dealing with
collections and blobs in AWS SDK shapes.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
