### PR TITLE
Update command for install ack-generate outside make

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -93,7 +93,7 @@ run:
  
 from the root directory or install ack-generate using:
 
-   go get -u -tags codegen github.com/aws-controllers-k8s/code-generator/cmd/ack-generate" 1>&2
+   go install -tags codegen github.com/aws-controllers-k8s/code-generator/cmd/ack-generate@latest" 1>&2
         exit 1;
     fi
 fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:

`go get` no longer installs go binaries, instead only updates the go.mod. `go install` replaces this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
