### PR TITLE
Remove redundant new lines in `sdk.go` and `role-writer` templates

### DIFF
--- a/templates/helm/templates/role-writer.yaml.tpl
+++ b/templates/helm/templates/role-writer.yaml.tpl
@@ -11,7 +11,7 @@ rules:
   resources:
 {{- range $crdName := .CRDNames }}
   - {{ $crdName }}
-{{ end }}
+{{- end }}
   verbs:
   - create
   - delete

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -145,7 +145,7 @@ func (rm *resourceManager) sdkDelete(
 		exit(err)
 	}()
 
-{{ if .CRD.CustomDeleteMethodName }}
+{{- if .CRD.CustomDeleteMethodName }}
 	{{- template "sdk_delete_custom" . }}
 {{- else if .CRD.Ops.Delete }}
 {{- if $hookCode := Hook .CRD "sdk_delete_pre_build_request" }}


### PR DESCRIPTION
Remove redundant new lines in `sdk.go` and `role-writer.yaml` templates

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
