### PR TITLE
update OLM's manifest/bases/csv generation to use `ControllerName`

### DIFF
--- a/pkg/generate/olm/olm.go
+++ b/pkg/generate/olm/olm.go
@@ -88,7 +88,7 @@ func BundleAssets(
 
 	csvBaseOutPath := fmt.Sprintf(
 		"config/manifests/bases/ack-%s-controller.clusterserviceversion.yaml",
-		m.MetaVars().ServicePackageName)
+		m.MetaVars().ControllerName)
 	if err := ts.Add(csvBaseOutPath, "config/manifests/bases/clusterserviceversion.yaml.tpl", olmVars); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #, if available:
- Relates: aws-controllers-k8s/community#2019

Description of changes:
Recently `ControllerName` was introduced to allow controllers to have a custom, more user friendly name. This change caused the `/config/manifest/bases/<SPN>.yaml` to be written to disk incorrectly for controllers that use the new `ControllerName` value. This change switches the `/config/manifest/bases/<CN>.yaml` to be written to disk so that OLM file/package generation can complete successfully and all of the proper values injected into the final `/bundle`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
