### PR TITLE
Extend GoTag configuration to nested fields and attributes

### DIFF
--- a/pkg/model/attr.go
+++ b/pkg/model/attr.go
@@ -14,6 +14,8 @@
 package model
 
 import (
+	"fmt"
+
 	"github.com/aws-controllers-k8s/pkg/names"
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 )
@@ -22,6 +24,7 @@ type Attr struct {
 	Names  names.Names
 	GoType string
 	Shape  *awssdkmodel.Shape
+	GoTag  string
 }
 
 func NewAttr(
@@ -34,4 +37,14 @@ func NewAttr(
 		GoType: goType,
 		Shape:  shape,
 	}
+}
+
+// GetGoTag returns the Go Tag to inject for this attribute. If the GoTag
+// field is not empty, it will be used. Otherwise, one will be generated
+// from the attribute's name.
+func (a *Attr) GetGoTag() string {
+	if a.GoTag != "" {
+		return a.GoTag
+	}
+	return fmt.Sprintf("`json:\"%s,omitempty\"`", a.Names.CamelLower)
 }

--- a/templates/apis/type_def.go.tpl
+++ b/templates/apis/type_def.go.tpl
@@ -7,7 +7,7 @@ type {{ .Names.Camel }} struct {
 	{{- if $attr.Shape.Documentation }}
 	{{ $attr.Shape.Documentation }}
 	{{- end }}
-	{{ $attr.Names.Camel }} {{ $attr.GoType }} `json:"{{ $attr.Names.CamelLower }},omitempty"`
+	{{ $attr.Names.Camel }} {{ $attr.GoType }} {{ $attr.GetGoTag }}
 {{- end }}
 }
 {{- end -}}


### PR DESCRIPTION
Building upon the introduced `GoTag` configuration in https://github.com/aws-controllers-k8s/code-generator/commit/3753ca3f6610172e9e652d6e5e62e0a05f2e639c, this
commit expands the functionality to cover nested fields and attributes.
Now users will be able to set custom Go Tags for nested fields using
JSONPath style directives. e.g:

```yaml
resources:
  AccessEntries:
    fields:
      AccessPolicies.AccessScope.Type:
        go_tag: json:"type,omitempty"
```

This patch also refactors `updateTypeDefAttributeWithReference` function
to reuse the code for finding and mutating Attribute objects.

Tested with eks-controller (`AccessPolicies.AccessScope.Type`).

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
