### PR TITLE
feat(fieldpath): Handle case differences in structure member names

### DIFF
--- a/pkg/fieldpath/path.go
+++ b/pkg/fieldpath/path.go
@@ -242,7 +242,17 @@ func memberShapeRef(
 	}
 	switch shapeRef.Shape.Type {
 	case "structure":
-		return shapeRef.Shape.MemberRefs[memberName]
+		// We are looking for a member of a structure. Since the ACK fields and
+		// the AWS SDK fields may have different casing (e.g AWSVPCConfiguration
+		// and AwsVpcConfiguration) we need to perform a case insensitive
+		// comparison to find the correct member reference.
+		for memberRefName, memberRefShape := range shapeRef.Shape.MemberRefs {
+			if strings.EqualFold(memberRefName, memberName) {
+				return memberRefShape
+			}
+		}
+		// If no matching member is found, return nil.
+		return nil
 	case "list":
 		return memberShapeRef(&shapeRef.Shape.MemberRef, memberName)
 	case "map":

--- a/pkg/fieldpath/path_test.go
+++ b/pkg/fieldpath/path_test.go
@@ -148,6 +148,12 @@ func TestShapeRef(t *testing.T) {
 						},
 					},
 				},
+				"WeirdlycasEdType": &awssdkmodel.ShapeRef{
+					ShapeName: "WeirdlycasEdType",
+					Shape: &awssdkmodel.Shape{
+						Type: "string",
+					},
+				},
 			},
 		},
 	}
@@ -220,4 +226,11 @@ func TestShapeRef(t *testing.T) {
 
 	// Calling ShapeRef should not modify the original Path
 	require.Equal("Author.Books.ChapterPageCounts.PageCount", p.String())
+
+	// Case-insensitive comparisons...
+	p = fieldpath.FromString("Author.WeirdlyCasedType")
+	ref = p.ShapeRef(authShapeRef)
+	require.NotNil(ref)
+	require.Equal("WeirdlycasEdType", ref.ShapeName)
+	require.Equal("string", ref.Shape.Type)
 }


### PR DESCRIPTION
This patch updates the `memberShapeRef` function in the `fieldpath`
package to handle case differences between struct member names in the
ACK model and the AWS SDK Model.

Previously, the function assumed that member names in the ACK model and
AWS SDK model were identical. However, this is not always the case, as
some field names may have different casing (e.g `AWSVPCConfiguration` in
the ACK model and `AwsVpcConfiguration` in the AWS SDK model).

To address this issue, the function now leverages `strings.EqualFold` to
compare the member names case isensitively.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
