### PR TITLE
Allow skipping state validations for resources that support cyclic references

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -354,6 +354,20 @@ type ReferencesConfig struct {
 	// Resource mentions the K8s resource which is read to resolve the
 	// reference
 	Resource string `json:"resource"`
+	// SkipResourceStateValidations if true, skips state validations performed during
+	// ResolveReferences step, that ensure the referenced resource exists in AWS and is synced.
+	// This is needed when multiple resources reference each other in a cyclic manner,
+	// as otherwise they will never sync due to circular ResourceReferenceNotSynced errors.
+	//
+	// see: https://github.com/aws-controllers-k8s/community/issues/2119
+	//
+	// N.B. when setting this field to true, the developer is responsible to amend the sdkCreate
+	// and/or sdkUpdate functions of the referencing resource, in order to correctly wait on the
+	// desired state of the referenced resource, before SDK API calls that require the latter.
+	// In the future, we could consider generating this logic, but for now this is a niche use case.
+	//
+	// see: https://github.com/aws-controllers-k8s/ec2-controller/blob/main/pkg/resource/security_group/sdk.go
+	SkipResourceStateValidations bool `json:"skip_resource_state_validations"`
 	// Path refers to the the path of field which should be copied
 	// to resolve the reference
 	Path string `json:"path"`

--- a/templates/pkg/resource/references_read_referenced_resource.go.tpl
+++ b/templates/pkg/resource/references_read_referenced_resource.go.tpl
@@ -28,12 +28,8 @@ func getReferencedResourceState_{{ .FieldConfig.References.Resource }}(
 	if err != nil {
 		return err
 	}
-	var refResourceSynced, refResourceTerminal bool
+	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
 		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
 			cond.Status == corev1.ConditionTrue {
 			return ackerr.ResourceReferenceTerminalFor(
@@ -46,6 +42,14 @@ func getReferencedResourceState_{{ .FieldConfig.References.Resource }}(
 			"{{ .FieldConfig.References.Resource }}",
 			namespace, name)
 	}
+{{if not .FieldConfig.References.SkipResourceStateValidations -}}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
 	if !refResourceSynced {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"{{ .FieldConfig.References.Resource }}",
@@ -57,6 +61,7 @@ func getReferencedResourceState_{{ .FieldConfig.References.Resource }}(
 			namespace, name,
 			"{{ .FieldConfig.References.Path }}")
 	}
+{{- end}}
 	return nil
 }
 {{- end -}}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2119

Description of changes:

Introducing a new field `config.Resources.Fields.References.SkipResourceStateValidations` , that, if set to true, skips state validations performed during `ResolveReferences` step, that ensure the referenced resource exists in AWS and is synced. This is needed when multiple resources reference each other in a cyclic manner, as otherwise they will never sync due to circular `ResourceReferenceNotSynced` errors.
 
N.B. when setting this field to true, the developer is responsible to amend the `sdkCreate` and/or `sdkUpdate` functions of the referencing resource, in order to correctly wait on the desired state of the referenced resource, before SDK API calls that require the latter. In the future, we could consider generating this logic, but for now this is a niche use case.

see (example will be available when this PR is merged): https://github.com/aws-controllers-k8s/ec2-controller/blob/main/pkg/resource/security_group/sdk.go 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
