### PR TITLE
Update base image to `eks-distro-minimal-base-nonroot:2024-04-01-1711929684.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Base image to use at runtime
-ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-09-06-1694026927.2
-
+ARG base_image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2024-04-01-1711929684.2
 
 # Golang image to use for compiling the manager
 ARG builder_image=public.ecr.aws/docker/library/golang


### PR DESCRIPTION
Dodging CVE scanners before it's late :)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
