### PR TITLE
Experimental configurations to override controller names

### DIFF
--- a/cmd/ack-generate/command/common.go
+++ b/cmd/ack-generate/command/common.go
@@ -99,7 +99,6 @@ func getLatestAPIVersion(apiVersions []ackmetadata.ServiceVersion) (string, erro
 
 // getServiceAccountName gets the service account name from the optional flag passed into ack-generate
 func getServiceAccountName() (string, error) {
-
 	if optServiceAccountName != "" {
 		return optServiceAccountName, nil
 	}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -127,7 +127,7 @@ func FallBackFindServiceID(sdkDir, svcAlias string) (string, error) {
 			defer f.Close()
 			scanner := bufio.NewScanner(f)
 			for scanner.Scan() {
-				if strings.Contains(scanner.Text(), "serviceId") {
+				if strings.Contains(scanner.Text(), "serviceId") && !strings.Contains(scanner.Text(), "serviceIdentifier") {
 					getServiceID := strings.Split(scanner.Text(), ":")
 					re := regexp.MustCompile(`[," \t]`)
 					svcID := strings.ToLower(re.ReplaceAllString(getServiceID[1], ``))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,14 @@ type Config struct {
 	// only the service model name, but also the iface name to `PipesAPI`. See
 	// https://github.com/aws/aws-sdk-go/blob/main/service/pipes/pipesiface/interface.go#L62
 	SDKNames SDKNames `json:"sdk_names"`
+	// ControllerName lets you specify a service alias override. This can be
+	// used to only override the controller name exposed to the user. Meaning that
+	// it will only change the module name, the import paths, and the controller
+	// name. This is useful when the service identifier is not very user friendly
+	// and you want to expose a more user friendly name to the user. e.g docdb ->
+	// documentdb.
+	// This will also change the helm chart and image names.
+	ControllerName string `json:"controller_name,omitempty"`
 }
 
 // SDKNames contains information on the SDK Client package. More precisely
@@ -56,6 +64,14 @@ type SDKNames struct {
 	// model name is `opensearch` and the service package is called
 	// `opensearchservice`.
 	Model string `json:"model_name,omitempty"`
+	// Package let you define the package name of the service client. This field
+	// is optional and only needed for services such as documentdb where the service
+	// controller is called `documentdb` and the package is called `docdb`.
+	//
+	// You might be wondering why not just use the `model_name` field... well the
+	// answer is prometheusservice... the model name is `amp` and the service package
+	// is called `prometheusservice`. :shrug:
+	Package string `json:"package_name,omitempty"`
 	// ClientInterface is the name of the interface that defines the "shape" of
 	// the a sdk service client. e.g PipesAPI, LambdaAPI, etc...
 	ClientInterface string `json:"client_interface,omitempty"`

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -100,7 +100,7 @@ func Release(
 		templateBasePaths,
 		releaseIncludePaths,
 		releaseCopyPaths,
-		releaseFuncMap(m.MetaVars().ServicePackageName),
+		releaseFuncMap(m.MetaVars().ControllerName),
 	)
 	metaVars := m.MetaVars()
 

--- a/pkg/generate/templateset/vars.go
+++ b/pkg/generate/templateset/vars.go
@@ -16,6 +16,10 @@ package templateset
 // MetaVars contains template variables that most templates need access to
 // that describe the service alias, its package name, etc
 type MetaVars struct {
+	// ControllerName contains the exact string used to identify the ACK
+	// controller in the aws-controllers-k8s project. This name is used as the
+	// name of the ACK controller's module, repository and helm chart.
+	ControllerName string
 	// ServiceModelName contains the exact string used to identify the AWS
 	// service API in the aws-sdk-go's models/apis/ directory. Note that some
 	// APIs this name does not match the ServiceID. e.g. The AWS Step Functions

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -25,6 +25,7 @@ import (
 If these referenced types are not added to scheme, this service controller will not be able to read
 resources across service controller. */ -}}
 {{- $servicePackageName := .ServicePackageName }}
+{{- $controllerName := .ControllerName }}
 {{- $apiVersion := .APIVersion }}
 {{- range $referencedServiceName := .ReferencedServiceNames }}
 {{- if not (eq $referencedServiceName $servicePackageName) }}
@@ -32,19 +33,19 @@ resources across service controller. */ -}}
 {{- end }}
 {{- end }}
 
-	svcresource "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/pkg/resource"
+	svcresource "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/pkg/resource"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
-	svctypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+	svctypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
 
 	{{/* TODO(a-hilaly): import apis/* packages to register webhooks */}}
-	{{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $servicePackageName }}-controller/pkg/resource/{{ $crdName }}"
+	{{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws-controllers-k8s/{{ $controllerName }}-controller/pkg/resource/{{ $crdName }}"
 	{{end}}
-	"github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/pkg/version"
+	"github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/pkg/version"
 )
 
 var (
 	awsServiceAPIGroup      = "{{ .APIGroup }}"
-	awsServiceAlias	        = "{{ .ServicePackageName }}"
+	awsServiceAlias	        = "{{ .ControllerName }}"
 	awsServiceEndpointsID   = svcsdk.EndpointsID
 	scheme			        = runtime.NewScheme()
 	setupLog		        = ctrlrt.Log.WithName("setup")

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -6,20 +6,20 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
   namespace: ack-system
   labels:
-    app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
+    app.kubernetes.io/name: ack-{{ .ControllerName }}-controller
     app.kubernetes.io/part-of: ack-system
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
+      app.kubernetes.io/name: ack-{{ .ControllerName }}-controller
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
+        app.kubernetes.io/name: ack-{{ .ControllerName }}-controller
     spec:
       containers:
       - command:

--- a/templates/config/controller/olm-kustomization.yaml.tpl
+++ b/templates/config/controller/olm-kustomization.yaml.tpl
@@ -15,6 +15,6 @@ patches:
   target:
     group: apps
     kind: Deployment
-    name: ack-{{ .ServicePackageName }}-controller
+    name: ack-{{ .ControllerName }}-controller
     version: v1
 - path: user-env.yaml

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ack-{{ .ServicePackageName }}-metrics-service
+  name: ack-{{ .ControllerName }}-metrics-service
   namespace: ack-system
 spec:
   selector:
-    app.kubernetes.io/name: ack-{{ .ServicePackageName }}-controller
+    app.kubernetes.io/name: ack-{{ .ControllerName }}-controller
   ports:
     - name: metricsport
       port: 8080

--- a/templates/config/controller/user-env.yaml.tpl
+++ b/templates/config/controller/user-env.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ack-{{.ServicePackageName}}-controller
+  name: ack-{{.ControllerName}}-controller
   namespace: {{.Annotations.SuggestedNamespace}}
 spec:
   template:
@@ -10,8 +10,8 @@ spec:
       - name: controller
         envFrom:
           - configMapRef:
-              name: ack-{{.ServicePackageName}}-user-config
+              name: ack-{{.ControllerName}}-user-config
               optional: false
           - secretRef:
-              name: ack-{{.ServicePackageName}}-user-secrets
+              name: ack-{{.ControllerName}}-user-secrets
               optional: true

--- a/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
+++ b/templates/config/manifests/bases/clusterserviceversion.yaml.tpl
@@ -16,7 +16,7 @@ metadata:
     operatorframework.io/os.linux: supported
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: ack-{{.ServicePackageName }}-controller.v0.0.0
+  name: ack-{{.ControllerName }}-controller.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -27,7 +27,7 @@ spec:
       name: {{ ToLower .Plural }}.{{$.APIGroup}}
       version: {{$.APIVersion}}
       displayName: {{.Kind}}
-      description: {{.Kind}} represents the state of an AWS {{$.ServicePackageName}} {{.Kind}} resource.
+      description: {{.Kind}} represents the state of an AWS {{$.ControllerName}} {{.Kind}} resource.
     {{- end}}
   description: '{{ .Description }}'
   displayName: {{ .DisplayName}}
@@ -46,7 +46,7 @@ spec:
     type: {{ .Type }}
   {{- end}}
   keywords:
-  - {{.ServicePackageName}}
+  - {{.ControllerName}}
   {{- range .Common.Keywords}}
   - {{ . }}
   {{- end}}

--- a/templates/config/overlays/namespaced/kustomization.yaml.tpl
+++ b/templates/config/overlays/namespaced/kustomization.yaml.tpl
@@ -6,10 +6,10 @@ patches:
     group: rbac.authorization.k8s.io
     version: v1
     kind: ClusterRole
-    name: ack-{{ .ServicePackageName }}-controller
+    name: ack-{{ .ControllerName }}-controller
 - path: role-binding.json
   target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: ClusterRoleBinding
-    name: ack-{{ .ServicePackageName }}-controller-rolebinding
+    name: ack-{{ .ControllerName }}-controller-rolebinding

--- a/templates/config/rbac/cluster-role-binding.yaml.tpl
+++ b/templates/config/rbac/cluster-role-binding.yaml.tpl
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-{{ .ServicePackageName }}-controller-rolebinding
+  name: ack-{{ .ControllerName }}-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
 subjects:
 - kind: ServiceAccount
   name: {{ .ServiceAccountName }}

--- a/templates/config/rbac/leader-election-role-binding.yaml.tpl
+++ b/templates/config/rbac/leader-election-role-binding.yaml.tpl
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: ack-system
-  name: {{.ServicePackageName}}-leader-election-rolebinding
+  name: {{.ControllerName}}-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{.ServicePackageName}}-leader-election-role
+  name: {{.ControllerName}}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{.ServiceAccountName}}

--- a/templates/config/rbac/leader-election-role.yaml.tpl
+++ b/templates/config/rbac/leader-election-role.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{.ServicePackageName}}-leader-election-role
+  name: {{.ControllerName}}-leader-election-role
   namespace: ack-system
 rules:
 - apiGroups:

--- a/templates/config/rbac/role-reader.yaml.tpl
+++ b/templates/config/rbac/role-reader.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServicePackageName }}-reader
+  name: ack-{{ .ControllerName }}-reader
   namespace: default
 rules:
 - apiGroups:

--- a/templates/config/rbac/role-writer.yaml.tpl
+++ b/templates/config/rbac/role-writer.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServicePackageName }}-writer
+  name: ack-{{ .ControllerName }}-writer
   namespace: default
 rules:
 - apiGroups:

--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,18 +1,18 @@
 apiVersion: v1
-name: {{ .ServicePackageName }}-chart
+name: {{ .ControllerName }}-chart
 description: A Helm chart for the ACK service controller for {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}
-home: https://github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller
+home: https://github.com/aws-controllers-k8s/{{ .ControllerName }}-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
-  - https://github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller
+  - https://github.com/aws-controllers-k8s/{{ .ControllerName }}-controller
 maintainers:
   - name: ACK Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
   - name: {{ .Metadata.Service.ShortName }} Admins
-    url: https://github.com/orgs/aws-controllers-k8s/teams/{{ .ServicePackageName }}-maintainer
+    url: https://github.com/orgs/aws-controllers-k8s/teams/{{ .ControllerName }}-maintainer
 keywords:
   - aws
   - kubernetes
-  - {{ .ServicePackageName }}
+  - {{ .ControllerName }}

--- a/templates/helm/templates/caches-role-binding.yaml.tpl
+++ b/templates/helm/templates/caches-role-binding.yaml.tpl
@@ -1,26 +1,26 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-namespaces-cache-{{ .ServicePackageName }}-controller
+  name: ack-namespaces-cache-{{ .ControllerName }}-controller
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: ack-namespaces-cache-{{ .ServicePackageName }}-controller
+  name: ack-namespaces-cache-{{ .ControllerName }}-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
   namespace: {{ "{{ .Release.Namespace }}" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ack-configmaps-cache-{{ .ServicePackageName }}-controller
+  name: ack-configmaps-cache-{{ .ControllerName }}-controller
   namespace: {{ "{{ .Release.Namespace }}" }}
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: ack-configmaps-cache-{{ .ServicePackageName }}-controller
+  name: ack-configmaps-cache-{{ .ControllerName }}-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
   namespace: {{ "{{ .Release.Namespace }}" }}

--- a/templates/helm/templates/caches-role.yaml.tpl
+++ b/templates/helm/templates/caches-role.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ack-namespaces-cache-{{ .ServicePackageName }}-controller
+  name: ack-namespaces-cache-{{ .ControllerName }}-controller
 rules:
 - apiGroups:
   - ""
@@ -15,7 +15,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ack-configmaps-cache-{{ .ServicePackageName }}-controller
+  name: ack-configmaps-cache-{{ .ControllerName }}-controller
   namespace: {{ "{{ .Release.Namespace }}" }}
 rules:
 - apiGroups:

--- a/templates/helm/templates/cluster-role-binding.yaml.tpl
+++ b/templates/helm/templates/cluster-role-binding.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
 subjects:
 - kind: ServiceAccount
   name: {{ IncludeTemplate "service-account.name" }}
@@ -27,7 +27,7 @@ metadata:
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
 subjects:
 - kind: ServiceAccount
   name: {{ "{{ $serviceAccountName }}" }}

--- a/templates/helm/templates/cluster-role-controller.yaml.tpl
+++ b/templates/helm/templates/cluster-role-controller.yaml.tpl
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
   labels:
   {{ "{{- range $key, $value := $labels }}" }}
     {{ "{{ $key }}: {{ $value | quote }}" }}
@@ -18,7 +18,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ack-{{ .ServicePackageName }}-controller
+  name: ack-{{ .ControllerName }}-controller
   namespace: {{ "{{ . }}" }}
   labels:
   {{ "{{- range $key, $value := $labels }}" }}

--- a/templates/helm/templates/leader-election-role-binding.yaml.tpl
+++ b/templates/helm/templates/leader-election-role-binding.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{.ServicePackageName}}-leader-election-rolebinding
+  name: {{.ControllerName}}-leader-election-rolebinding
 {{ "{{ if .Values.leaderElection.namespace }}" }}
   namespace: {{ "{{ .Values.leaderElection.namespace }}" }}
 {{ "{{ else }}" }}
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{.ServicePackageName}}-leader-election-role
+  name: {{.ControllerName}}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ IncludeTemplate "service-account.name" }}

--- a/templates/helm/templates/leader-election-role.yaml.tpl
+++ b/templates/helm/templates/leader-election-role.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{.ServicePackageName}}-leader-election-role
+  name: {{.ControllerName}}-leader-election-role
 {{ "{{ if .Values.leaderElection.namespace }}" }}
   namespace: {{ "{{ .Values.leaderElection.namespace }}" }}
 {{ "{{ else }}" }}

--- a/templates/helm/templates/role-reader.yaml.tpl
+++ b/templates/helm/templates/role-reader.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServicePackageName }}-reader
+  name: ack-{{ .ControllerName }}-reader
   namespace: {{ "{{ .Release.Namespace }}" }}
 rules:
 - apiGroups:

--- a/templates/helm/templates/role-writer.yaml.tpl
+++ b/templates/helm/templates/role-writer.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-{{ .ServicePackageName }}-writer
+  name: ack-{{ .ControllerName }}-writer
   namespace: {{ "{{ .Release.Namespace }}" }}
 rules:
 - apiGroups:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -1,4 +1,4 @@
-# Default values for ack-{{ .ServicePackageName }}-controller.
+# Default values for ack-{{ .ControllerName }}-controller.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -11,7 +11,7 @@ import (
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
 )
 
 const (

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -25,7 +25,7 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .ServicePackageName }}/{{ .ServicePackageName }}iface"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
 )
 
 var (
@@ -180,7 +180,7 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:{{ .ServicePackageName }}:%s:%s:%s",
+		"arn:aws:{{ .ControllerName }}:%s:%s:%s",
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
 
-	svcresource "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/pkg/resource"
+	svcresource "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/pkg/resource"
 )
 
 // resourceManagerFactory produces resourceManager objects. It implements the

--- a/templates/pkg/resource/references.go.tpl
+++ b/templates/pkg/resource/references.go.tpl
@@ -27,7 +27,7 @@ import (
 {{- end }}
 {{- end }}
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
 )
 
 {{ if .CRD.HasReferenceFields -}}

--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion}}"
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion}}"
 )
 
 // Hack to avoid import errors during build...

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	svcapitypes "github.com/aws-controllers-k8s/{{.ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+	svcapitypes "github.com/aws-controllers-k8s/{{.ControllerName }}-controller/apis/{{ .APIVersion }}"
 )
 
 // Hack to avoid import errors during build...

--- a/templates/pkg/resource/tags.go.tpl
+++ b/templates/pkg/resource/tags.go.tpl
@@ -5,7 +5,7 @@ package {{ .CRD.Names.Snake }}
 import(
     acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 
-    svcapitypes "github.com/aws-controllers-k8s/{{ .ServicePackageName }}-controller/apis/{{ .APIVersion }}"
+    svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
 )
 
 var (


### PR DESCRIPTION
Since the early days of ACK, we've always relied on the `serviceID` to
name the controller repositories. The way names, go modules, import
paths, helm charts are named relied on this `serviceID`. Which was the
main reason why some controllers had a bit of odd names, like
`prometheusservice-controller` instead of `amp-controller`,
`acmpca-controller` instead of `pca-controller`. This patch introduces
experimental configurations that instructs the code generator to
override the serviceID/servicePackageName when it comes to import
paths/helm charts names etc...

Related issue: https://github.com/aws-controllers-k8s/community/issues/1411

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
