### PR TITLE
Default watchNamespace to release namespace

### DIFF
--- a/templates/helm/templates/cluster-role-binding.yaml.tpl
+++ b/templates/helm/templates/cluster-role-binding.yaml.tpl
@@ -11,8 +11,9 @@ subjects:
 - kind: ServiceAccount
   name: {{ "{{ include \"service-account.name\" . }}" }}
   namespace: {{ "{{ .Release.Namespace }}" }}
-{{ "{{ else if .Values.watchNamespace }}" }}
-{{ "{{ $namespaces := split \",\" .Values.watchNamespace }}" }}
+{{ "{{ else if eq .Values.installScope \"namespace\" }}" }}
+{{ "{{ $wn := include \"watch-namespace\" . }}" }}
+{{ "{{ $namespaces := split \",\" $wn }}" }}
 {{ "{{ $fullname := include \"app.fullname\" .  }}" }}
 {{ "{{ $releaseNamespace := .Release.Namespace }}" }}
 {{ "{{ $serviceAccountName := include \"service-account.name\" .  }}" }}

--- a/templates/helm/templates/cluster-role-controller.yaml.tpl
+++ b/templates/helm/templates/cluster-role-controller.yaml.tpl
@@ -10,8 +10,9 @@ metadata:
     {{ "{{ $key }}: {{ $value | quote }}" }}
   {{ "{{- end }}" }}
 {{ "{{- $rules }}" }}
-{{ "{{ else if .Values.watchNamespace }}" }}
-{{ "{{ $namespaces := split \",\" .Values.watchNamespace }}" }}
+{{ "{{ else if eq .Values.installScope \"namespace\" }}" }}
+{{ "{{ $wn := include \"watch-namespace\" . }}" }}
+{{ "{{ $namespaces := split \",\" $wn }}" }}
 {{ "{{ range $namespaces }}" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/2006

This patch default the `watchNamespace` to the release namespace if not
provided.

When a helm chart is installed users can set two parameters to define
the isntallation mode: `installScope`, `watchNamespace`. The latter is
only actionable when `installScope` is set to `namespace`. This patch
defaults the `watchNamespace` to the helm release namespace if the user
doesn't provide any.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
