### PR TITLE
Fix comparison type mismatch in deployment template

### DIFF
--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -64,7 +64,7 @@ spec:
         - --leader-election-namespace
         - "$(LEADER_ELECTION_NAMESPACE)"
 {{ "{{- end }}" }}
-{{ "{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}" }}
+{{ "{{- if gt (int .Values.reconcile.defaultResyncPeriod) 0 }}" }}
         - --reconcile-default-resync-seconds
         - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
 {{ "{{- end }}" }}
@@ -99,7 +99,7 @@ spec:
           value: {{ "{{ .Values.log.level | quote }}" }}
         - name: ACK_RESOURCE_TAGS
           value: {{ "{{ join \",\" .Values.resourceTags | quote }}" }}
-{{ "{{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}" }}
+{{ "{{- if gt (int .Values.reconcile.defaultResyncPeriod) 0 }}" }}
         - name: RECONCILE_DEFAULT_RESYNC_SECONDS
           value: {{ "{{ .Values.reconcile.defaultResyncPeriod | quote }}" }}
 {{ "{{- end }}" }}


### PR DESCRIPTION
This commit addresses the `incompatible types for comparison`
error ncountered during the deployment process (using helm).
The issue was caused by the incorrect comparison of a integer against a
float

This patch fixesd the issues describe above by casting the
`reconcile.defaultResyncPeriod` value to an integerer before performing
the comparison.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
