### PR TITLE
fix documentation templating bug

### DIFF
--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -20,13 +20,13 @@ type {{ .CRD.Kind }}Spec struct {
     {{ $field.GetDocumentation }}
 {{ end -}}
 
-{{- if $field.IsImmutable }}
+{{- if $field.IsImmutable -}}
     // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
-{{- end }}
+{{ end -}}
 
-{{- if and ($field.IsRequired) (not $field.HasReference) }}
+{{- if and ($field.IsRequired) (not $field.HasReference) -}}
     // +kubebuilder:validation:Required
-{{- end }}
+{{ end -}}
 
     {{ $field.Names.Camel }} {{ $field.GoType }} {{ $field.GetGoTag }}
 {{- end }}


### PR DESCRIPTION
Description of changes:

This PR fixes a templating issue where multi-line documentation strings were being truncated due to template whitespace control markers. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
