### PR TITLE
Adapt release generator to controller-gen 0.14.0 new format

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -255,7 +255,7 @@ controller-gen rbac:roleName="$K8S_RBAC_ROLE_NAME" paths=./... output:rbac:artif
 # this will leave us the rules section of the role.yaml file. We then append the rules section to the
 # _helpers-patch.yaml file which is a file that will be included in the _helpers.tpl file. This will
 # allow us to use the rules section in the _helpers.tpl file to generate the correct role/clusterrole.
-tail -n +7  "$helm_output_dir/templates/role.yaml" > "$helm_output_dir/templates/_helpers-patch.yaml"
+tail -n +6  "$helm_output_dir/templates/role.yaml" > "$helm_output_dir/templates/_helpers-patch.yaml"
 helpers_patch_path="$helm_output_dir/templates/_helpers-patch.yaml"
 
 # Some sed-fu to fill the "controller-role-rules" section. Urgh.


### PR DESCRIPTION
Since controller-tools v0.12.0 release - the `controller-gen` binary no
longer injects a null creation timestamp in the CRDs, RBACs and
webhooks. This slightly impacts our code generation process.

This patch fixes a bug that started triming the `rules` directive from
generated RBACs

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
