### PR TITLE
Default `AWS_SDK_GO_VERSION` to the last used version for code-generation

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -138,7 +138,7 @@ mkdir -p "$config_output_dir/crd/common"
 cp -r "$RUNTIME_CRD_DIR"/crd/* "$config_output_dir/crd/common/"
 
 if [ -z "$AWS_SDK_GO_VERSION" ]; then
-    AWS_SDK_GO_VERSION=$(go list -m -f '{{ .Version }}' -modfile "$SERVICE_CONTROLLER_SOURCE_PATH/go.mod" github.com/aws/aws-sdk-go)
+    AWS_SDK_GO_VERSION=$(cat "$SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION/ack-generate-metadata.yaml" | yq ".aws_sdk_go_version" -r)
 fi
 
 # If there's a generator.yaml in the service's directory and the caller hasn't


### PR DESCRIPTION
Default the AWS_SDK_GO_VERSION to last used version for code-generation

Will revert once, we release ARM images for all the controllers.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
