### PR TITLE
Improve nested fields path and type resolution

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -581,7 +581,20 @@ func getAttributeFromPath(crd *CRD, fieldPath string, tdefs []*TypeDef) (parentT
 
 	var parentFieldTypeDef *TypeDef
 	for _, td := range tdefs {
-		if strings.EqualFold(td.Names.Original, parentFieldTypeDefName) {
+
+		fallbackName := ""
+		switch parentFieldShapeRef.Shape.Type {
+		case "list":
+			// e.g FunctionAssociationsList in CloudFront DistributionConfig.DefaultCacheBehavior.FunctionAssociations
+			fallbackName = parentFieldShapeRef.Shape.MemberRef.ShapeName
+			fallbackName = strings.TrimSuffix(fallbackName, "List")
+		default:
+			// NOTE(a-hilaly): Very likely that we will need to add more cases here
+			// as we encounter more special APIs in the future.
+		}
+
+		if strings.EqualFold(td.Names.Original, parentFieldTypeDefName) ||
+			(fallbackName != "" && strings.EqualFold(td.Names.Original, fallbackName)) {
 			parentFieldTypeDef = td
 			break
 		}


### PR DESCRIPTION
This commit improves the `getAttributeFromPath` function by introducing
a better field path and type resolution mechanism. Now, it considers
aadditional fallback naming conventions, particularly for cases
involving lists.

This is needed to generate type references for `Distribution` resource
in ACK CloudFront controller. More specifically, the CF API Schema for
the `Distribution` resource is naming the `FunctionAssociations` shape
`FunctionAssociationsList`.

Tested with cloudfront-controller using the following config:
```yaml
resources:
  Distribution:
    fields:
      DistributionConfig.DefaultCacheBehavior.FunctionAssociations.Items.FunctionARN:
        references:
          resource: Function
          path: Status.ACKResourceMetadata.ARN
```

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
