### PR TITLE
updating release script logic for olm flow to use cache director

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -290,6 +290,9 @@ if [[ $ACK_GENERATE_OLM == "true" ]]; then
     if [ -n "$ACK_DOCUMENTATION_CONFIG_PATH" ]; then
         ag_olm_args=("${ag_olm_args[@]}" --documentation-config-path "$ACK_DOCUMENTATION_CONFIG_PATH")
     fi
+    if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
+        ag_olm_args=("${ag_olm_args[@]}" --cache-dir "$ACK_GENERATE_CACHE_DIR")
+    fi
 
     $ACK_GENERATE_BIN_PATH olm "${ag_olm_args[@]}"
     "$SCRIPTS_DIR"/olm-create-bundle.sh "$SERVICE" "$RELEASE_VERSION"


### PR DESCRIPTION
Updating the logic in the OLM flow to use a the default cache directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
