### PR TITLE
Pin `github.com/aws-controllers-k8s/pkg` to v0.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.21
 
 require (
-	github.com/aws-controllers-k8s/pkg v0.0.9
+	github.com/aws-controllers-k8s/pkg v0.0.10
 	github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/pkg v0.0.9 h1:f3ejpb6VKnt5CS8F/0+7dGH691eox0xT9mQ2PW4ZrR4=
-github.com/aws-controllers-k8s/pkg v0.0.9/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
+github.com/aws-controllers-k8s/pkg v0.0.10 h1:16CIVKHVDxI+yG7zZ9vQ/FgDKm+0UDoe9EskPgfuTEA=
+github.com/aws-controllers-k8s/pkg v0.0.10/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
 github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb h1:Cdicq3reak7cXeuSYpJJEf8lyEHcE/ACnevC133vWGc=
 github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb/go.mod h1:6qr9ULkjOHo0fTwEUkE+48IxHqNbHxvvf/9JzGoR8pM=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=


### PR DESCRIPTION
Bringing `ACM` and `PCA` initialisms

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
