### PR TITLE
Add hook code to `PopulareResourceFromAnnotation`

### DIFF
--- a/templates/pkg/resource/resource.go.tpl
+++ b/templates/pkg/resource/resource.go.tpl
@@ -85,7 +85,13 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation 
 // 
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+{{- if $hookCode := Hook .CRD "pre_populate_resource_from_annotation" }}
+{{ $hookCode }}
+{{- end }}
 {{- GoCodePopulateResourceFromAnnotation .CRD "fields" "r.ko" 1}}
+{{- if $hookCode := Hook .CRD "post_populate_resource_from_annotation" }}
+{{ $hookCode }}
+{{- end }}
 	return nil
 }
 


### PR DESCRIPTION
Description of changes:
This function is similar to the `SetIdentifiers` function. 
If any controller has a hook for `SetIdentifiers`, we need 
a similar one for `PopulateResourceFromAnnotation`

Hooks:
* `pre_populate_resource_from_annotation`
* `post_populate_resource_from_annotation`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
