### PR TITLE
Fixes Helm reference include reference

### DIFF
--- a/templates/helm/templates/_helpers.tpl.tpl
+++ b/templates/helm/templates/_helpers.tpl.tpl
@@ -44,7 +44,8 @@
 
 {{ "{{/* The path the shared credentials file is mounted */}}" }}
 {{ DefineTemplate "aws.credentials.path" }}
-{{ "{{- printf \"%s/%s\" (include \"aws.credentials.secret_mount_path\" .) .Values.aws.credentials.secretKey -}}" }}
+{{ VarIncludeTemplate "secret_mount_path" "aws.credentials.secret_mount_path" }}
+{{ "{{- printf \"%s/%s\" $secret_mount_path .Values.aws.credentials.secretKey -}}" }}
 {{ "{{- end -}}" }}
 
 {{ "{{/* The rules a of ClusterRole or Role */}}" }}


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/2029

Description of changes:
Fixed the reference by using `varIncludeTemplate`, so that the controller name is properly prefixed.

Generated ec2 controller code before:
```
{{/* The path the shared credentials file is mounted */}}
{{- define "ack-ec2-controller.aws.credentials.path" -}}
{{- printf "%s/%s" (include "aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
{{- end -}}
```
Which resulted in:
```
Error: template: ec2-chart/templates/deployment.yaml:112:20: executing "ec2-chart/templates/deployment.yaml" at <include "ack-ec2-controller.aws.credentials.path" .>: error calling include: template: ec2-chart/templates/_helpers.tpl:47:20: executing "ack-ec2-controller.aws.credentials.path" at <include "aws.credentials.secret_mount_path" .>: error calling include: template: no template "aws.credentials.secret_mount_path" associated with template "gotpl"
```

After:
```
{{/* The path the shared credentials file is mounted */}}
{{- define "ack-ec2-controller.aws.credentials.path" -}}
{{ $secret_mount_path := include "ack-ec2-controller.aws.credentials.secret_mount_path" . }}
{{- printf "%s/%s" $secret_mount_path .Values.aws.credentials.secretKey -}}
{{- end -}}
```
Now the template renders correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.