### PR TITLE
Add support for empty shapes, used as booleans in SDK

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	// Resources contains generator instructions for individual CRDs within an
 	// API
 	Resources map[string]ResourceConfig `json:"resources"`
+	// EmptyShapes contains fields associated with empty struct types
+	EmptyShapes []string `json:"empty_shapes,omitempty"`
 	// CRDs to ignore. ACK generator would skip these resources.
 	Ignore IgnoreSpec `json:"ignore"`
 	// Contains generator instructions for individual API operations.
@@ -149,6 +151,17 @@ func (c *Config) GetCustomMapFieldMembers() []string {
 	}
 
 	return members
+}
+
+// HasEmptyShape returns true if the given shape is setup as empty_shape in config,
+// otherwise returns false
+func (c *Config) HasEmptyShape(shapeName string) bool {
+	for _, emptyShape := range c.EmptyShapes {
+		if emptyShape == shapeName {
+			return true
+		}
+	}
+	return false
 }
 
 // New returns a new Config object given a supplied

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1388,8 +1388,13 @@ func varEmptyConstructorK8sType(
 
 	switch shape.Type {
 	case "structure":
-		// f0 := &svcapitypes.BookData{}
-		out += fmt.Sprintf("%s%s := &%s{}\n", indent, varName, goType)
+		if r.Config().HasEmptyShape(shape.ShapeName) {
+			// f0 := map[string]*string{}
+			out += fmt.Sprintf("%s%s := map[string]*string{}\n", indent, varName)
+		} else {
+			// f0 := &svcapitypes.BookData{}
+			out += fmt.Sprintf("%s%s := &%s{}\n", indent, varName, goType)
+		}
 	case "list", "map":
 		// f0 := []*string{}
 		out += fmt.Sprintf("%s%s := %s{}\n", indent, varName, goType)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -471,6 +471,12 @@ func (m *Model) getShapeCleanGoType(shape *awssdkmodel.Shape) string {
 		// otherwise there is no DeepCopy support
 		return "*metav1.Time"
 	case "structure":
+		if len(shape.MemberRefs) == 0 {
+			if m.cfg.HasEmptyShape(shape.ShapeName) {
+				return "map[string]*string"
+			}
+			panic(fmt.Sprintf("structure %s has no fields, either configure it as a `empty_shape` or manually set the field type", shape.ShapeName))
+		}
 		// There are shapes that are called things like DBProxyStatus that are
 		// fields in a DBProxy CRD... we need to ensure the type names don't
 		// conflict. Also, the name of the Go type in the generated code is


### PR DESCRIPTION
Issue #, if available: prerequisite for WAFv2 [RuleGroup](https://github.com/aws-controllers-k8s/wafv2-controller/pull/6) and [WebACL](https://github.com/aws-controllers-k8s/wafv2-controller/pull/7) CRDs

Description of changes:

Some WAFv2 API fields have empty json specs `{}`, e.g. https://docs.aws.amazon.com/waf/latest/APIReference/API_AllQueryArguments.html

For these type of fields, codegen currently errors out because it infers their gotypes as e.g. 
`AllQueryArguments *AllQueryArguments`

but does not generate a `type AllQueryArguments struct` since the struct itself is empty, and not picked up by `newFieldRecurse` function.

The solution proposed in this PR is to allow users to define `marker-shapes`, which instruct codegen to overwrite the type of these empty structs as `[]byte`, both when generating the APIs and when setting up the SDK. 

e.g. [generator.yaml](https://github.com/aws-controllers-k8s/wafv2-controller/blob/bb682409da8f96c5035783602b9d948c8cc8e21f/apis/v1alpha1/generator.yaml#L15-L24) for WAFv2, and inline:

```
empty_shapes:
- All
- Method
- UriPath
- QueryString
- AllQueryArguments
- RateLimitIP
- RateLimitForwardedIP
- RateLimitHTTPMethod
- NoneAction
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
