### PR TITLE
Introducing a generator configuration for GoTag customization

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -405,6 +405,30 @@ type FieldConfig struct {
 	// TODO(jaypipes,crtbry): Figure out if we can roll the CustomShape stuff
 	// into this type override...
 	Type *string `json:"type,omitempty"`
+	// GoTag is used to override the default Go tag injected into the fields of
+	// a generated go structure. This is useful if we want to override the json
+	// tag name or add an omitempty directive to the tag. If not specified,
+	// the default json tag is used, i.e. json:"<fieldName>,omitempty"
+	//
+	// The main reason behind introducing this feature is that, our naming utility
+	// package appends an underscore suffix to the field name if it is colliding with
+	// a Golang keyword (switch, if, else etc...). This is needed to avoid violating
+	// the Go language spec, when defining package names, variable names, etc.
+	// This functionality resulted in injecting the underscore suffix to the json tag
+	// as well, e.g. json:"type_,omitempty". Which is not ideal because it weirdens
+	// the experience for the users of the generated CRDs.
+	//
+	// One could argue that we should just modify the `names`` package to return an
+	// extra field indicating whether the field name is a Go keyword or not, or even
+	// better, return the correct go tag dirrctly. The reason why we should avoid
+	// such a change is that it would modify the already existing/generated code, which
+	// would break the compatibility for the existing CRDs. Without introducing some
+	// sort of mutating webhook to handle field name change, this is not a viable.
+	// We decided to introduce this feature to, at least, allow us to override the
+	// go tag for any new resource or fields that we generate in the future.
+	//
+	// (See https://github.com/aws-controllers-k8s/pkg/blob/main/names/names.go)
+	GoTag *string `json:"go_tag,omitempty"`
 }
 
 // GetFieldConfigs returns all FieldConfigs for a given resource as a map.

--- a/pkg/testdata/models/apis/eks/0000-00-00/generator-with-gotag.yaml
+++ b/pkg/testdata/models/apis/eks/0000-00-00/generator-with-gotag.yaml
@@ -1,0 +1,7 @@
+resources:
+  Cluster:
+    fields:
+      Version:
+        go_tag: json:"myCustomVersionName,omitempty"
+      Status:
+        go_tag: json:"clusterState,omitempty" yaml:"some_extra_tags"

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -22,7 +22,7 @@ type {{ .CRD.Kind }}Spec struct {
 {{- if and ($field.IsRequired) (not $field.HasReference) -}}
     // +kubebuilder:validation:Required
 {{ end -}}
-    {{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }}{{- if or (not $field.IsRequired) ($field.HasReference) }},omitempty{{- end -}}"`
+    {{ $field.Names.Camel }} {{ $field.GoType }} {{ $field.GetGoTag }}
 {{- end }}
 }
 
@@ -44,7 +44,7 @@ type {{ .CRD.Kind }}Status struct {
 	{{ $field.GetDocumentation }}
 	{{- end }}
 	// +kubebuilder:validation:Optional
-	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
+	{{ $field.Names.Camel }} {{ $field.GoType }} {{ $field.GetGoTag }}
 {{- end }}
 }
 


### PR DESCRIPTION
This patch introduces a new configuration, `go_tag`, to allow ACK
developers to customize the "Go tags" in the generated structures.
With this configuration users can easily override the default Go tags,
making adjustements like changing the tag name, adding omitempty
directives or even introducing new ones (yaml, gorm, protobuf etc).

This change helps ACK users overcome the challenge imposed by our names
utility package (`aws-controllers-k8s/pkg/names/`) which adds an
underscore suffix to field names that matches Golang keywords. Resulting
in an odd UX when consuming the generated ACK  CRDs (e.g using
`type_: <...>` instead of `type: <...>`)

We purposefully avoided directly modifying the `names` utility package
(trimming the underscores when generating the go tags) as it will break
compatibility with the already existing CRDs (yep we missed this).
Without some sort of mutating webhooks that will handle field renames,
we'll avoid going that route, and instead start using `go_tag` configs
for future CRDs/fields.

This patch will help in tweaking the generated code for
https://github.com/aws-controllers-k8s/eks-controller/pull/84

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
