### PR TITLE
Pin ACK runtime to `v0.28.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.7
-	github.com/aws-controllers-k8s/runtime v0.27.1
-	github.com/aws/aws-sdk-go v1.44.93
+	github.com/aws-controllers-k8s/runtime v0.28.0
+	github.com/aws/aws-sdk-go v1.49.0
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	// pin to v0.1.1 due to release problem with v0.1.2
 	github.com/gertd/go-pluralize v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -79,10 +79,10 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.7 h1:Rz2Rk6mjDnJodl1QAdEn3Gb+OlirquMvDoNfgYCMh/M=
 github.com/aws-controllers-k8s/pkg v0.0.7/go.mod h1:CFqOn8ioKf/WAUMR1cFV2Nj1egY9Wvk532e657Nsoa8=
-github.com/aws-controllers-k8s/runtime v0.27.1 h1:tvJRQDioBFkob0kF4DwgS7MsoXZKwkG5QCHWxFEh+2o=
-github.com/aws-controllers-k8s/runtime v0.27.1/go.mod h1:oSCqCzbzJLUrzv+cx4TIxCuSUvL75ABJmhxBc87IRqc=
-github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=
-github.com/aws/aws-sdk-go v1.44.93/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws-controllers-k8s/runtime v0.28.0 h1:QhtZDwF4TId5rBW924FMMKWFb0PGTtclVj+Cyj3bRaI=
+github.com/aws-controllers-k8s/runtime v0.28.0/go.mod h1:OYbm782YcAQDN1M5k3lttI16FcLoiRqrIQL0DvU3+Lg=
+github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
+github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
- Pin ACK runtime to `v0.28.0`
- `go mod tidy`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
