### PR TITLE
fix: do not hard-code arch to amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG golang_version
 FROM $builder_image:$golang_version as builder
 
 ARG service_alias
-ARG target_arch=amd64
+ARG TARGETARCH
 # The tuple of controller image version information
 ARG service_controller_git_version
 ARG service_controller_git_commit
@@ -22,7 +22,7 @@ ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$target_arch
+ENV GOARCH=$TARGETARCH
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -15,14 +15,14 @@ ARG service_alias
 ARG service_controller_git_version
 ARG service_controller_git_commit
 ARG build_date
-ARG target_arch=amd64
+ARG TARGETARCH
 # The directory within the builder container into which we will copy our
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=on
-ENV GOARCH=$target_arch
+ENV GOARCH=$TARGETARCH
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Instead of hard-coding `GOARCH` to `amd64`, set it based on docker `TARGETARCH`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
