### PR TITLE
feat: rename finalizerString to FinalizerString

### DIFF
--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.{{ .APIGroup }}/{{ .CRD.Kind }}"
+	FinalizerString = "finalizers.{{ .APIGroup }}/{{ .CRD.Kind }}"
 )
 
 var (
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -105,7 +105,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -120,7 +120,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the


### PR DESCRIPTION
Issue #, if available: closes [#2201]( https://github.com/aws-controllers-k8s/community/issues/2201)

Description of changes: Rename finalizerString to FinalizerString to export the constant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
