### PR TITLE
Expose concurrent reconcile configuration flags in helm chart values

### DIFF
--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -39,6 +39,8 @@ spec:
         - --enable-leader-election=$(ENABLE_LEADER_ELECTION)
         - --leader-election-namespace
         - "$(LEADER_ELECTION_NAMESPACE)"
+        - --reconcile-default-max-concurrent-syncs
+        - "$(RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS)"
         image: controller:latest
         name: controller
         ports:
@@ -72,6 +74,8 @@ spec:
           value: "false"
         - name: LEADER_ELECTION_NAMESPACE
           value: "ack-system"
+        - name: "RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS"
+          value: "1"
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -72,6 +72,14 @@ spec:
         - --reconcile-resource-resync-seconds
         - {{ "\"$(RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }})\"" }}
 {{ "{{- end }}" }}
+{{ "{{- if gt (int .Values.reconcile.defaultMaxConcurrentSyncs) 0 }}" }}
+        - --reconcile-default-max-concurrenct-syncs
+        - "$(RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS)"
+{{ "{{- end }}" }}
+{{ "{{- range $key, $value := .Values.reconcile.resourceMaxConcurrentSyncs }}" }}
+        - --reconcile-resource-max-concurrenct-syncs
+        - {{ "\"$(RECONCILE_RESOURCE_MAX_CONCURRENT_SYNCS_{{ $key | upper }})\"" }}
+{{ "{{- end }}" }}
         image: {{ "{{ .Values.image.repository }}:{{ .Values.image.tag }}" }}
         imagePullPolicy: {{ "{{ .Values.image.pullPolicy }}" }}
         name: controller
@@ -105,6 +113,14 @@ spec:
 {{ "{{- end }}" }}
 {{ "{{- range $key, $value := .Values.reconcile.resourceResyncPeriods }}" }}
         - name: {{ "RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }}" }}
+          value: {{ "{{ $key }}={{ $value }}" }}
+{{ "{{- end }}" }}
+{{ "{{- if gt (int .Values.reconcile.defaultMaxConcurrentSyncs) 0 }}" }}
+        - name: RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS
+          value: {{ "{{ .Values.reconcile.defaultMaxConcurrentSyncs | quote }}" }}
+{{ "{{- end }}" }}
+{{ "{{- range $key, $value := .Values.reconcile.resourceMaxConcurrentSyncs }}" }}
+        - name: {{ "RECONCILE_RESOURCE_MAX_CONCURRENT_SYNCS_{{ $key | upper }}" }}
           value: {{ "{{ $key }}={{ $value }}" }}
 {{ "{{- end }}" }}
         {{ "{{- if .Values.aws.credentials.secretName }}" }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -223,12 +223,18 @@
       "enum": ["delete", "retain"]
     },
     "reconcile": {
-      "description": "Reconcile resync settings. Parameters to tune the controller's drift remediation period.",
+      "description": "Reconcile settings. This is used to configure the controller's reconciliation behavior. e.g resyncPeriod and maxConcurrentSyncs",
       "properties": {
         "defaultResyncPeriod": {
           "type": "number"
         },
         "resourceResyncPeriods": {
+          "type": "object"
+        },
+        "defaultMaxConcurentSyncs": {
+          "type": "number"
+        },
+        "resourceMaxConcurrentSyncs": {
           "type": "object"
         }
       },

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -128,6 +128,12 @@ reconcile:
   # An object representing the reconcile resync configuration for each specific resource.
   resourceResyncPeriods: {}
 
+  # The default number of concurrent syncs that a reconciler can perform.
+  defaultMaxConcurrentSyncs: 1
+  # An object representing the reconcile max concurrent syncs configuration for each specific
+  # resource.
+  resourceMaxConcurrentSyncs: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
This patch adds configuration options for reconciler concurrency tuning
 (`reconcileDefaultMaxConcurrency` and `reconcileResourceMaxConcurrency`) 
in the Helm chart values, allowing users to customize reconciliation concurrency
for ACK service controllers deployed via Helm charts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
