### PR TITLE
Fix logic that allows ignoring Resource and SDK setters

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -1301,6 +1301,20 @@ func SetResourceForStruct(
 	var sourceAdaptedVarName, qualifiedTargetVar string
 
 	for _, targetMemberName := range targetShape.MemberNames() {
+		// To check if the field member has `ignore` set to `true`.
+		// This condition currently applies only for members of a field whose shape is `structure`.
+		var setCfg *ackgenconfig.SetFieldConfig
+		f, ok := r.Fields[targetFieldPath]
+		if ok {
+			mf, ok := f.MemberFields[targetMemberName]
+			if ok {
+				setCfg = mf.GetSetterConfig(op)
+				if setCfg != nil && setCfg.IgnoreResourceSetter() {
+					continue
+				}
+			}
+		}
+
 		sourceMemberShapeRef = sourceShape.MemberRefs[targetMemberName]
 		if sourceMemberShapeRef == nil {
 			continue

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1108,7 +1108,7 @@ func SetSDKForStruct(
 		// To check if the field member has `ignore` set to `true`.
 		// This condition currently applies only for members of a field whose shape is `structure`
 		var setCfg *ackgenconfig.SetFieldConfig
-		f, ok := r.Fields[targetFieldName]
+		f, ok := r.Fields[sourceFieldPath]
 		if ok {
 			mf, ok := f.MemberFields[memberName]
 			if ok {
@@ -1117,7 +1117,6 @@ func SetSDKForStruct(
 					continue
 				}
 			}
-
 		}
 
 		fallBackName := r.GetMatchingInputShapeFieldName(op, targetFieldName)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- fix logic that allows ignoring SDK setters (i.e. `sdkCreate` and `sdkUpdate`) for nested fields. The field path map is currently queried using a wrong key i.e. the field name instead of field path.
- introduce logic that allows ignoring Resource setters (i.e. `sdkFind`). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
