### PR TITLE
Update CARM feature gates in Helm values template

### DIFF
--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -158,4 +158,7 @@ leaderElection:
 # can be individually enabled ("true") or disabled ("false") by adding key/value
 # pairs below.
 featureGates:
-  CARMv2: false
+  # Enables the Service level granularity for CARM. See https://github.com/aws-controllers-k8s/community/issues/2031
+  ServiceLevelCARM: false
+  # Enables the Team level granularity for CARM. See https://github.com/aws-controllers-k8s/community/issues/2031
+  TeamLevelCARM: false


### PR DESCRIPTION
This patchh updates the feature gates configuration in the Helm values
template:

- Removes the `CARMv2` feature gate
- Adds two new feature gates:
  - `ServiceLevelCARM`: Enables Service level granularity for CARM
  - `TeamLevelCARM`: Enables Team level granularity for CARM

Both new feature gates are set to `false` by default.

See https://github.com/aws-controllers-k8s/community/issues/2031 for more
information on these CARM granularity levels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
