### PR TITLE
Pin ACK runtime to `v0.31.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.10
-	github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb
+	github.com/aws-controllers-k8s/runtime v0.31.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.10 h1:16CIVKHVDxI+yG7zZ9vQ/FgDKm+0UDoe9EskPgfuTEA=
 github.com/aws-controllers-k8s/pkg v0.0.10/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
-github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb h1:Cdicq3reak7cXeuSYpJJEf8lyEHcE/ACnevC133vWGc=
-github.com/aws-controllers-k8s/runtime v0.30.1-0.20240217174305-eb1315466efb/go.mod h1:6qr9ULkjOHo0fTwEUkE+48IxHqNbHxvvf/9JzGoR8pM=
+github.com/aws-controllers-k8s/runtime v0.31.0 h1:/N5u2x9jB1JD8tGYe6P2rihA/ratHc5b8Au0YRjneyo=
+github.com/aws-controllers-k8s/runtime v0.31.0/go.mod h1:6qr9ULkjOHo0fTwEUkE+48IxHqNbHxvvf/9JzGoR8pM=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Pin ACK runtime to v0.31.0. Mainly addressing two github issues:
- Healthz, liveness and readiness probes https://github.com/aws-controllers-k8s/community/issues/2012
- CARM Race condition and scaling issues https://github.com/aws-controllers-k8s/community/issues/2011

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
