### PR TITLE
Safely assign resources to the sdk opType maps

### DIFF
--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -111,6 +111,11 @@ func (a *SDKAPI) GetOperationMap(cfg *ackgenconfig.Config) *OperationMap {
 		for _, operationType := range opCfg.OperationType {
 			opType := OpTypeFromString(operationType)
 			for _, resName := range opCfg.ResourceName {
+				resMap, ok := opMap[opType]
+				if !ok {
+					resMap = map[string]*awssdkmodel.Operation{}
+					opMap[opType] = resMap
+				}
 				opMap[opType][resName] = op
 			}
 		}


### PR DESCRIPTION
While trying to re-generate controllers, we observed this rare error
where the code-generator tries to assign a key/value into a nil map.
Which is an illegal assignement... This should be handled now.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
