### PR TITLE
Force controller-gen `v0.16.2` for all controller

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CONTROLLER_TOOLS_VERSION="v0.14.0"
+export CONTROLLER_TOOLS_VERSION="v0.16.2"
 export HELM_VERSION="v3.7"
 
 # setting the -x option if debugging is true


### PR DESCRIPTION
Looks like controller builds will start failing once we move to controller-runtime v0.19.0
Just trying to stay ahead of the dependencies here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
