### PR TITLE
use readOnlyRootFilesystem

### DIFF
--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -152,6 +152,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           capabilities:
             drop:


### PR DESCRIPTION
Issue #, if available:

https://github.com/aws-controllers-k8s/community/issues/2166

Description of changes:

Configure the generated helm chart to set a readOnlyRootFilesystem on pods for ACK controllers to improve the security posture.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
