### PR TITLE
Add conditional check before setting attributes in `SetSDKSetAttributes`

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -729,7 +729,13 @@ func SetSDKSetAttributes(
 					)
 				}
 			}
-			out += fmt.Sprintf("%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
+			out += fmt.Sprintf(
+				"%sif len(attrMap) > 0 {\n", indent,
+			)
+			out += fmt.Sprintf("\t%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
 			continue
 		}
 


### PR DESCRIPTION
Add a conditional check in `SetSDKSetAttributes` to only call `SetAttributes`
when the attribute map is not empty. This prevents API validation errors
that occur when setting an empty attribute map.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
