### PR TITLE
wrong chart name

### DIFF
--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: {{ .ControllerName }}-chart
+name: {{ .ControllerName }}-controller
 description: A Helm chart for the ACK service controller for {{ .Metadata.Service.FullName }} ({{ .Metadata.Service.ShortName }})
 version: {{ .ReleaseVersion }}
 appVersion: {{ .ReleaseVersion }}


### PR DESCRIPTION
### Issue 
the generator name creates a charge that is called for example "iam-controller" yet the chart name at `Chart.yaml` is iam-chart which is incorrent. 


### Description of changes
the suggested change is aligning this to to match the generated controller name correctly. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
