### PR TITLE
Pin runtime to `v0.37.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.4
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.14
-	github.com/aws-controllers-k8s/runtime v0.37.0
+	github.com/aws-controllers-k8s/runtime v0.37.1
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	// pin to v0.1.1 due to release problem with v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.14 h1:6GDwy4SHvL6znO3qb9rDStTOLwUEYRlGsfLfv/p16ck=
 github.com/aws-controllers-k8s/pkg v0.0.14/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
-github.com/aws-controllers-k8s/runtime v0.37.0 h1:NobDzkYdSnHG44glFmOKJkT5nqbBTcTZH8UDmv/4T6w=
-github.com/aws-controllers-k8s/runtime v0.37.0/go.mod h1:gI2pWb20UGLP2SnHf1a1VzTd7iVVy+/I9VAzT0Y+Dew=
+github.com/aws-controllers-k8s/runtime v0.37.1 h1:OKSG3WnswkazWgUtSZh3RApU6OK3l01LklP1DjWgEFY=
+github.com/aws-controllers-k8s/runtime v0.37.1/go.mod h1:gI2pWb20UGLP2SnHf1a1VzTd7iVVy+/I9VAzT0Y+Dew=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -157,6 +157,5 @@ leaderElection:
 # Configuration for feature gates.  These are optional controller features that
 # can be individually enabled ("true") or disabled ("false") by adding key/value
 # pairs below.
-featureGates: {}
-  # featureGate1: true
-  # featureGate2: false
+featureGates:
+  CARMv2: false


### PR DESCRIPTION
- Add CARMv2 as a featureGate, disabled by default
- Pin runtime to v0.37.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
