### PR TITLE
Expand the search space for shapes in `from.operation`

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -176,6 +176,12 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 				memberShapeRef, found = m.SDKAPI.GetInputShapeRef(
 					from.Operation, from.Path,
 				)
+				// allowing getting spec fields from output shape
+				if !found {
+					memberShapeRef, found = m.SDKAPI.GetOutputShapeRef(
+						from.Operation, from.Path,
+					)
+				}
 				if !found {
 					// This is a compile-time failure, just bomb out...
 					msg := fmt.Sprintf(
@@ -289,6 +295,12 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 				memberShapeRef, found = m.SDKAPI.GetOutputShapeRef(
 					from.Operation, from.Path,
 				)
+				// allowing to get status fields from output shapes
+				if !found {
+					memberShapeRef, found = m.SDKAPI.GetInputShapeRef(
+						from.Operation, from.Path,
+					)
+				}
 				if !found {
 					// This is a compile-time failure, just bomb out...
 					msg := fmt.Sprintf(

--- a/pkg/model/model_route53_test.go
+++ b/pkg/model/model_route53_test.go
@@ -1,0 +1,86 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestRoute53_RecordSet(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "route53")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("RecordSet", crds)
+	require.NotNil(crd)
+
+	assert.Equal("RecordSet", crd.Names.Camel)
+	assert.Equal("recordSet", crd.Names.CamelLower)
+	assert.Equal("record_set", crd.Names.Snake)
+
+	// The Route53 API has CD as one operation +L:
+	//
+	// * ChangeResourceRecordSets
+	// * ChangeResourceRecordSets
+	// * ListResourceRecordSets
+	require.NotNil(crd.Ops)
+
+	assert.NotNil(crd.Ops.Create)
+	assert.NotNil(crd.Ops.ReadMany)
+	assert.NotNil(crd.Ops.Delete)
+
+	// But sadly, has no Update or ReadOne operation :(
+	// for update we still use ChangeResourceRecordSets
+	assert.Nil(crd.Ops.ReadOne)
+	assert.Nil(crd.Ops.Update)
+
+	specFields := crd.SpecFields
+	statusFields := crd.StatusFields
+
+	expSpecFieldCamel := []string{
+		"AliasTarget",
+		// "ChangeBatch", <= Testing that this is removed from spec
+		"CIDRRoutingConfig",
+		"Failover",
+		"GeoLocation",
+		"HealthCheckID",
+		"HostedZoneID",
+		"HostedZoneRef",
+		"MultiValueAnswer",
+		"Name",
+		"RecordType",
+		"Region",
+		"ResourceRecords",
+		"SetIdentifier",
+		"TTL",
+		"Weight",
+	}
+	assert.Equal(expSpecFieldCamel, attrCamelNames(specFields))
+
+	expStatusFieldCamel := []string{
+		"ID",
+		"Status",
+		"SubmittedAt",
+	}
+	assert.Equal(expStatusFieldCamel, attrCamelNames(statusFields))
+}

--- a/pkg/testdata/codegen/sdk-codegen/aws-models/route53.json
+++ b/pkg/testdata/codegen/sdk-codegen/aws-models/route53.json
@@ -1,0 +1,12582 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.route53#ARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "\\S"
+            }
+        },
+        "com.amazonaws.route53#AWSAccountID": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#AWSDnsV20130401": {
+            "type": "service",
+            "version": "2013-04-01",
+            "operations": [
+                {
+                    "target": "com.amazonaws.route53#ActivateKeySigningKey"
+                },
+                {
+                    "target": "com.amazonaws.route53#AssociateVPCWithHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#ChangeCidrCollection"
+                },
+                {
+                    "target": "com.amazonaws.route53#ChangeResourceRecordSets"
+                },
+                {
+                    "target": "com.amazonaws.route53#ChangeTagsForResource"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateCidrCollection"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateKeySigningKey"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateQueryLoggingConfig"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateReusableDelegationSet"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateTrafficPolicyInstance"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateTrafficPolicyVersion"
+                },
+                {
+                    "target": "com.amazonaws.route53#CreateVPCAssociationAuthorization"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeactivateKeySigningKey"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteCidrCollection"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteKeySigningKey"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteQueryLoggingConfig"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteReusableDelegationSet"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteTrafficPolicyInstance"
+                },
+                {
+                    "target": "com.amazonaws.route53#DeleteVPCAssociationAuthorization"
+                },
+                {
+                    "target": "com.amazonaws.route53#DisableHostedZoneDNSSEC"
+                },
+                {
+                    "target": "com.amazonaws.route53#DisassociateVPCFromHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#EnableHostedZoneDNSSEC"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetAccountLimit"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetChange"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetCheckerIpRanges"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetDNSSEC"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetGeoLocation"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHealthCheckCount"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHealthCheckLastFailureReason"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHealthCheckStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHostedZoneCount"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetHostedZoneLimit"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetQueryLoggingConfig"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetReusableDelegationSet"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetReusableDelegationSetLimit"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetTrafficPolicyInstance"
+                },
+                {
+                    "target": "com.amazonaws.route53#GetTrafficPolicyInstanceCount"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListCidrBlocks"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListCidrCollections"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListCidrLocations"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListGeoLocations"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListHealthChecks"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListHostedZones"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListHostedZonesByName"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListHostedZonesByVPC"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListQueryLoggingConfigs"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListResourceRecordSets"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListReusableDelegationSets"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTagsForResource"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTagsForResources"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTrafficPolicies"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTrafficPolicyInstances"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListTrafficPolicyVersions"
+                },
+                {
+                    "target": "com.amazonaws.route53#ListVPCAssociationAuthorizations"
+                },
+                {
+                    "target": "com.amazonaws.route53#TestDNSAnswer"
+                },
+                {
+                    "target": "com.amazonaws.route53#UpdateHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#UpdateHostedZoneComment"
+                },
+                {
+                    "target": "com.amazonaws.route53#UpdateTrafficPolicyComment"
+                },
+                {
+                    "target": "com.amazonaws.route53#UpdateTrafficPolicyInstance"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Route 53",
+                    "arnNamespace": "route53",
+                    "cloudFormationName": "Route53",
+                    "cloudTrailEventSource": "route53.amazonaws.com",
+                    "docId": "route53-2013-04-01",
+                    "endpointPrefix": "route53"
+                },
+                "aws.auth#sigv4": {
+                    "name": "route53"
+                },
+                "aws.protocols#restXml": {},
+                "smithy.api#documentation": "<p>Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web\n\t\t\tservice.</p>\n         <p>You can use Route 53 to:</p>\n         <ul>\n            <li>\n               <p>Register domain names.</p>\n               <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-domain-registration.html\">How domain registration works</a>.</p>\n            </li>\n            <li>\n               <p>Route internet traffic to the resources for your domain</p>\n               <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html\">How internet traffic is routed to your website or web application</a>.</p>\n            </li>\n            <li>\n               <p>Check the health of your resources.</p>\n               <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-health-checks.html\">How Route 53 checks the health of your resources</a>.</p>\n            </li>\n         </ul>",
+                "smithy.api#title": "Amazon Route 53",
+                "smithy.api#xmlNamespace": {
+                    "uri": "https://route53.amazonaws.com/doc/2013-04-01/"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseDualStack"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": {
+                                            "ref": "Endpoint"
+                                        },
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "aws.partition",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ],
+                                            "assign": "PartitionResult"
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.amazonaws.com",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-east-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53-fips.amazonaws.com",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-east-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-cn"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.amazonaws.com.cn",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "cn-northwest-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-us-gov"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.us-gov.amazonaws.com",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-gov-west-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-us-gov"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.us-gov.amazonaws.com",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-gov-west-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-iso"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.c2s.ic.gov",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-iso-east-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-iso-b"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.sc2s.sgov.gov",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-isob-east-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-iso-e"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.cloud.adc-e.uk",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "eu-isoe-west-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws-iso-f"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://route53.csp.hci.ic.gov",
+                                                "properties": {
+                                                    "authSchemes": [
+                                                        {
+                                                            "name": "sigv4",
+                                                            "signingName": "route53",
+                                                            "signingRegion": "us-isof-south-1"
+                                                        }
+                                                    ]
+                                                },
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://route53.{Region}.{PartitionResult#dnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-global",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-global with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53-fips.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-global",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53-fips.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-cn-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "cn-northwest-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-cn-global",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "cn-northwest-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-us-gov-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-us-gov-global",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-us-gov-global with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-us-gov-global",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-iso-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-iso-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-iso-global",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-iso-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-iso-b-global",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-isoe-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "eu-isoe-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.cloud.adc-e.uk"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-isoe-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isof-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-isof-south-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.csp.hci.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isof-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.route53#AWSRegion": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#AccountLimit": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#AccountLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit that you requested. Valid values include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>MAX_HEALTH_CHECKS_BY_OWNER</b>: The maximum\n\t\t\t\t\tnumber of health checks that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_HOSTED_ZONES_BY_OWNER</b>: The maximum number\n\t\t\t\t\tof hosted zones that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_REUSABLE_DELEGATION_SETS_BY_OWNER</b>: The\n\t\t\t\t\tmaximum number of reusable delegation sets that you can create using the current\n\t\t\t\t\taccount.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_TRAFFIC_POLICIES_BY_OWNER</b>: The maximum\n\t\t\t\t\tnumber of traffic policies that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER</b>: The\n\t\t\t\t\tmaximum number of traffic policy instances that you can create using the current\n\t\t\t\t\taccount. (Traffic policy instances are referred to as traffic flow policy\n\t\t\t\t\trecords in the Amazon Route 53 console.)</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.route53#LimitValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current value for the limit that is specified by <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_AccountLimit.html#Route53-Type-AccountLimit-Type\">Type</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the type of limit that you specified in the request and\n\t\t\tthe current value for that limit.</p>"
+            }
+        },
+        "com.amazonaws.route53#AccountLimitType": {
+            "type": "enum",
+            "members": {
+                "MAX_HEALTH_CHECKS_BY_OWNER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_HEALTH_CHECKS_BY_OWNER"
+                    }
+                },
+                "MAX_HOSTED_ZONES_BY_OWNER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_HOSTED_ZONES_BY_OWNER"
+                    }
+                },
+                "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER"
+                    }
+                },
+                "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER"
+                    }
+                },
+                "MAX_TRAFFIC_POLICIES_BY_OWNER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_TRAFFIC_POLICIES_BY_OWNER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#ActivateKeySigningKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ActivateKeySigningKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ActivateKeySigningKeyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKMSArn"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidSigningStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchKeySigningKey"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Activates a key-signing key (KSK) so that it can be used for signing by DNSSEC. This\n\t\t\toperation changes the KSK status to <code>ACTIVE</code>.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/keysigningkey/{HostedZoneId}/{Name}/activate",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ActivateKeySigningKeyRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#SigningKeyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to identify a key-signing key (KSK). <code>Name</code> can include\n\t\t\tnumbers, letters, and underscores (_). <code>Name</code> must be unique for each\n\t\t\tkey-signing key in the same hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ActivateKeySigningKeyResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#AlarmIdentifier": {
+            "type": "structure",
+            "members": {
+                "Region": {
+                    "target": "com.amazonaws.route53#CloudWatchRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the CloudWatch alarm that you want Route 53 health checkers to use to determine\n\t\t\twhether this health check is healthy, the region that the alarm was created in.</p>\n         <p>For the current list of CloudWatch regions, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/cw_region.html\">Amazon CloudWatch endpoints and\n\t\t\t\tquotas</a> in the <i>Amazon Web Services General\n\t\t\tReference</i>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#AlarmName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch alarm that you want Amazon Route 53 health checkers to use\n\t\t\tto determine whether this health check is healthy.</p>\n         <note>\n            <p>Route 53 supports CloudWatch alarms with the following features:</p>\n            <ul>\n               <li>\n                  <p>Standard-resolution metrics. High-resolution metrics aren't supported. For\n\t\t\t\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html#high-resolution-metrics\">High-Resolution Metrics</a> in the <i>Amazon CloudWatch User\n\t\t\t\t\t\t\tGuide</i>.</p>\n               </li>\n               <li>\n                  <p>Statistics: Average, Minimum, Maximum, Sum, and SampleCount. Extended\n\t\t\t\t\t\tstatistics aren't supported.</p>\n               </li>\n            </ul>\n         </note>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53\n\t\t\thealth checkers to use to determine whether the specified health check is\n\t\t\thealthy.</p>"
+            }
+        },
+        "com.amazonaws.route53#AlarmName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.route53#AliasHealthEnabled": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.route53#AliasTarget": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Alias resource records sets only</i>: The value used depends on where\n\t\t\tyou want to route traffic:</p>\n         <dl>\n            <dt>Amazon API Gateway custom regional APIs and edge-optimized APIs</dt>\n            <dd>\n               <p>Specify the hosted zone ID for your API. You can get the applicable value\n\t\t\t\t\t\tusing the CLI command <a href=\"https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-domain-names.html\">get-domain-names</a>:</p>\n               <ul>\n                  <li>\n                     <p>For regional APIs, specify the value of\n\t\t\t\t\t\t\t\t\t<code>regionalHostedZoneId</code>.</p>\n                  </li>\n                  <li>\n                     <p>For edge-optimized APIs, specify the value of\n\t\t\t\t\t\t\t\t\t<code>distributionHostedZoneId</code>.</p>\n                  </li>\n               </ul>\n            </dd>\n            <dt>Amazon Virtual Private Cloud interface VPC endpoint</dt>\n            <dd>\n               <p>Specify the hosted zone ID for your interface endpoint. You can get the\n\t\t\t\t\t\tvalue of <code>HostedZoneId</code> using the CLI command\n\t\t\t\t\t\t\t<a href=\"https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoints.html\">describe-vpc-endpoints</a>.</p>\n            </dd>\n            <dt>CloudFront distribution</dt>\n            <dd>\n               <p>Specify <code>Z2FDTNDATAQYW2</code>.</p>\n               <note>\n                  <p>Alias resource record sets for CloudFront can't be created in a\n\t\t\t\t\t\t\tprivate zone.</p>\n               </note>\n            </dd>\n            <dt>Elastic Beanstalk environment</dt>\n            <dd>\n               <p>Specify the hosted zone ID for the region that you created the environment in. The\n\t\t\t\t\t\tenvironment must have a regionalized subdomain. For a list of regions and\n\t\t\t\t\t\tthe corresponding hosted zone IDs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/elasticbeanstalk.html\">Elastic Beanstalk\n\t\t\t\t\t\t\tendpoints and quotas</a> in the <i>Amazon Web Services\n\t\t\t\t\t\t\tGeneral Reference</i>.</p>\n            </dd>\n            <dt>ELB load balancer</dt>\n            <dd>\n               <p>Specify the value of the hosted zone ID for the load balancer. Use the\n\t\t\t\t\t\tfollowing methods to get the hosted zone ID:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/general/latest/gr/elb.html\">Elastic Load Balancing endpoints and quotas</a> topic in\n\t\t\t\t\t\t\t\tthe <i>Amazon Web Services General Reference</i>: Use\n\t\t\t\t\t\t\t\tthe value that corresponds with the region that you created your\n\t\t\t\t\t\t\t\tload balancer in. Note that there are separate columns for\n\t\t\t\t\t\t\t\tApplication and Classic Load Balancers and for Network Load\n\t\t\t\t\t\t\t\tBalancers.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>Amazon Web Services Management Console</b>: Go to the\n\t\t\t\t\t\t\t\tAmazon EC2 page, choose <b>Load\n\t\t\t\t\t\t\t\t\tBalancers</b> in the navigation pane, select the load\n\t\t\t\t\t\t\t\tbalancer, and get the value of the <b>Hosted\n\t\t\t\t\t\t\t\t\tzone</b> field on the <b>Description</b> tab.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>Elastic Load Balancing API</b>: Use\n\t\t\t\t\t\t\t\t\t<code>DescribeLoadBalancers</code> to get the applicable value.\n\t\t\t\t\t\t\t\tFor more information, see the applicable guide:</p>\n                     <ul>\n                        <li>\n                           <p>Classic Load Balancers: Use <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> to get the value of\n\t\t\t\t\t\t\t\t\t\t\t<code>CanonicalHostedZoneNameId</code>.</p>\n                        </li>\n                        <li>\n                           <p>Application and Network Load Balancers: Use <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> to get the value of\n\t\t\t\t\t\t\t\t\t\t\t<code>CanonicalHostedZoneId</code>.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <b>CLI</b>: Use\n\t\t\t\t\t\t\t\t\t<code>describe-load-balancers</code> to get the applicable\n\t\t\t\t\t\t\t\tvalue. For more information, see the applicable guide:</p>\n                     <ul>\n                        <li>\n                           <p>Classic Load Balancers: Use <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html\">describe-load-balancers</a> to get the value of\n\t\t\t\t\t\t\t\t\t\t\t<code>CanonicalHostedZoneNameId</code>.</p>\n                        </li>\n                        <li>\n                           <p>Application and Network Load Balancers: Use <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elbv2/describe-load-balancers.html\">describe-load-balancers</a> to get the value of\n\t\t\t\t\t\t\t\t\t\t\t<code>CanonicalHostedZoneId</code>.</p>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </dd>\n            <dt>Global Accelerator accelerator</dt>\n            <dd>\n               <p>Specify <code>Z2BJ6XQ5FK7U4H</code>.</p>\n            </dd>\n            <dt>An Amazon S3 bucket configured as a static website</dt>\n            <dd>\n               <p>Specify the hosted zone ID for the region that you created the bucket in.\n\t\t\t\t\t\tFor more information about valid values, see the table <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints\">Amazon S3\n\t\t\t\t\t\t\tWebsite Endpoints</a> in the <i>Amazon Web Services General\n\t\t\t\t\t\t\tReference</i>.</p>\n            </dd>\n            <dt>Another Route 53 resource record set in your hosted zone</dt>\n            <dd>\n               <p>Specify the hosted zone ID of your hosted zone. (An alias resource record\n\t\t\t\t\t\tset can't reference a resource record set in a different hosted\n\t\t\t\t\t\tzone.)</p>\n            </dd>\n         </dl>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DNSName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Alias resource record sets only:</i> The value that you specify\n\t\t\tdepends on where you want to route queries:</p>\n         <dl>\n            <dt>Amazon API Gateway custom regional APIs and edge-optimized APIs</dt>\n            <dd>\n               <p>Specify the applicable domain name for your API. You can get the\n\t\t\t\t\t\tapplicable value using the CLI command <a href=\"https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-domain-names.html\">get-domain-names</a>:</p>\n               <ul>\n                  <li>\n                     <p>For regional APIs, specify the value of\n\t\t\t\t\t\t\t\t\t<code>regionalDomainName</code>.</p>\n                  </li>\n                  <li>\n                     <p>For edge-optimized APIs, specify the value of\n\t\t\t\t\t\t\t\t\t<code>distributionDomainName</code>. This is the name of the\n\t\t\t\t\t\t\t\tassociated CloudFront distribution, such as\n\t\t\t\t\t\t\t\t\t<code>da1b2c3d4e5.cloudfront.net</code>.</p>\n                  </li>\n               </ul>\n               <note>\n                  <p>The name of the record that you're creating must match a custom domain\n\t\t\t\t\t\t\tname for your API, such as <code>api.example.com</code>.</p>\n               </note>\n            </dd>\n            <dt>Amazon Virtual Private Cloud interface VPC endpoint</dt>\n            <dd>\n               <p>Enter the API endpoint for the interface endpoint, such as\n\t\t\t\t\t\t\t<code>vpce-123456789abcdef01-example-us-east-1a.elasticloadbalancing.us-east-1.vpce.amazonaws.com</code>.\n\t\t\t\t\t\tFor edge-optimized APIs, this is the domain name for the corresponding\n\t\t\t\t\t\tCloudFront distribution. You can get the value of <code>DnsName</code> using\n\t\t\t\t\t\tthe CLI command <a href=\"https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoints.html\">describe-vpc-endpoints</a>.</p>\n            </dd>\n            <dt>CloudFront distribution</dt>\n            <dd>\n               <p>Specify the domain name that CloudFront assigned when you created your\n\t\t\t\t\t\tdistribution.</p>\n               <p>Your CloudFront distribution must include an alternate domain name that\n\t\t\t\t\t\tmatches the name of the resource record set. For example, if the name of the\n\t\t\t\t\t\tresource record set is <i>acme.example.com</i>, your\n\t\t\t\t\t\tCloudFront distribution must include <i>acme.example.com</i>\n\t\t\t\t\t\tas one of the alternate domain names. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html\">Using Alternate\n\t\t\t\t\t\t\tDomain Names (CNAMEs)</a> in the <i>Amazon CloudFront\n\t\t\t\t\t\t\tDeveloper Guide</i>.</p>\n               <p>You can't create a resource record set in a private hosted zone to route\n\t\t\t\t\t\ttraffic to a CloudFront distribution.</p>\n               <note>\n                  <p>For failover alias records, you can't specify a CloudFront\n\t\t\t\t\t\t\tdistribution for both the primary and secondary records. A distribution\n\t\t\t\t\t\t\tmust include an alternate domain name that matches the name of the\n\t\t\t\t\t\t\trecord. However, the primary and secondary records have the same name,\n\t\t\t\t\t\t\tand you can't include the same alternate domain name in more than one\n\t\t\t\t\t\t\tdistribution. </p>\n               </note>\n            </dd>\n            <dt>Elastic Beanstalk environment</dt>\n            <dd>\n               <p>If the domain name for your Elastic Beanstalk environment includes the\n\t\t\t\t\t\tregion that you deployed the environment in, you can create an alias record\n\t\t\t\t\t\tthat routes traffic to the environment. For example, the domain name\n\t\t\t\t\t\t\t\t<code>my-environment.<i>us-west-2</i>.elasticbeanstalk.com</code>\n\t\t\t\t\t\tis a regionalized domain name. </p>\n               <important>\n                  <p>For environments that were created before early 2016, the domain name\n\t\t\t\t\t\t\tdoesn't include the region. To route traffic to these environments, you\n\t\t\t\t\t\t\tmust create a CNAME record instead of an alias record. Note that you\n\t\t\t\t\t\t\tcan't create a CNAME record for the root domain name. For example, if\n\t\t\t\t\t\t\tyour domain name is example.com, you can create a record that routes\n\t\t\t\t\t\t\ttraffic for acme.example.com to your Elastic Beanstalk environment, but\n\t\t\t\t\t\t\tyou can't create a record that routes traffic for example.com to your\n\t\t\t\t\t\t\tElastic Beanstalk environment.</p>\n               </important>\n               <p>For Elastic Beanstalk environments that have regionalized subdomains,\n\t\t\t\t\t\tspecify the <code>CNAME</code> attribute for the environment. You can use\n\t\t\t\t\t\tthe following methods to get the value of the CNAME attribute:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <i>Amazon Web Services Management Console</i>: For information about\n\t\t\t\t\t\t\t\thow to get the value by using the console, see <a href=\"https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html\">Using Custom\n\t\t\t\t\t\t\t\t\tDomains with Elastic Beanstalk</a> in the\n\t\t\t\t\t\t\t\t\t\t<i>Elastic Beanstalk Developer\n\t\t\t\t\t\t\t\tGuide</i>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <i>Elastic Beanstalk API</i>: Use the\n\t\t\t\t\t\t\t\t\t<code>DescribeEnvironments</code> action to get the value of the\n\t\t\t\t\t\t\t\t\t<code>CNAME</code> attribute. For more information, see <a href=\"https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html\">DescribeEnvironments</a> in the <i>Elastic Beanstalk API Reference</i>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <i>CLI</i>: Use the\n\t\t\t\t\t\t\t\t\t<code>describe-environments</code> command to get the value of\n\t\t\t\t\t\t\t\tthe <code>CNAME</code> attribute. For more information, see <a href=\"https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html\">describe-environments</a> in the <i>CLI Command Reference</i>.</p>\n                  </li>\n               </ul>\n            </dd>\n            <dt>ELB load balancer</dt>\n            <dd>\n               <p>Specify the DNS name that is associated with the load balancer. Get the\n\t\t\t\t\t\tDNS name by using the Amazon Web Services Management Console, the ELB API, or the CLI. </p>\n               <ul>\n                  <li>\n                     <p>\n                        <b>Amazon Web Services Management Console</b>: Go to the\n\t\t\t\t\t\t\t\tEC2 page, choose <b>Load Balancers</b> in\n\t\t\t\t\t\t\t\tthe navigation pane, choose the load balancer, choose the <b>Description</b> tab, and get the value of the\n\t\t\t\t\t\t\t\t\t<b>DNS name</b> field. </p>\n                     <p>If you're routing traffic to a Classic Load Balancer, get the\n\t\t\t\t\t\t\t\tvalue that begins with <b>dualstack</b>.\n\t\t\t\t\t\t\t\tIf you're routing traffic to another type of load balancer, get the\n\t\t\t\t\t\t\t\tvalue that applies to the record type, A or AAAA.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>Elastic Load Balancing API</b>: Use\n\t\t\t\t\t\t\t\t\t<code>DescribeLoadBalancers</code> to get the value of\n\t\t\t\t\t\t\t\t\t<code>DNSName</code>. For more information, see the applicable\n\t\t\t\t\t\t\t\tguide:</p>\n                     <ul>\n                        <li>\n                           <p>Classic Load Balancers: <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a>\n                           </p>\n                        </li>\n                        <li>\n                           <p>Application and Network Load Balancers: <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a>\n                           </p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <b>CLI</b>: Use\n\t\t\t\t\t\t\t\t\t<code>describe-load-balancers</code> to get the value of\n\t\t\t\t\t\t\t\t\t<code>DNSName</code>. For more information, see the applicable\n\t\t\t\t\t\t\t\tguide:</p>\n                     <ul>\n                        <li>\n                           <p>Classic Load Balancers: <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html\">describe-load-balancers</a>\n                           </p>\n                        </li>\n                        <li>\n                           <p>Application and Network Load Balancers: <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elbv2/describe-load-balancers.html\">describe-load-balancers</a>\n                           </p>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </dd>\n            <dt>Global Accelerator accelerator</dt>\n            <dd>\n               <p>Specify the DNS name for your accelerator:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <b>Global Accelerator API:</b> To get\n\t\t\t\t\t\t\t\tthe DNS name, use <a href=\"https://docs.aws.amazon.com/global-accelerator/latest/api/API_DescribeAccelerator.html\">DescribeAccelerator</a>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>CLI:</b> To get the\n\t\t\t\t\t\t\t\tDNS name, use <a href=\"https://docs.aws.amazon.com/cli/latest/reference/globalaccelerator/describe-accelerator.html\">describe-accelerator</a>.</p>\n                  </li>\n               </ul>\n            </dd>\n            <dt>Amazon S3 bucket that is configured as a static website</dt>\n            <dd>\n               <p>Specify the domain name of the Amazon S3 website endpoint that you created\n\t\t\t\t\t\tthe bucket in, for example, <code>s3-website.us-east-2.amazonaws.com</code>.\n\t\t\t\t\t\tFor more information about valid values, see the table <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints\">Amazon S3\n\t\t\t\t\t\t\tWebsite Endpoints</a> in the <i>Amazon Web Services General\n\t\t\t\t\t\t\tReference</i>. For more information about using S3 buckets for\n\t\t\t\t\t\twebsites, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html\">Getting Started\n\t\t\t\t\t\t\twith Amazon Route 53</a> in the <i>Amazon Route 53 Developer\n\t\t\t\t\t\t\tGuide.</i>\n               </p>\n            </dd>\n            <dt>Another Route 53 resource record set</dt>\n            <dd>\n               <p>Specify the value of the <code>Name</code> element for a resource record\n\t\t\t\t\t\tset in the current hosted zone.</p>\n               <note>\n                  <p>If you're creating an alias record that has the same name as the\n\t\t\t\t\t\t\thosted zone (known as the zone apex), you can't specify the domain name\n\t\t\t\t\t\t\tfor a record for which the value of <code>Type</code> is\n\t\t\t\t\t\t\t\t<code>CNAME</code>. This is because the alias record must have the\n\t\t\t\t\t\t\tsame type as the record that you're routing traffic to, and creating a\n\t\t\t\t\t\t\tCNAME record for the zone apex isn't supported even for an alias\n\t\t\t\t\t\t\trecord.</p>\n               </note>\n            </dd>\n         </dl>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EvaluateTargetHealth": {
+                    "target": "com.amazonaws.route53#AliasHealthEnabled",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>\n            <i>Applies only to alias, failover alias, geolocation alias, latency alias, and\n\t\t\t\tweighted alias resource record sets:</i> When\n\t\t\t\t<code>EvaluateTargetHealth</code> is <code>true</code>, an alias resource record set\n\t\t\tinherits the health of the referenced Amazon Web Services resource, such as an ELB load\n\t\t\tbalancer or another resource record set in the hosted zone.</p>\n         <p>Note the following:</p>\n         <dl>\n            <dt>CloudFront distributions</dt>\n            <dd>\n               <p>You can't set <code>EvaluateTargetHealth</code> to <code>true</code> when\n\t\t\t\t\t\tthe alias target is a CloudFront distribution.</p>\n            </dd>\n            <dt>Elastic Beanstalk environments that have regionalized subdomains</dt>\n            <dd>\n               <p>If you specify an Elastic Beanstalk environment in <code>DNSName</code>\n\t\t\t\t\t\tand the environment contains an ELB load balancer, Elastic Load Balancing\n\t\t\t\t\t\troutes queries only to the healthy Amazon EC2 instances that are registered\n\t\t\t\t\t\twith the load balancer. (An environment automatically contains an ELB load\n\t\t\t\t\t\tbalancer if it includes more than one Amazon EC2 instance.) If you set\n\t\t\t\t\t\t\t<code>EvaluateTargetHealth</code> to <code>true</code> and either no\n\t\t\t\t\t\tAmazon EC2 instances are healthy or the load balancer itself is unhealthy,\n\t\t\t\t\t\tRoute 53 routes queries to other available resources that are healthy, if\n\t\t\t\t\t\tany. </p>\n               <p>If the environment contains a single Amazon EC2 instance, there are no\n\t\t\t\t\t\tspecial requirements.</p>\n            </dd>\n            <dt>ELB load balancers</dt>\n            <dd>\n               <p>Health checking behavior depends on the type of load balancer:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <b>Classic Load Balancers</b>: If you\n\t\t\t\t\t\t\t\tspecify an ELB Classic Load Balancer in <code>DNSName</code>,\n\t\t\t\t\t\t\t\tElastic Load Balancing routes queries only to the healthy Amazon EC2\n\t\t\t\t\t\t\t\tinstances that are registered with the load balancer. If you set\n\t\t\t\t\t\t\t\t\t<code>EvaluateTargetHealth</code> to <code>true</code> and\n\t\t\t\t\t\t\t\teither no EC2 instances are healthy or the load balancer itself is\n\t\t\t\t\t\t\t\tunhealthy, Route 53 routes queries to other resources.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>Application and Network Load\n\t\t\t\t\t\t\t\t\tBalancers</b>: If you specify an ELB Application or\n\t\t\t\t\t\t\t\tNetwork Load Balancer and you set <code>EvaluateTargetHealth</code>\n\t\t\t\t\t\t\t\tto <code>true</code>, Route 53 routes queries to the load balancer\n\t\t\t\t\t\t\t\tbased on the health of the target groups that are associated with\n\t\t\t\t\t\t\t\tthe load balancer:</p>\n                     <ul>\n                        <li>\n                           <p>For an Application or Network Load Balancer to be\n\t\t\t\t\t\t\t\t\t\tconsidered healthy, every target group that contains targets\n\t\t\t\t\t\t\t\t\t\tmust contain at least one healthy target. If any target\n\t\t\t\t\t\t\t\t\t\tgroup contains only unhealthy targets, the load balancer is\n\t\t\t\t\t\t\t\t\t\tconsidered unhealthy, and Route 53 routes queries to other\n\t\t\t\t\t\t\t\t\t\tresources.</p>\n                        </li>\n                        <li>\n                           <p>A target group that has no registered targets is\n\t\t\t\t\t\t\t\t\t\tconsidered unhealthy.</p>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n               <note>\n                  <p>When you create a load balancer, you configure settings for Elastic\n\t\t\t\t\t\t\tLoad Balancing health checks; they're not Route 53 health checks, but\n\t\t\t\t\t\t\tthey perform a similar function. Do not create Route 53 health checks\n\t\t\t\t\t\t\tfor the EC2 instances that you register with an ELB load balancer.\n\t\t\t\t\t\t</p>\n               </note>\n            </dd>\n            <dt>S3 buckets</dt>\n            <dd>\n               <p>There are no special requirements for setting\n\t\t\t\t\t\t\t<code>EvaluateTargetHealth</code> to <code>true</code> when the alias\n\t\t\t\t\t\ttarget is an S3 bucket.</p>\n            </dd>\n            <dt>Other records in the same hosted zone</dt>\n            <dd>\n               <p>If the Amazon Web Services resource that you specify in\n\t\t\t\t\t\t\t<code>DNSName</code> is a record or a group of records (for example, a\n\t\t\t\t\t\tgroup of weighted records) but is not another alias record, we recommend\n\t\t\t\t\t\tthat you associate a health check with all of the records in the alias\n\t\t\t\t\t\ttarget. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html#dns-failover-complex-configs-hc-omitting\">What Happens When You Omit Health Checks?</a> in the\n\t\t\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n            </dd>\n         </dl>\n         <p>For more information and examples, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Amazon Route 53 Health Checks\n\t\t\t\tand DNS Failover</a> in the <i>Amazon Route 53 Developer\n\t\t\tGuide</i>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            <i>Alias resource record sets only:</i> Information about the Amazon Web Services resource, such as a CloudFront distribution or an Amazon S3 bucket, that\n\t\t\tyou want to route traffic to.</p>\n         <p>When creating resource record sets for a private hosted zone, note the\n\t\t\tfollowing:</p>\n         <ul>\n            <li>\n               <p>For information about creating failover resource record sets in a private\n\t\t\t\t\thosted zone, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a>.</p>\n            </li>\n         </ul>"
+            }
+        },
+        "com.amazonaws.route53#AssociateVPCComment": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#AssociateVPCWithHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#AssociateVPCWithHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#AssociateVPCWithHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConflictingDomainExists"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidVPCId"
+                },
+                {
+                    "target": "com.amazonaws.route53#LimitsExceeded"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#NotAuthorizedException"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                },
+                {
+                    "target": "com.amazonaws.route53#PublicZoneVPCAssociation"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Associates an Amazon VPC with a private hosted zone. </p>\n         <important>\n            <p>To perform the association, the VPC and the private hosted zone must already\n\t\t\t\texist. You can't convert a public hosted zone into a private hosted zone.</p>\n         </important>\n         <note>\n            <p>If you want to associate a VPC that was created by using one Amazon Web Services account with a private hosted zone that was created by using a\n\t\t\t\tdifferent account, the Amazon Web Services account that created the private hosted\n\t\t\t\tzone must first submit a <code>CreateVPCAssociationAuthorization</code> request.\n\t\t\t\tThen the account that created the VPC must submit an\n\t\t\t\t\t<code>AssociateVPCWithHostedZone</code> request.</p>\n         </note>\n         <note>\n            <p>When granting access, the hosted zone and the Amazon VPC must belong to\n\t\t\t\tthe same partition. A partition is a group of Amazon Web Services Regions. Each\n\t\t\t\t\tAmazon Web Services account is scoped to one partition.</p>\n            <p>The following are the supported partitions:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>aws</code> - Amazon Web Services Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-cn</code> - China Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-us-gov</code> - Amazon Web Services GovCloud (US) Region</p>\n               </li>\n            </ul>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Access Management</a>\n\t\t\t\tin the <i>Amazon Web Services General Reference</i>.</p>\n         </note>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To associate a VPC with a hosted zone",
+                        "documentation": "The following example associates the VPC with ID vpc-1a2b3c4d with the hosted zone with ID Z3M3LMPEXAMPLE.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "VPC": {
+                                "VPCId": "vpc-1a2b3c4d",
+                                "VPCRegion": "us-east-2"
+                            },
+                            "Comment": ""
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Status": "INSYNC",
+                                "Comment": "",
+                                "SubmittedAt": "2017-01-31T01:36:41.958Z",
+                                "Id": "/change/C3HC6WDB2UANE2"
+                            }
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/associatevpc",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#AssociateVPCWithHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the private hosted zone that you want to associate an Amazon VPC\n\t\t\twith.</p>\n         <p>Note that you can't associate a VPC with a hosted zone that doesn't have an existing\n\t\t\tVPC association.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the VPC that you want to associate with\n\t\t\ta private hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#AssociateVPCComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Optional:</i> A comment about the association request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to associate a VPC with a\n\t\t\tprivate hosted zone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#AssociateVPCWithHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that describes the changes made to your hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the\n\t\t\t\t<code>AssociateVPCWithHostedZone</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#Bias": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": -99,
+                    "max": 99
+                }
+            }
+        },
+        "com.amazonaws.route53#Change": {
+            "type": "structure",
+            "members": {
+                "Action": {
+                    "target": "com.amazonaws.route53#ChangeAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The action to perform:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE</code>: Creates a resource record set that has the specified\n\t\t\t\t\tvalues.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE</code>: Deletes a existing resource record set.</p>\n               <important>\n                  <p>To delete the resource record set that is associated with a traffic policy\n\t\t\t\t\t\tinstance, use <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteTrafficPolicyInstance.html\">DeleteTrafficPolicyInstance</a>. Amazon Route 53 will delete the\n\t\t\t\t\t\tresource record set automatically. If you delete the resource record set by\n\t\t\t\t\t\tusing <code>ChangeResourceRecordSets</code>, Route 53 doesn't automatically\n\t\t\t\t\t\tdelete the traffic policy instance, and you'll continue to be charged for it\n\t\t\t\t\t\teven though it's no longer in use. </p>\n               </important>\n            </li>\n            <li>\n               <p>\n                  <code>UPSERT</code>: If a resource record set doesn't already exist, Route 53\n\t\t\t\t\tcreates it. If a resource record set does exist, Route 53 updates it with the\n\t\t\t\t\tvalues in the request.</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResourceRecordSet": {
+                    "target": "com.amazonaws.route53#ResourceRecordSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the resource record set to create, delete, or update.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The information for each resource record set that you want to change.</p>"
+            }
+        },
+        "com.amazonaws.route53#ChangeAction": {
+            "type": "enum",
+            "members": {
+                "CREATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE"
+                    }
+                },
+                "DELETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE"
+                    }
+                },
+                "UPSERT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPSERT"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeBatch": {
+            "type": "structure",
+            "members": {
+                "Comment": {
+                    "target": "com.amazonaws.route53#ResourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Optional:</i> Any comments you want to include about a change batch\n\t\t\trequest.</p>"
+                    }
+                },
+                "Changes": {
+                    "target": "com.amazonaws.route53#Changes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the changes to make to the record sets.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The information for a change request.</p>"
+            }
+        },
+        "com.amazonaws.route53#ChangeCidrCollection": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ChangeCidrCollectionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ChangeCidrCollectionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#CidrBlockInUseException"
+                },
+                {
+                    "target": "com.amazonaws.route53#CidrCollectionVersionMismatchException"
+                },
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#LimitsExceeded"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCidrCollectionException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates, changes, or deletes CIDR blocks within a collection. Contains authoritative\n\t\t\tIP information mapping blocks to one or multiple locations.</p>\n         <p>A change request can update multiple locations in a collection at a time, which is\n\t\t\thelpful if you want to move one or more CIDR blocks from one location to another in one\n\t\t\ttransaction, without downtime. </p>\n         <p>\n            <b>Limits</b>\n         </p>\n         <p>The max number of CIDR blocks included in the request is 1000. As a result, big updates\n\t\t\trequire multiple API calls.</p>\n         <p>\n            <b> PUT and DELETE_IF_EXISTS</b>\n         </p>\n         <p>Use <code>ChangeCidrCollection</code> to perform the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PUT</code>: Create a CIDR block within the specified collection.</p>\n            </li>\n            <li>\n               <p>\n                  <code> DELETE_IF_EXISTS</code>: Delete an existing CIDR block from the\n\t\t\t\t\tcollection.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/cidrcollection/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeCidrCollectionRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The UUID of the CIDR collection to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "CollectionVersion": {
+                    "target": "com.amazonaws.route53#CollectionVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A sequential counter that Amazon Route 53 sets to 1 when you create a\n\t\t\tcollection and increments it by 1 each time you update the collection.</p>\n         <p>We recommend that you use <code>ListCidrCollection</code> to get the current value of\n\t\t\t\t<code>CollectionVersion</code> for the collection that you want to update, and then\n\t\t\tinclude that value with the change request. This prevents Route 53 from\n\t\t\toverwriting an intervening update: </p>\n         <ul>\n            <li>\n               <p>If the value in the request matches the value of\n\t\t\t\t\t\t<code>CollectionVersion</code> in the collection, Route 53 updates\n\t\t\t\t\tthe collection.</p>\n            </li>\n            <li>\n               <p>If the value of <code>CollectionVersion</code> in the collection is greater\n\t\t\t\t\tthan the value in the request, the collection was changed after you got the\n\t\t\t\t\tversion number. Route 53 does not update the collection, and it\n\t\t\t\t\treturns a <code>CidrCollectionVersionMismatch</code> error. </p>\n            </li>\n         </ul>"
+                    }
+                },
+                "Changes": {
+                    "target": "com.amazonaws.route53#CidrCollectionChanges",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Information about changes to a CIDR collection.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ChangeCidrCollectionResponse": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ChangeId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that is returned by <code>ChangeCidrCollection</code>. You can use it as input to\n\t\t\t\t<code>GetChange</code> to see if a CIDR collection change has propagated or\n\t\t\tnot.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ChangeId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 6500
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeInfo": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This element contains an ID that you use when performing a <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html\">GetChange</a> action to get\n\t\t\tdetailed information about the change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.route53#ChangeStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the request. <code>PENDING</code> indicates that this request has\n\t\t\tnot yet been applied to all Amazon Route 53 DNS servers.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SubmittedAt": {
+                    "target": "com.amazonaws.route53#TimeStamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time that the change request was submitted in <a href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 format</a> and Coordinated\n\t\t\tUniversal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code>\n\t\t\trepresents March 27, 2017 at 17:48:16.751 UTC.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#ResourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A comment you can provide.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that describes change information about changes made to your hosted\n\t\t\tzone.</p>"
+            }
+        },
+        "com.amazonaws.route53#ChangeResourceRecordSets": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ChangeResourceRecordSetsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ChangeResourceRecordSetsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidChangeBatch"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates, changes, or deletes a resource record set, which contains authoritative DNS\n\t\t\tinformation for a specified domain name or subdomain name. For example, you can use\n\t\t\t\t<code>ChangeResourceRecordSets</code> to create a resource record set that routes\n\t\t\ttraffic for test.example.com to a web server that has an IP address of\n\t\t\t192.0.2.44.</p>\n         <p>\n            <b>Deleting Resource Record Sets</b>\n         </p>\n         <p>To delete a resource record set, you must specify all the same values that you\n\t\t\tspecified when you created it.</p>\n         <p>\n            <b>Change Batches and Transactional Changes</b>\n         </p>\n         <p>The request body must include a document with a\n\t\t\t\t<code>ChangeResourceRecordSetsRequest</code> element. The request body contains a\n\t\t\tlist of change items, known as a change batch. Change batches are considered\n\t\t\ttransactional changes. Route 53 validates the changes in the request and then either\n\t\t\tmakes all or none of the changes in the change batch request. This ensures that DNS\n\t\t\trouting isn't adversely affected by partial changes to the resource record sets in a\n\t\t\thosted zone. </p>\n         <p>For example, suppose a change batch request contains two changes: it deletes the\n\t\t\t\t<code>CNAME</code> resource record set for www.example.com and creates an alias\n\t\t\tresource record set for www.example.com. If validation for both records succeeds, Route\n\t\t\t53 deletes the first resource record set and creates the second resource record set in a\n\t\t\tsingle operation. If validation for either the <code>DELETE</code> or the\n\t\t\t\t<code>CREATE</code> action fails, then the request is canceled, and the original\n\t\t\t\t<code>CNAME</code> record continues to exist.</p>\n         <note>\n            <p>If you try to delete the same resource record set more than once in a single\n\t\t\t\tchange batch, Route 53 returns an <code>InvalidChangeBatch</code> error.</p>\n         </note>\n         <p>\n            <b>Traffic Flow</b>\n         </p>\n         <p>To create resource record sets for complex routing configurations, use either the\n\t\t\ttraffic flow visual editor in the Route 53 console or the API actions for traffic\n\t\t\tpolicies and traffic policy instances. Save the configuration as a traffic policy, then\n\t\t\tassociate the traffic policy with one or more domain names (such as example.com) or\n\t\t\tsubdomain names (such as www.example.com), in the same hosted zone or in multiple hosted\n\t\t\tzones. You can roll back the updates if the new configuration isn't performing as\n\t\t\texpected. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/traffic-flow.html\">Using Traffic Flow to Route\n\t\t\t\tDNS Traffic</a> in the <i>Amazon Route 53 Developer\n\t\t\tGuide</i>.</p>\n         <p>\n            <b>Create, Delete, and Upsert</b>\n         </p>\n         <p>Use <code>ChangeResourceRecordsSetsRequest</code> to perform the following\n\t\t\tactions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE</code>: Creates a resource record set that has the specified\n\t\t\t\t\tvalues.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE</code>: Deletes an existing resource record set that has the\n\t\t\t\t\tspecified values.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPSERT</code>: If a resource set doesn't exist, Route 53 creates it. If a resource\n\t\t\t\t\tset exists Route 53 updates it with the values in the request. </p>\n            </li>\n         </ul>\n         <p>\n            <b>Syntaxes for Creating, Updating, and Deleting Resource Record\n\t\t\t\tSets</b>\n         </p>\n         <p>The syntax for a request depends on the type of resource record set that you want to\n\t\t\tcreate, delete, or update, such as weighted, alias, or failover. The XML elements in\n\t\t\tyour request must appear in the order listed in the syntax. </p>\n         <p>For an example for each type of resource record set, see \"Examples.\"</p>\n         <p>Don't refer to the syntax in the \"Parameter Syntax\" section, which includes\n\t\t\tall of the elements for every kind of resource record set that you can create, delete,\n\t\t\tor update by using <code>ChangeResourceRecordSets</code>. </p>\n         <p>\n            <b>Change Propagation to Route 53 DNS Servers</b>\n         </p>\n         <p>When you submit a <code>ChangeResourceRecordSets</code> request, Route 53 propagates your\n\t\t\tchanges to all of the Route 53 authoritative DNS servers managing the hosted zone. While\n\t\t\tyour changes are propagating, <code>GetChange</code> returns a status of\n\t\t\t\t<code>PENDING</code>. When propagation is complete, <code>GetChange</code> returns a\n\t\t\tstatus of <code>INSYNC</code>. Changes generally propagate to all Route 53 name servers\n\t\t\tmanaging the hosted zone within 60 seconds. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html\">GetChange</a>.</p>\n         <p>\n            <b>Limits on ChangeResourceRecordSets Requests</b>\n         </p>\n         <p>For information about the limits on a <code>ChangeResourceRecordSets</code> request,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To create an alias resource record set",
+                        "documentation": "The following example creates an alias resource record set that routes traffic to a CloudFront distribution.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "CloudFront distribution for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z2FDTNDATAQYW2",
+                                                "DNSName": "d123rk29d0stfj.cloudfront.net",
+                                                "EvaluateTargetHealth": false
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "CloudFront distribution for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create failover alias resource record sets",
+                        "documentation": "The following example creates primary and secondary failover alias resource record sets that route traffic to ELB load balancers. Traffic is generally routed to the primary resource, in the Ohio region. If that resource is unavailable, traffic is routed to the secondary resource, in the Oregon region.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Failover alias configuration for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Ohio region",
+                                            "Failover": "PRIMARY",
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z3AADJGX6KTTL2",
+                                                "DNSName": "example-com-123456789.us-east-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Oregon region",
+                                            "Failover": "SECONDARY",
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z1H1FL5HABSF5",
+                                                "DNSName": "example-com-987654321.us-west-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Failover alias configuration for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create failover resource record sets",
+                        "documentation": "The following example creates primary and secondary failover resource record sets that route traffic to EC2 instances. Traffic is generally routed to the primary resource, in the Ohio region. If that resource is unavailable, traffic is routed to the secondary resource, in the Oregon region.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Failover configuration for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Ohio region",
+                                            "Failover": "PRIMARY",
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.44"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef11-2222-3333-4444-555555fedcba"
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Oregon region",
+                                            "Failover": "SECONDARY",
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.45"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef66-7777-8888-9999-000000fedcba"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Failover configuration for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create geolocation alias resource record sets",
+                        "documentation": "The following example creates four geolocation alias resource record sets that route traffic to ELB load balancers. Traffic is routed to one of four IP addresses, for North America (NA), for South America (SA), for Europe (EU), and for all other locations (*).",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Geolocation alias configuration for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "North America",
+                                            "GeoLocation": {
+                                                "ContinentCode": "NA"
+                                            },
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z3AADJGX6KTTL2",
+                                                "DNSName": "example-com-123456789.us-east-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "South America",
+                                            "GeoLocation": {
+                                                "ContinentCode": "SA"
+                                            },
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z2P70J7HTTTPLU",
+                                                "DNSName": "example-com-234567890.sa-east-1.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Europe",
+                                            "GeoLocation": {
+                                                "ContinentCode": "EU"
+                                            },
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z215JYRZR1TBD5",
+                                                "DNSName": "example-com-234567890.eu-central-1.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Other locations",
+                                            "GeoLocation": {
+                                                "CountryCode": "*"
+                                            },
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z1LMS91P8CMLE5",
+                                                "DNSName": "example-com-234567890.ap-southeast-1.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Geolocation alias configuration for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create geolocation resource record sets",
+                        "documentation": "The following example creates four geolocation resource record sets that use IPv4 addresses to route traffic to resources such as web servers running on EC2 instances. Traffic is routed to one of four IP addresses, for North America (NA), for South America (SA), for Europe (EU), and for all other locations (*).",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Geolocation configuration for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "North America",
+                                            "GeoLocation": {
+                                                "ContinentCode": "NA"
+                                            },
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.44"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "South America",
+                                            "GeoLocation": {
+                                                "ContinentCode": "SA"
+                                            },
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.45"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Europe",
+                                            "GeoLocation": {
+                                                "ContinentCode": "EU"
+                                            },
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.46"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Other locations",
+                                            "GeoLocation": {
+                                                "CountryCode": "*"
+                                            },
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.47"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Geolocation configuration for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create latency alias resource record sets",
+                        "documentation": "The following example creates two latency alias resource record sets that route traffic for example.com to ELB load balancers. Requests are routed either to the Ohio region or the Oregon region, depending on the latency between the user and those regions.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "ELB load balancers for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Ohio region",
+                                            "Region": "us-east-2",
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z3AADJGX6KTTL2",
+                                                "DNSName": "example-com-123456789.us-east-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Oregon region",
+                                            "Region": "us-west-2",
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z1H1FL5HABSF5",
+                                                "DNSName": "example-com-987654321.us-west-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "ELB load balancers for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create latency resource record sets",
+                        "documentation": "The following example creates two latency resource record sets that route traffic to EC2 instances. Traffic for example.com is routed either to the Ohio region or the Oregon region, depending on the latency between the user and those regions.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "EC2 instances for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Ohio region",
+                                            "Region": "us-east-2",
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.44"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef11-2222-3333-4444-555555fedcba"
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Oregon region",
+                                            "Region": "us-west-2",
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.45"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef66-7777-8888-9999-000000fedcba"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "EC2 instances for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create a basic resource record set",
+                        "documentation": "The following example creates a resource record set that routes Internet traffic to a resource with an IP address of 192.0.2.44.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Web server for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.44"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Web server for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create weighted alias resource record sets",
+                        "documentation": "The following example creates two weighted alias resource record sets that route traffic to ELB load balancers. The resource with a Weight of 100 will get 1/3rd of traffic (100/100+200), and the other resource will get the rest of the traffic for example.com.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "ELB load balancers for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Ohio region",
+                                            "Weight": 100,
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z3AADJGX6KTTL2",
+                                                "DNSName": "example-com-123456789.us-east-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Oregon region",
+                                            "Weight": 200,
+                                            "AliasTarget": {
+                                                "HostedZoneId": "Z1H1FL5HABSF5",
+                                                "DNSName": "example-com-987654321.us-west-2.elb.amazonaws.com ",
+                                                "EvaluateTargetHealth": true
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "ELB load balancers for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    },
+                    {
+                        "title": "To create weighted resource record sets",
+                        "documentation": "The following example creates two weighted resource record sets. The resource with a Weight of 100 will get 1/3rd of traffic (100/100+200), and the other resource will get the rest of the traffic for example.com.",
+                        "input": {
+                            "HostedZoneId": "Z3M3LMPEXAMPLE",
+                            "ChangeBatch": {
+                                "Comment": "Web servers for example.com",
+                                "Changes": [
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Seattle data center",
+                                            "Weight": 100,
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.44"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef11-2222-3333-4444-555555fedcba"
+                                        }
+                                    },
+                                    {
+                                        "Action": "CREATE",
+                                        "ResourceRecordSet": {
+                                            "Name": "example.com",
+                                            "Type": "A",
+                                            "SetIdentifier": "Portland data center",
+                                            "Weight": 200,
+                                            "TTL": 60,
+                                            "ResourceRecords": [
+                                                {
+                                                    "Value": "192.0.2.45"
+                                                }
+                                            ],
+                                            "HealthCheckId": "abcdef66-7777-8888-9999-000000fedcba"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "output": {
+                            "ChangeInfo": {
+                                "Comment": "Web servers for example.com",
+                                "Id": "/change/C2682N5HXP0BZ4",
+                                "Status": "PENDING",
+                                "SubmittedAt": "2017-02-10T01:36:41.958Z"
+                            }
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/rrset",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeResourceRecordSetsRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that contains the resource record sets that you want to\n\t\t\tchange.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ChangeBatch": {
+                    "target": "com.amazonaws.route53#ChangeBatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains an optional comment and the <code>Changes</code>\n\t\t\telement.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains change information for the resource record set.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ChangeResourceRecordSetsResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about changes made to your hosted\n\t\t\tzone.</p>\n         <p>This element contains an ID that you use when performing a <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html\">GetChange</a> action to get\n\t\t\tdetailed information about the change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing the response for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ChangeStatus": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "INSYNC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INSYNC"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeTagsForResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ChangeTagsForResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ChangeTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                },
+                {
+                    "target": "com.amazonaws.route53#ThrottlingException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds, edits, or deletes tags for a health check or a hosted zone.</p>\n         <p>For information about using tags for cost allocation, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using Cost Allocation\n\t\t\t\tTags</a> in the <i>Billing and Cost Management User Guide</i>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To add or remove tags from a hosted zone or health check",
+                        "documentation": "The following example adds two tags and removes one tag from the hosted zone with ID Z3M3LMPEXAMPLE.",
+                        "input": {
+                            "ResourceType": "hostedzone",
+                            "ResourceId": "Z3M3LMPEXAMPLE",
+                            "AddTags": [
+                                {
+                                    "Key": "apex",
+                                    "Value": "3874"
+                                },
+                                {
+                                    "Key": "acme",
+                                    "Value": "4938"
+                                }
+                            ],
+                            "RemoveTagKeys": [
+                                "Nadir"
+                            ]
+                        },
+                        "output": {}
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/tags/{ResourceType}/{ResourceId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ChangeTagsForResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceType": {
+                    "target": "com.amazonaws.route53#TagResourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource.</p>\n         <ul>\n            <li>\n               <p>The resource type for health checks is <code>healthcheck</code>.</p>\n            </li>\n            <li>\n               <p>The resource type for hosted zones is <code>hostedzone</code>.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResourceId": {
+                    "target": "com.amazonaws.route53#TagResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the resource for which you want to add, change, or delete tags.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "AddTags": {
+                    "target": "com.amazonaws.route53#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains a list of the tags that you want to add to the specified\n\t\t\thealth check or hosted zone and/or the tags that you want to edit <code>Value</code>\n\t\t\tfor.</p>\n         <p>You can add a maximum of 10 tags to a health check or a hosted zone.</p>"
+                    }
+                },
+                "RemoveTagKeys": {
+                    "target": "com.amazonaws.route53#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains a list of the tags that you want to delete from the\n\t\t\tspecified health check or hosted zone. You can specify up to 10 keys.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the tags that you want to add, edit, or\n\t\t\tdelete.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ChangeTagsForResourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Empty response for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#Changes": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#Change",
+                "traits": {
+                    "smithy.api#xmlName": "Change"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#CheckerIpRanges": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#IPAddressCidr"
+            }
+        },
+        "com.amazonaws.route53#ChildHealthCheckList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HealthCheckId",
+                "traits": {
+                    "smithy.api#xmlName": "ChildHealthCheck"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.route53#Cidr": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 50
+                },
+                "smithy.api#pattern": "\\S"
+            }
+        },
+        "com.amazonaws.route53#CidrBlockInUseException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This CIDR block is already in use.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#CidrBlockSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#CidrBlockSummary"
+            }
+        },
+        "com.amazonaws.route53#CidrBlockSummary": {
+            "type": "structure",
+            "members": {
+                "CidrBlock": {
+                    "target": "com.amazonaws.route53#Cidr",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Value for the CIDR block.</p>"
+                    }
+                },
+                "LocationName": {
+                    "target": "com.amazonaws.route53#CidrLocationNameDefaultNotAllowed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The location name of the CIDR block.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that lists the CIDR blocks.</p>"
+            }
+        },
+        "com.amazonaws.route53#CidrCollection": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.route53#ARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the collection. Can be used to reference the collection in IAM policy or in\n\t\t\tanother Amazon Web Services account.</p>"
+                    }
+                },
+                "Id": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique ID of the CIDR collection.</p>"
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#CollectionName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a CIDR collection.</p>"
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#CollectionVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A sequential counter that Route 53 sets to 1 when you create a CIDR\n\t\t\tcollection and increments by 1 each time you update settings for the CIDR\n\t\t\tcollection.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex\n\t\t\ttype that\n\t\t\tidentifies a CIDR collection.</p>"
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionAlreadyExistsException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A CIDR collection with this name and a different caller reference already exists in this account.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionChange": {
+            "type": "structure",
+            "members": {
+                "LocationName": {
+                    "target": "com.amazonaws.route53#CidrLocationNameDefaultNotAllowed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the location that is associated with the CIDR collection.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Action": {
+                    "target": "com.amazonaws.route53#CidrCollectionChangeAction",
+                    "traits": {
+                        "smithy.api#documentation": "<p>CIDR collection change action. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CidrList": {
+                    "target": "com.amazonaws.route53#CidrList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of CIDR blocks.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the CIDR collection change.</p>"
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionChangeAction": {
+            "type": "enum",
+            "members": {
+                "PUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PUT"
+                    }
+                },
+                "DELETE_IF_EXISTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_IF_EXISTS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionChanges": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#CidrCollectionChange"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionInUseException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This CIDR collection is in use, and isn't empty.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#CidrCollectionVersionMismatchException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The CIDR collection version you provided, doesn't match the one in the\n\t\t\t\t<code>ListCidrCollections</code> operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#CidrList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#Cidr",
+                "traits": {
+                    "smithy.api#xmlName": "Cidr"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.route53#CidrLocationNameDefaultAllowed": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 16
+                },
+                "smithy.api#pattern": "^[0-9A-Za-z_\\-\\*]+$"
+            }
+        },
+        "com.amazonaws.route53#CidrLocationNameDefaultNotAllowed": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 16
+                },
+                "smithy.api#pattern": "^[0-9A-Za-z_\\-]+$"
+            }
+        },
+        "com.amazonaws.route53#CidrNonce": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^\\p{ASCII}+$"
+            }
+        },
+        "com.amazonaws.route53#CidrRoutingConfig": {
+            "type": "structure",
+            "members": {
+                "CollectionId": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CIDR collection ID.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "LocationName": {
+                    "target": "com.amazonaws.route53#CidrLocationNameDefaultAllowed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CIDR collection location name.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The object that is specified in resource record set object when you are linking a\n\t\t\tresource record set to a CIDR location.</p>\n         <p>A <code>LocationName</code> with an asterisk “*” can be used to create a default CIDR\n\t\t\trecord. <code>CollectionId</code> is still required for default record.</p>"
+            }
+        },
+        "com.amazonaws.route53#CloudWatchAlarmConfiguration": {
+            "type": "structure",
+            "members": {
+                "EvaluationPeriods": {
+                    "target": "com.amazonaws.route53#EvaluationPeriods",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the number of periods\n\t\t\tthat the metric is compared to the threshold.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Threshold": {
+                    "target": "com.amazonaws.route53#Threshold",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the value the metric is\n\t\t\tcompared with.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ComparisonOperator": {
+                    "target": "com.amazonaws.route53#ComparisonOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the arithmetic operation\n\t\t\tthat is used for the comparison.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Period": {
+                    "target": "com.amazonaws.route53#Period",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the duration of one\n\t\t\tevaluation period in seconds.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MetricName": {
+                    "target": "com.amazonaws.route53#MetricName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch metric that the alarm is associated with.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Namespace": {
+                    "target": "com.amazonaws.route53#Namespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The namespace of the metric that the alarm is associated with. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html\">Amazon\n\t\t\t\tCloudWatch Namespaces, Dimensions, and Metrics Reference</a> in the\n\t\t\t\t<i>Amazon CloudWatch User Guide</i>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Statistic": {
+                    "target": "com.amazonaws.route53#Statistic",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the statistic that is\n\t\t\tapplied to the metric.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Dimensions": {
+                    "target": "com.amazonaws.route53#DimensionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, a complex type that\n\t\t\tcontains information about the dimensions for the metric. For information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html\">Amazon\n\t\t\t\tCloudWatch Namespaces, Dimensions, and Metrics Reference</a> in the\n\t\t\t\t<i>Amazon CloudWatch User Guide</i>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the CloudWatch alarm that Amazon Route\n\t\t\t53 is monitoring for this health check.</p>"
+            }
+        },
+        "com.amazonaws.route53#CloudWatchLogsLogGroupArn": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#CloudWatchRegion": {
+            "type": "enum",
+            "members": {
+                "us_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-1"
+                    }
+                },
+                "us_east_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-2"
+                    }
+                },
+                "us_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-1"
+                    }
+                },
+                "us_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-2"
+                    }
+                },
+                "ca_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-central-1"
+                    }
+                },
+                "eu_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-1"
+                    }
+                },
+                "eu_central_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-2"
+                    }
+                },
+                "eu_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-1"
+                    }
+                },
+                "eu_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-2"
+                    }
+                },
+                "eu_west_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-3"
+                    }
+                },
+                "ap_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-east-1"
+                    }
+                },
+                "me_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-south-1"
+                    }
+                },
+                "me_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-central-1"
+                    }
+                },
+                "ap_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-1"
+                    }
+                },
+                "ap_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-2"
+                    }
+                },
+                "ap_southeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-1"
+                    }
+                },
+                "ap_southeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-2"
+                    }
+                },
+                "ap_southeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-3"
+                    }
+                },
+                "ap_northeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-1"
+                    }
+                },
+                "ap_northeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-2"
+                    }
+                },
+                "ap_northeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-3"
+                    }
+                },
+                "eu_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-north-1"
+                    }
+                },
+                "sa_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sa-east-1"
+                    }
+                },
+                "cn_northwest_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-northwest-1"
+                    }
+                },
+                "cn_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-north-1"
+                    }
+                },
+                "af_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "af-south-1"
+                    }
+                },
+                "eu_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-1"
+                    }
+                },
+                "eu_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-2"
+                    }
+                },
+                "us_gov_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-gov-west-1"
+                    }
+                },
+                "us_gov_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-gov-east-1"
+                    }
+                },
+                "us_iso_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-iso-east-1"
+                    }
+                },
+                "us_iso_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-iso-west-1"
+                    }
+                },
+                "us_isob_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-isob-east-1"
+                    }
+                },
+                "ap_southeast_4": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-4"
+                    }
+                },
+                "il_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "il-central-1"
+                    }
+                },
+                "ca_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-west-1"
+                    }
+                },
+                "ap_southeast_5": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-5"
+                    }
+                },
+                "mx_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mx-central-1"
+                    }
+                },
+                "ap_southeast_7": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-7"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#CollectionName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[0-9A-Za-z_\\-]+$"
+            }
+        },
+        "com.amazonaws.route53#CollectionSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#CollectionSummary"
+            }
+        },
+        "com.amazonaws.route53#CollectionSummary": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.route53#ARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the collection summary. Can be used to reference the collection in IAM\n\t\t\tpolicy or cross-account.</p>"
+                    }
+                },
+                "Id": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Unique ID for the CIDR collection.</p>"
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#CollectionName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a CIDR collection.</p>"
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#CollectionVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A sequential counter that Route 53 sets to 1 when you create a CIDR\n\t\t\tcollection and increments by 1 each time you update settings for the CIDR\n\t\t\tcollection.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that is an entry in an <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CidrCollection.html\">CidrCollection</a>\n\t\t\tarray.</p>"
+            }
+        },
+        "com.amazonaws.route53#CollectionVersion": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#ComparisonOperator": {
+            "type": "enum",
+            "members": {
+                "GreaterThanOrEqualToThreshold": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GreaterThanOrEqualToThreshold"
+                    }
+                },
+                "GreaterThanThreshold": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GreaterThanThreshold"
+                    }
+                },
+                "LessThanThreshold": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LessThanThreshold"
+                    }
+                },
+                "LessThanOrEqualToThreshold": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LessThanOrEqualToThreshold"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#ConcurrentModification": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Another user submitted a request to create, update, or delete the object at the same\n\t\t\ttime that you did. Retry the request. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#ConflictingDomainExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The cause of this error depends on the operation that you're performing:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Create a public hosted zone:</b> Two hosted zones\n\t\t\t\t\tthat have the same name or that have a parent/child relationship (example.com\n\t\t\t\t\tand test.example.com) can't have any common name servers. You tried to create a\n\t\t\t\t\thosted zone that has the same name as an existing hosted zone or that's the\n\t\t\t\t\tparent or child of an existing hosted zone, and you specified a delegation set\n\t\t\t\t\tthat shares one or more name servers with the existing hosted zone. For more\n\t\t\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html\">CreateReusableDelegationSet</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Create a private hosted zone:</b> A hosted zone\n\t\t\t\t\twith the specified name already exists and is already associated with the Amazon\n\t\t\t\t\tVPC that you specified.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Associate VPCs with a private hosted zone:</b>\n\t\t\t\t\tThe VPC that you specified is already associated with another hosted zone that\n\t\t\t\t\thas the same name.</p>\n            </li>\n         </ul>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#ConflictingTypes": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You tried to update a traffic policy instance by using a traffic policy version that\n\t\t\thas a different DNS type than the current type for the instance. You specified the type\n\t\t\tin the JSON document in the <code>CreateTrafficPolicy</code> or\n\t\t\t\t<code>CreateTrafficPolicyVersion</code>request. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#Coordinates": {
+            "type": "structure",
+            "members": {
+                "Latitude": {
+                    "target": "com.amazonaws.route53#Latitude",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Specifies a coordinate of the north–south position of a geographic point on the surface of\n\t\t\tthe Earth (-90 - 90). </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Longitude": {
+                    "target": "com.amazonaws.route53#Longitude",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Specifies a coordinate of the east–west position of a geographic point on the surface of\n\t\t\tthe Earth (-180 - 180). </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n\t\t\tA complex type that lists the coordinates for a geoproximity resource record.\n\t\t</p>"
+            }
+        },
+        "com.amazonaws.route53#CreateCidrCollection": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateCidrCollectionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateCidrCollectionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#CidrCollectionAlreadyExistsException"
+                },
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#LimitsExceeded"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a CIDR collection in the current Amazon Web Services account.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/cidrcollection",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateCidrCollectionRequest": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#CollectionName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique identifier for the account that can be used to reference the collection from\n\t\t\tother API calls.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#CidrNonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A client-specific token that allows requests to be securely retried so that the\n\t\t\tintended outcome will only occur once, retries receive a similar response, and there are\n\t\t\tno additional edge cases to handle.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateCidrCollectionResponse": {
+            "type": "structure",
+            "members": {
+                "Collection": {
+                    "target": "com.amazonaws.route53#CidrCollection",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the CIDR collection.</p>"
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique URL that represents the location for the CIDR collection.</p>",
+                        "smithy.api#httpHeader": "Location"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateHealthCheck": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateHealthCheckRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateHealthCheckResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#HealthCheckAlreadyExists"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyHealthChecks"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new health check.</p>\n         <p>For information about adding health checks to resource record sets, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html#Route53-Type-ResourceRecordSet-HealthCheckId\">HealthCheckId</a> in <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html\">ChangeResourceRecordSets</a>. </p>\n         <p>\n            <b>ELB Load Balancers</b>\n         </p>\n         <p>If you're registering EC2 instances with an Elastic Load Balancing (ELB) load\n\t\t\tbalancer, do not create Amazon Route 53 health checks for the EC2 instances. When you\n\t\t\tregister an EC2 instance with a load balancer, you configure settings for an ELB health\n\t\t\tcheck, which performs a similar function to a Route 53 health check.</p>\n         <p>\n            <b>Private Hosted Zones</b>\n         </p>\n         <p>You can associate health checks with failover resource record sets in a private hosted\n\t\t\tzone. Note the following:</p>\n         <ul>\n            <li>\n               <p>Route 53 health checkers are outside the VPC. To check the health of an\n\t\t\t\t\tendpoint within a VPC by IP address, you must assign a public IP address to the\n\t\t\t\t\tinstance in the VPC.</p>\n            </li>\n            <li>\n               <p>You can configure a health checker to check the health of an external resource\n\t\t\t\t\tthat the instance relies on, such as a database server.</p>\n            </li>\n            <li>\n               <p>You can create a CloudWatch metric, associate an alarm with the metric, and\n\t\t\t\t\tthen create a health check that is based on the state of the alarm. For example,\n\t\t\t\t\tyou might create a CloudWatch metric that checks the status of the Amazon EC2\n\t\t\t\t\t\t<code>StatusCheckFailed</code> metric, add an alarm to the metric, and then\n\t\t\t\t\tcreate a health check that is based on the state of the alarm. For information\n\t\t\t\t\tabout creating CloudWatch metrics and alarms by using the CloudWatch console,\n\t\t\t\t\tsee the <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatch.html\">Amazon\n\t\t\t\t\t\tCloudWatch User Guide</a>.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/healthcheck",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateHealthCheckRequest": {
+            "type": "structure",
+            "members": {
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#HealthCheckNonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string that identifies the request and that allows you to retry a failed\n\t\t\t\t<code>CreateHealthCheck</code> request without the risk of creating two identical\n\t\t\thealth checks:</p>\n         <ul>\n            <li>\n               <p>If you send a <code>CreateHealthCheck</code> request with the same\n\t\t\t\t\t\t<code>CallerReference</code> and settings as a previous request, and if the\n\t\t\t\t\thealth check doesn't exist, Amazon Route 53 creates the health check. If the\n\t\t\t\t\thealth check does exist, Route 53 returns the settings for the existing health\n\t\t\t\t\tcheck.</p>\n            </li>\n            <li>\n               <p>If you send a <code>CreateHealthCheck</code> request with the same\n\t\t\t\t\t\t<code>CallerReference</code> as a deleted health check, regardless of the\n\t\t\t\t\tsettings, Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p>\n            </li>\n            <li>\n               <p>If you send a <code>CreateHealthCheck</code> request with the same\n\t\t\t\t\t\t<code>CallerReference</code> as an existing health check but with different\n\t\t\t\t\tsettings, Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p>\n            </li>\n            <li>\n               <p>If you send a <code>CreateHealthCheck</code> request with a unique\n\t\t\t\t\t\t<code>CallerReference</code> but settings identical to an existing health\n\t\t\t\t\tcheck, Route 53 creates the health check.</p>\n            </li>\n         </ul>\n         <p> Route 53 does not store the <code>CallerReference</code> for a deleted health check indefinitely. \n\t\t\tThe <code>CallerReference</code> for a deleted health check will be deleted after a number of days.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HealthCheckConfig": {
+                    "target": "com.amazonaws.route53#HealthCheckConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for a new health check.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the health check request information.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateHealthCheckResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheck": {
+                    "target": "com.amazonaws.route53#HealthCheck",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains identifying information about the health check.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL representing the new health check.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing the response information for the new health check.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConflictingDomainExists"
+                },
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotAvailable"
+                },
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotReusable"
+                },
+                {
+                    "target": "com.amazonaws.route53#HostedZoneAlreadyExists"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidDomainName"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidVPCId"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchDelegationSet"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyHostedZones"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new public or private hosted zone. You create records in a public hosted\n\t\t\tzone to define how you want to route traffic on the internet for a domain, such as\n\t\t\texample.com, and its subdomains (apex.example.com, acme.example.com). You create records\n\t\t\tin a private hosted zone to define how you want to route traffic for a domain and its\n\t\t\tsubdomains within one or more Amazon Virtual Private Clouds (Amazon VPCs). </p>\n         <important>\n            <p>You can't convert a public hosted zone to a private hosted zone or vice versa.\n\t\t\t\tInstead, you must create a new hosted zone with the same name and create new\n\t\t\t\tresource record sets.</p>\n         </important>\n         <p>For more information about charges for hosted zones, see <a href=\"http://aws.amazon.com/route53/pricing/\">Amazon Route 53 Pricing</a>.</p>\n         <p>Note the following:</p>\n         <ul>\n            <li>\n               <p>You can't create a hosted zone for a top-level domain (TLD) such as\n\t\t\t\t\t.com.</p>\n            </li>\n            <li>\n               <p>For public hosted zones, Route 53 automatically creates a default SOA record\n\t\t\t\t\tand four NS records for the zone. For more information about SOA and NS records,\n\t\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html\">NS and SOA Records\n\t\t\t\t\t\tthat Route 53 Creates for a Hosted Zone</a> in the\n\t\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n               <p>If you want to use the same name servers for multiple public hosted zones, you\n\t\t\t\t\tcan optionally associate a reusable delegation set with the hosted zone. See the\n\t\t\t\t\t\t<code>DelegationSetId</code> element.</p>\n            </li>\n            <li>\n               <p>If your domain is registered with a registrar other than Route 53,\n\t\t\t\t\tyou must update the name servers with your registrar to make Route 53 the DNS\n\t\t\t\t\tservice for the domain. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html\">Migrating DNS Service\n\t\t\t\t\t\tfor an Existing Domain to Amazon Route 53</a> in the\n\t\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>. </p>\n            </li>\n         </ul>\n         <p>When you submit a <code>CreateHostedZone</code> request, the initial status of the\n\t\t\thosted zone is <code>PENDING</code>. For public hosted zones, this means that the NS and\n\t\t\tSOA records are not yet available on all Route 53 DNS servers. When the NS and\n\t\t\tSOA records are available, the status of the zone changes to <code>INSYNC</code>.</p>\n         <p>The <code>CreateHostedZone</code> request requires the caller to have an\n\t\t\t\t<code>ec2:DescribeVpcs</code> permission.</p>\n         <note>\n            <p>When creating private hosted zones, the Amazon VPC must belong to the same\n\t\t\t\tpartition where the hosted zone is created. A partition is a group of Amazon Web Services Regions. Each Amazon Web Services account is scoped to one\n\t\t\t\tpartition.</p>\n            <p>The following are the supported partitions:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>aws</code> - Amazon Web Services Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-cn</code> - China Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-us-gov</code> - Amazon Web Services GovCloud (US) Region</p>\n               </li>\n            </ul>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Access Management</a>\n\t\t\t\tin the <i>Amazon Web Services General Reference</i>.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the domain. Specify a fully qualified domain name, for example,\n\t\t\t\t<i>www.example.com</i>. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that\n\t\t\t\tRoute 53 treats <i>www.example.com</i> (without a trailing\n\t\t\tdot) and <i>www.example.com.</i> (with a trailing dot) as\n\t\t\tidentical.</p>\n         <p>If you're creating a public hosted zone, this is the name you have registered with\n\t\t\tyour DNS registrar. If your domain name is registered with a registrar other than\n\t\t\t\tRoute 53, change the name servers for your domain to the set of\n\t\t\t\t<code>NameServers</code> that <code>CreateHostedZone</code> returns in\n\t\t\t\t<code>DelegationSet</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Private hosted zones only) A complex type that contains information about the Amazon\n\t\t\tVPC that you're associating with this hosted zone.</p>\n         <p>You can specify only one Amazon VPC when you create a private hosted zone. If you are\n\t\t\tassociating a VPC with a hosted zone with this request, the paramaters\n\t\t\t\t<code>VPCId</code> and <code>VPCRegion</code> are also required.</p>\n         <p>To associate additional Amazon VPCs with the hosted zone, use <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_AssociateVPCWithHostedZone.html\">AssociateVPCWithHostedZone</a> after you create a hosted zone.</p>"
+                    }
+                },
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#Nonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string that identifies the request and that allows failed\n\t\t\t\t<code>CreateHostedZone</code> requests to be retried without the risk of executing\n\t\t\tthe operation twice. You must use a unique <code>CallerReference</code> string every\n\t\t\ttime you submit a <code>CreateHostedZone</code> request. <code>CallerReference</code>\n\t\t\tcan be any unique string, for example, a date/time stamp.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneConfig": {
+                    "target": "com.amazonaws.route53#HostedZoneConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) A complex type that contains the following optional values:</p>\n         <ul>\n            <li>\n               <p>For public and private hosted zones, an optional comment</p>\n            </li>\n            <li>\n               <p>For private hosted zones, an optional <code>PrivateZone</code> element</p>\n            </li>\n         </ul>\n         <p>If you don't specify a comment or the <code>PrivateZone</code> element, omit\n\t\t\t\t<code>HostedZoneConfig</code> and the other elements.</p>"
+                    }
+                },
+                "DelegationSetId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you want to associate a reusable delegation set with this hosted zone, the ID that\n\t\t\t\tAmazon Route 53 assigned to the reusable delegation set when you created it.\n\t\t\tFor more information about reusable delegation sets, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html\">CreateReusableDelegationSet</a>.</p>\n         <p>If you are using a reusable delegation set to create a public hosted zone for a subdomain,\n\t\t\tmake sure that the parent hosted zone doesn't use one or more of the same name servers.\n\t\t\tIf you have overlapping nameservers, the operation will cause a\n\t\t\t\t<code>ConflictingDomainsExist</code> error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to create a public or\n\t\t\tprivate hosted zone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZone": {
+                    "target": "com.amazonaws.route53#HostedZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains general information about the hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the <code>CreateHostedZone</code>\n\t\t\trequest.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DelegationSet": {
+                    "target": "com.amazonaws.route53#DelegationSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that describes the name servers for this hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about an Amazon VPC that you associated with\n\t\t\tthis hosted zone.</p>"
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL representing the new hosted zone.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing the response information for the hosted zone.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateKeySigningKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateKeySigningKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateKeySigningKeyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidArgument"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyName"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKMSArn"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidSigningStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#KeySigningKeyAlreadyExists"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyKeySigningKeys"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new key-signing key (KSK) associated with a hosted zone. You can only have\n\t\t\ttwo KSKs per hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/keysigningkey",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateKeySigningKeyRequest": {
+            "type": "structure",
+            "members": {
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#Nonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string that identifies the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique string (ID) used to identify a hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "KeyManagementServiceArn": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon resource name (ARN) for a customer managed key in Key Management Service\n\t\t\t\t(KMS). The <code>KeyManagementServiceArn</code> must be unique for\n\t\t\teach key-signing key (KSK) in a single hosted zone. To see an example of\n\t\t\t\t<code>KeyManagementServiceArn</code> that grants the correct permissions for DNSSEC,\n\t\t\tscroll down to <b>Example</b>. </p>\n         <p>You must configure the customer managed customer managed key as follows:</p>\n         <dl>\n            <dt>Status</dt>\n            <dd>\n               <p>Enabled</p>\n            </dd>\n            <dt>Key spec</dt>\n            <dd>\n               <p>ECC_NIST_P256</p>\n            </dd>\n            <dt>Key usage</dt>\n            <dd>\n               <p>Sign and verify</p>\n            </dd>\n            <dt>Key policy</dt>\n            <dd>\n               <p>The key policy must give permission for the following actions:</p>\n               <ul>\n                  <li>\n                     <p>DescribeKey</p>\n                  </li>\n                  <li>\n                     <p>GetPublicKey</p>\n                  </li>\n                  <li>\n                     <p>Sign</p>\n                  </li>\n               </ul>\n               <p>The key policy must also include the Amazon Route 53 service in the\n\t\t\t\t\t\tprincipal for your account. Specify the following:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>\"Service\": \"dnssec-route53.amazonaws.com\"</code>\n                     </p>\n                  </li>\n               </ul>\n            </dd>\n         </dl>\n         <p>For more information about working with a customer managed key in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html\">Key Management Service concepts</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#SigningKeyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to identify a key-signing key (KSK). <code>Name</code> can include\n\t\t\tnumbers, letters, and underscores (_). <code>Name</code> must be unique for each\n\t\t\tkey-signing key in the same hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.route53#SigningKeyStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string specifying the initial status of the key-signing key (KSK). You can set the\n\t\t\tvalue to <code>ACTIVE</code> or <code>INACTIVE</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateKeySigningKeyResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "KeySigningKey": {
+                    "target": "com.amazonaws.route53#KeySigningKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-signing key (KSK) that the request creates.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL representing the new key-signing key (KSK).</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateQueryLoggingConfig": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateQueryLoggingConfigRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateQueryLoggingConfigResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InsufficientCloudWatchLogsResourcePolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCloudWatchLogsLogGroup"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#QueryLoggingConfigAlreadyExists"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a configuration for DNS query logging. After you create a query logging\n\t\t\tconfiguration, Amazon Route 53 begins to publish log data to an Amazon CloudWatch Logs\n\t\t\tlog group.</p>\n         <p>DNS query logs contain information about the queries that Route 53 receives for a\n\t\t\tspecified public hosted zone, such as the following:</p>\n         <ul>\n            <li>\n               <p>Route 53 edge location that responded to the DNS query</p>\n            </li>\n            <li>\n               <p>Domain or subdomain that was requested</p>\n            </li>\n            <li>\n               <p>DNS record type, such as A or AAAA</p>\n            </li>\n            <li>\n               <p>DNS response code, such as <code>NoError</code> or\n\t\t\t\t\t<code>ServFail</code>\n               </p>\n            </li>\n         </ul>\n         <dl>\n            <dt>Log Group and Resource Policy</dt>\n            <dd>\n               <p>Before you create a query logging configuration, perform the following\n\t\t\t\t\t\toperations.</p>\n               <note>\n                  <p>If you create a query logging configuration using the Route 53\n\t\t\t\t\t\t\tconsole, Route 53 performs these operations automatically.</p>\n               </note>\n               <ol>\n                  <li>\n                     <p>Create a CloudWatch Logs log group, and make note of the ARN,\n\t\t\t\t\t\t\t\twhich you specify when you create a query logging configuration.\n\t\t\t\t\t\t\t\tNote the following:</p>\n                     <ul>\n                        <li>\n                           <p>You must create the log group in the us-east-1\n\t\t\t\t\t\t\t\t\t\tregion.</p>\n                        </li>\n                        <li>\n                           <p>You must use the same Amazon Web Services account to create\n\t\t\t\t\t\t\t\t\t\tthe log group and the hosted zone that you want to configure\n\t\t\t\t\t\t\t\t\t\tquery logging for.</p>\n                        </li>\n                        <li>\n                           <p>When you create log groups for query logging, we recommend\n\t\t\t\t\t\t\t\t\t\tthat you use a consistent prefix, for example:</p>\n                           <p>\n                              <code>/aws/route53/<i>hosted zone\n\t\t\t\t\t\t\t\t\t\t\tname</i>\n                              </code>\n                           </p>\n                           <p>In the next step, you'll create a resource policy, which\n\t\t\t\t\t\t\t\t\t\tcontrols access to one or more log groups and the associated\n\t\t\t\t\t\t\t\t\t\t\tAmazon Web Services resources, such as Route 53 hosted\n\t\t\t\t\t\t\t\t\t\tzones. There's a limit on the number of resource policies\n\t\t\t\t\t\t\t\t\t\tthat you can create, so we recommend that you use a\n\t\t\t\t\t\t\t\t\t\tconsistent prefix so you can use the same resource policy\n\t\t\t\t\t\t\t\t\t\tfor all the log groups that you create for query\n\t\t\t\t\t\t\t\t\t\tlogging.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>Create a CloudWatch Logs resource policy, and give it the\n\t\t\t\t\t\t\t\tpermissions that Route 53 needs to create log streams and to send\n\t\t\t\t\t\t\t\tquery logs to log streams. You must create the CloudWatch Logs resource policy in the us-east-1\n\t\t\t\t\t\t\t\t\tregion. For the value of <code>Resource</code>,\n\t\t\t\t\t\t\t\tspecify the ARN for the log group that you created in the previous\n\t\t\t\t\t\t\t\tstep. To use the same resource policy for all the CloudWatch Logs\n\t\t\t\t\t\t\t\tlog groups that you created for query logging configurations,\n\t\t\t\t\t\t\t\treplace the hosted zone name with <code>*</code>, for\n\t\t\t\t\t\t\t\texample:</p>\n                     <p>\n                        <code>arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*</code>\n                     </p>\n                     <p>To avoid the confused deputy problem, a security issue where an\n\t\t\t\t\t\t\t\tentity without a permission for an action can coerce a\n\t\t\t\t\t\t\t\tmore-privileged entity to perform it, you can optionally limit the\n\t\t\t\t\t\t\t\tpermissions that a service has to a resource in a resource-based\n\t\t\t\t\t\t\t\tpolicy by supplying the following values:</p>\n                     <ul>\n                        <li>\n                           <p>For <code>aws:SourceArn</code>, supply the hosted zone ARN\n\t\t\t\t\t\t\t\t\t\tused in creating the query logging configuration. For\n\t\t\t\t\t\t\t\t\t\texample, <code>aws:SourceArn:\n\t\t\t\t\t\t\t\t\t\t\tarn:aws:route53:::hostedzone/hosted zone\n\t\t\t\t\t\t\t\t\t\tID</code>.</p>\n                        </li>\n                        <li>\n                           <p>For <code>aws:SourceAccount</code>, supply the account ID\n\t\t\t\t\t\t\t\t\t\tfor the account that creates the query logging\n\t\t\t\t\t\t\t\t\t\tconfiguration. For example,\n\t\t\t\t\t\t\t\t\t\t\t<code>aws:SourceAccount:111111111111</code>.</p>\n                        </li>\n                     </ul>\n                     <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html\">The confused\n\t\t\t\t\t\t\t\t\tdeputy problem</a> in the <i>Amazon Web Services\n\t\t\t\t\t\t\t\t\tIAM User Guide</i>.</p>\n                     <note>\n                        <p>You can't use the CloudWatch console to create or edit a\n\t\t\t\t\t\t\t\t\tresource policy. You must use the CloudWatch API, one of the\n\t\t\t\t\t\t\t\t\t\tAmazon Web Services SDKs, or the CLI.</p>\n                     </note>\n                  </li>\n               </ol>\n            </dd>\n            <dt>Log Streams and Edge Locations</dt>\n            <dd>\n               <p>When Route 53 finishes creating the configuration for DNS query logging,\n\t\t\t\t\t\tit does the following:</p>\n               <ul>\n                  <li>\n                     <p>Creates a log stream for an edge location the first time that the\n\t\t\t\t\t\t\t\tedge location responds to DNS queries for the specified hosted zone.\n\t\t\t\t\t\t\t\tThat log stream is used to log all queries that Route 53 responds to\n\t\t\t\t\t\t\t\tfor that edge location.</p>\n                  </li>\n                  <li>\n                     <p>Begins to send query logs to the applicable log stream.</p>\n                  </li>\n               </ul>\n               <p>The name of each log stream is in the following format:</p>\n               <p>\n                  <code>\n                     <i>hosted zone ID</i>/<i>edge location\n\t\t\t\t\t\t\t\tcode</i>\n                  </code>\n               </p>\n               <p>The edge location code is a three-letter code and an arbitrarily assigned\n\t\t\t\t\t\tnumber, for example, DFW3. The three-letter code typically corresponds with\n\t\t\t\t\t\tthe International Air Transport Association airport code for an airport near\n\t\t\t\t\t\tthe edge location. (These abbreviations might change in the future.) For a\n\t\t\t\t\t\tlist of edge locations, see \"The Route 53 Global Network\" on the <a href=\"http://aws.amazon.com/route53/details/\">Route 53 Product Details</a>\n\t\t\t\t\t\tpage.</p>\n            </dd>\n            <dt>Queries That Are Logged</dt>\n            <dd>\n               <p>Query logs contain only the queries that DNS resolvers forward to Route\n\t\t\t\t\t\t53. If a DNS resolver has already cached the response to a query (such as\n\t\t\t\t\t\tthe IP address for a load balancer for example.com), the resolver will\n\t\t\t\t\t\tcontinue to return the cached response. It doesn't forward another query to\n\t\t\t\t\t\tRoute 53 until the TTL for the corresponding resource record set expires.\n\t\t\t\t\t\tDepending on how many DNS queries are submitted for a resource record set,\n\t\t\t\t\t\tand depending on the TTL for that resource record set, query logs might\n\t\t\t\t\t\tcontain information about only one query out of every several thousand\n\t\t\t\t\t\tqueries that are submitted to DNS. For more information about how DNS works,\n\t\t\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html\">Routing\n\t\t\t\t\t\t\tInternet Traffic to Your Website or Web Application</a> in the\n\t\t\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n            </dd>\n            <dt>Log File Format</dt>\n            <dd>\n               <p>For a list of the values in each query log and the format of each value,\n\t\t\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html\">Logging DNS\n\t\t\t\t\t\t\tQueries</a> in the <i>Amazon Route 53 Developer\n\t\t\t\t\t\t\tGuide</i>.</p>\n            </dd>\n            <dt>Pricing</dt>\n            <dd>\n               <p>For information about charges for query logs, see <a href=\"http://aws.amazon.com/cloudwatch/pricing/\">Amazon CloudWatch Pricing</a>.</p>\n            </dd>\n            <dt>How to Stop Logging</dt>\n            <dd>\n               <p>If you want Route 53 to stop sending query logs to CloudWatch Logs, delete\n\t\t\t\t\t\tthe query logging configuration. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html\">DeleteQueryLoggingConfig</a>.</p>\n            </dd>\n         </dl>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/queryloggingconfig",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateQueryLoggingConfigRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want to log queries for. You can log queries only\n\t\t\tfor public hosted zones.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CloudWatchLogsLogGroupArn": {
+                    "target": "com.amazonaws.route53#CloudWatchLogsLogGroupArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the log group that you want to Amazon Route 53 to\n\t\t\tsend query logs to. This is the format of the ARN:</p>\n         <p>arn:aws:logs:<i>region</i>:<i>account-id</i>:log-group:<i>log_group_name</i>\n         </p>\n         <p>To get the ARN for a log group, you can use the CloudWatch console, the <a href=\"https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html\">DescribeLogGroups</a> API action, the <a href=\"https://docs.aws.amazon.com/cli/latest/reference/logs/describe-log-groups.html\">describe-log-groups</a>\n\t\t\tcommand, or the applicable command in one of the Amazon Web Services SDKs.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateQueryLoggingConfigResponse": {
+            "type": "structure",
+            "members": {
+                "QueryLoggingConfig": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the ID for a query logging configuration, the ID of the\n\t\t\thosted zone that you want to log queries for, and the ARN for the log group that you\n\t\t\twant Amazon Route 53 to send query logs to.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL representing the new query logging configuration.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateReusableDelegationSet": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateReusableDelegationSetRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateReusableDelegationSetResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#DelegationSetAlreadyCreated"
+                },
+                {
+                    "target": "com.amazonaws.route53#DelegationSetAlreadyReusable"
+                },
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotAvailable"
+                },
+                {
+                    "target": "com.amazonaws.route53#HostedZoneNotFound"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidArgument"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#LimitsExceeded"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a delegation set (a group of four name servers) that can be reused by multiple\n\t\t\thosted zones that were created by the same Amazon Web Services account. </p>\n         <p>You can also create a reusable delegation set that uses the four name servers that are\n\t\t\tassociated with an existing hosted zone. Specify the hosted zone ID in the\n\t\t\t\t<code>CreateReusableDelegationSet</code> request.</p>\n         <note>\n            <p>You can't associate a reusable delegation set with a private hosted zone.</p>\n         </note>\n         <p>For information about using a reusable delegation set to configure white label name\n\t\t\tservers, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/white-label-name-servers.html\">Configuring White\n\t\t\t\tLabel Name Servers</a>.</p>\n         <p>The process for migrating existing hosted zones to use a reusable delegation set is\n\t\t\tcomparable to the process for configuring white label name servers. You need to perform\n\t\t\tthe following steps:</p>\n         <ol>\n            <li>\n               <p>Create a reusable delegation set.</p>\n            </li>\n            <li>\n               <p>Recreate hosted zones, and reduce the TTL to 60 seconds or less.</p>\n            </li>\n            <li>\n               <p>Recreate resource record sets in the new hosted zones.</p>\n            </li>\n            <li>\n               <p>Change the registrar's name servers to use the name servers for the new hosted\n\t\t\t\t\tzones.</p>\n            </li>\n            <li>\n               <p>Monitor traffic for the website or application.</p>\n            </li>\n            <li>\n               <p>Change TTLs back to their original values.</p>\n            </li>\n         </ol>\n         <p>If you want to migrate existing hosted zones to use a reusable delegation set, the\n\t\t\texisting hosted zones can't use any of the name servers that are assigned to the\n\t\t\treusable delegation set. If one or more hosted zones do use one or more name servers\n\t\t\tthat are assigned to the reusable delegation set, you can do one of the\n\t\t\tfollowing:</p>\n         <ul>\n            <li>\n               <p>For small numbers of hosted zones—up to a few hundred—it's\n\t\t\t\t\trelatively easy to create reusable delegation sets until you get one that has\n\t\t\t\t\tfour name servers that don't overlap with any of the name servers in your hosted\n\t\t\t\t\tzones.</p>\n            </li>\n            <li>\n               <p>For larger numbers of hosted zones, the easiest solution is to use more than\n\t\t\t\t\tone reusable delegation set.</p>\n            </li>\n            <li>\n               <p>For larger numbers of hosted zones, you can also migrate hosted zones that\n\t\t\t\t\thave overlapping name servers to hosted zones that don't have overlapping name\n\t\t\t\t\tservers, then migrate the hosted zones again to use the reusable delegation\n\t\t\t\t\tset.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/delegationset",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateReusableDelegationSetRequest": {
+            "type": "structure",
+            "members": {
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#Nonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string that identifies the request, and that allows you to retry failed\n\t\t\t\t<code>CreateReusableDelegationSet</code> requests without the risk of executing the\n\t\t\toperation twice. You must use a unique <code>CallerReference</code> string every time\n\t\t\tyou submit a <code>CreateReusableDelegationSet</code> request.\n\t\t\t\t<code>CallerReference</code> can be any unique string, for example a date/time\n\t\t\tstamp.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you want to mark the delegation set for an existing hosted zone as reusable, the ID\n\t\t\tfor that hosted zone.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateReusableDelegationSetResponse": {
+            "type": "structure",
+            "members": {
+                "DelegationSet": {
+                    "target": "com.amazonaws.route53#DelegationSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains name server information.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique URL representing the new reusable delegation set.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicy": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidTrafficPolicyDocument"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyTrafficPolicies"
+                },
+                {
+                    "target": "com.amazonaws.route53#TrafficPolicyAlreadyExists"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a traffic policy, which you use to create multiple DNS resource record sets\n\t\t\tfor one domain name (such as example.com) or one subdomain name (such as\n\t\t\twww.example.com).</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/trafficpolicy",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyInstance": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyInstanceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyInstanceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyTrafficPolicyInstances"
+                },
+                {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceAlreadyExists"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates resource record sets in a specified hosted zone based on the settings in a\n\t\t\tspecified traffic policy version. In addition, <code>CreateTrafficPolicyInstance</code>\n\t\t\tassociates the resource record sets with a specified domain name (such as example.com)\n\t\t\tor subdomain name (such as www.example.com). Amazon Route 53 responds to DNS queries for\n\t\t\tthe domain or subdomain name by using the resource record sets that\n\t\t\t\t<code>CreateTrafficPolicyInstance</code> created.</p>\n         <note>\n            <p>After you submit an <code>CreateTrafficPolicyInstance</code> request, there's a\n\t\t\t\tbrief delay while Amazon Route 53 creates the resource record sets that are\n\t\t\t\tspecified in the traffic policy definition. \n\t\t\t\tUse <code>GetTrafficPolicyInstance</code> with the <code>id</code> of new traffic policy instance to confirm that the <code>CreateTrafficPolicyInstance</code>\n\t\t\t\trequest completed successfully. For more information, see the\n\t\t\t\t<code>State</code> response element.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/trafficpolicyinstance",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyInstanceRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want Amazon Route 53 to create resource record sets\n\t\t\tin by using the configuration in a traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name (such as example.com) or subdomain name (such as www.example.com) for\n\t\t\twhich Amazon Route 53 responds to DNS queries by using the resource record sets that\n\t\t\tRoute 53 creates for this traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TTL": {
+                    "target": "com.amazonaws.route53#TTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The TTL that you want Amazon Route 53 to assign to all of the resource\n\t\t\trecord sets that it creates in the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyId": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy that you want to use to create resource record sets in\n\t\t\tthe specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersion": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the traffic policy that you want to use to create resource record sets\n\t\t\tin the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the resource record sets that you want\n\t\t\tto create based on a specified traffic policy.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyInstanceResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstance": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstance",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the new traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique URL that represents a new traffic policy instance.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the\n\t\t\t\t<code>CreateTrafficPolicyInstance</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyRequest": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#TrafficPolicyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Document": {
+                    "target": "com.amazonaws.route53#TrafficPolicyDocument",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The definition of this traffic policy in JSON format. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html\">Traffic Policy Document Format</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#TrafficPolicyComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) Any comments that you want to include about the traffic policy.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the traffic policy that you want to\n\t\t\tcreate.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicy": {
+                    "target": "com.amazonaws.route53#TrafficPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the new traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique URL that represents a new traffic policy.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the\n\t\t\t\t<code>CreateTrafficPolicy</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateTrafficPolicyVersionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidTrafficPolicyDocument"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyTrafficPolicyVersionsForCurrentPolicy"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new version of an existing traffic policy. When you create a new version of\n\t\t\ta traffic policy, you specify the ID of the traffic policy that you want to update and a\n\t\t\tJSON-formatted document that describes the new version. You use traffic policies to\n\t\t\tcreate multiple DNS resource record sets for one domain name (such as example.com) or\n\t\t\tone subdomain name (such as www.example.com). You can create a maximum of 1000 versions\n\t\t\tof a traffic policy. If you reach the limit and need to create another version, you'll\n\t\t\tneed to start a new traffic policy.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/trafficpolicy/{Id}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyVersionRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy for which you want to create a new version.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Document": {
+                    "target": "com.amazonaws.route53#TrafficPolicyDocument",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The definition of this version of the traffic policy, in JSON format. You specified\n\t\t\tthe JSON in the <code>CreateTrafficPolicyVersion</code> request. For more information\n\t\t\tabout the JSON format, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateTrafficPolicy.html\">CreateTrafficPolicy</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#TrafficPolicyComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The comment that you specified in the <code>CreateTrafficPolicyVersion</code> request,\n\t\t\tif any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the traffic policy that you want to\n\t\t\tcreate a new version for.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateTrafficPolicyVersionResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicy": {
+                    "target": "com.amazonaws.route53#TrafficPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the new version of the traffic\n\t\t\tpolicy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Location": {
+                    "target": "com.amazonaws.route53#ResourceURI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique URL that represents a new traffic policy version.</p>",
+                        "smithy.api#httpHeader": "Location",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the\n\t\t\t\t<code>CreateTrafficPolicyVersion</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#CreateVPCAssociationAuthorization": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#CreateVPCAssociationAuthorizationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#CreateVPCAssociationAuthorizationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidVPCId"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#TooManyVPCAssociationAuthorizations"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Authorizes the Amazon Web Services account that created a specified VPC to submit an\n\t\t\t\t<code>AssociateVPCWithHostedZone</code> request to associate the VPC with a\n\t\t\tspecified hosted zone that was created by a different account. To submit a\n\t\t\t\t<code>CreateVPCAssociationAuthorization</code> request, you must use the account\n\t\t\tthat created the hosted zone. After you authorize the association, use the account that\n\t\t\tcreated the VPC to submit an <code>AssociateVPCWithHostedZone</code> request.</p>\n         <note>\n            <p>If you want to associate multiple VPCs that you created by using one account with\n\t\t\t\ta hosted zone that you created by using a different account, you must submit one\n\t\t\t\tauthorization request for each VPC.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/authorizevpcassociation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#CreateVPCAssociationAuthorizationRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the private hosted zone that you want to authorize associating a VPC\n\t\t\twith.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the VPC ID and region for the VPC that you want to\n\t\t\tauthorize associating with your hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to authorize associating a\n\t\t\tVPC with your private hosted zone. Authorization is only required when a private hosted\n\t\t\tzone and a VPC were created by using different accounts.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#CreateVPCAssociationAuthorizationResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you authorized associating a VPC with.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The VPC that you authorized associating with a hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information from a\n\t\t\t\t<code>CreateVPCAssociationAuthorization</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DNSName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#DNSRCode": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#DNSSECNotFound": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The hosted zone doesn't have any DNSSEC resources.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#DNSSECStatus": {
+            "type": "structure",
+            "members": {
+                "ServeSignature": {
+                    "target": "com.amazonaws.route53#ServeSignature",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string that represents the current hosted zone signing status.</p>\n         <p>Status can have one of the following values:</p>\n         <dl>\n            <dt>SIGNING</dt>\n            <dd>\n               <p>DNSSEC signing is enabled for the hosted zone.</p>\n            </dd>\n            <dt>NOT_SIGNING</dt>\n            <dd>\n               <p>DNSSEC signing is not enabled for the hosted zone.</p>\n            </dd>\n            <dt>DELETING</dt>\n            <dd>\n               <p>DNSSEC signing is in the process of being removed for the hosted\n\t\t\t\t\t\tzone.</p>\n            </dd>\n            <dt>ACTION_NEEDED</dt>\n            <dd>\n               <p>There is a problem with signing in the hosted zone that requires you to\n\t\t\t\t\t\ttake action to resolve. For example, the customer managed key might have\n\t\t\t\t\t\tbeen deleted, or the permissions for the customer managed key might have\n\t\t\t\t\t\tbeen changed.</p>\n            </dd>\n            <dt>INTERNAL_FAILURE</dt>\n            <dd>\n               <p>There was an error during a request. Before you can continue to work with\n\t\t\t\t\t\tDNSSEC signing, including with key-signing keys (KSKs), you must correct the\n\t\t\t\t\t\tproblem by enabling or disabling DNSSEC signing for the hosted zone.</p>\n            </dd>\n         </dl>"
+                    }
+                },
+                "StatusMessage": {
+                    "target": "com.amazonaws.route53#SigningKeyStatusMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status message provided for the following DNSSEC signing status:\n\t\t\t\t<code>INTERNAL_FAILURE</code>. The status message includes information about what\n\t\t\tthe problem might be and steps that you can take to correct the issue.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A string representing the status of DNSSEC signing.</p>"
+            }
+        },
+        "com.amazonaws.route53#DeactivateKeySigningKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeactivateKeySigningKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeactivateKeySigningKeyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidSigningStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#KeySigningKeyInParentDSRecord"
+                },
+                {
+                    "target": "com.amazonaws.route53#KeySigningKeyInUse"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchKeySigningKey"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deactivates a key-signing key (KSK) so that it will not be used for signing by DNSSEC.\n\t\t\tThis operation changes the KSK status to <code>INACTIVE</code>.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/keysigningkey/{HostedZoneId}/{Name}/deactivate",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeactivateKeySigningKeyRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#SigningKeyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to identify a key-signing key (KSK).</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeactivateKeySigningKeyResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DelegationSet": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigns to a reusable delegation set.</p>"
+                    }
+                },
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#Nonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for <code>CallerReference</code> when you created the\n\t\t\treusable delegation set.</p>"
+                    }
+                },
+                "NameServers": {
+                    "target": "com.amazonaws.route53#DelegationSetNameServers",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains a list of the authoritative name servers for a hosted\n\t\t\tzone or for a reusable delegation set.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that lists the name servers in a delegation set, as well as the\n\t\t\t\t<code>CallerReference</code> and the <code>ID</code> for the delegation set.</p>"
+            }
+        },
+        "com.amazonaws.route53#DelegationSetAlreadyCreated": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A delegation set with the same owner and caller reference combination has already been\n\t\t\tcreated.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#DelegationSetAlreadyReusable": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified delegation set has already been marked as reusable.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#DelegationSetInUse": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified delegation contains associated hosted zones which must be deleted before\n\t\t\tthe reusable delegation set can be deleted.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#DelegationSetNameServers": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#DNSName",
+                "traits": {
+                    "smithy.api#xmlName": "NameServer"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#DelegationSetNotAvailable": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You can create a hosted zone that has the same name as an existing hosted zone\n\t\t\t(example.com is common), but there is a limit to the number of hosted zones that have\n\t\t\tthe same name. If you get this error, Amazon Route 53 has reached that limit. If you own\n\t\t\tthe domain name and Route 53 generates this error, contact Customer Support.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#DelegationSetNotReusable": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A reusable delegation set with the specified ID does not exist.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#DelegationSets": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#DelegationSet",
+                "traits": {
+                    "smithy.api#xmlName": "DelegationSet"
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteCidrCollection": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteCidrCollectionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteCidrCollectionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#CidrCollectionInUseException"
+                },
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCidrCollectionException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a CIDR collection in the current Amazon Web Services account. The collection\n\t\t\tmust be empty before it can be deleted.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/cidrcollection/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteCidrCollectionRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The UUID of the collection to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteCidrCollectionResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteHealthCheck": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteHealthCheckRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteHealthCheckResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#HealthCheckInUse"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a health check.</p>\n         <important>\n            <p>Amazon Route 53 does not prevent you from deleting a health check even if the\n\t\t\t\thealth check is associated with one or more resource record sets. If you delete a\n\t\t\t\thealth check and you don't update the associated resource record sets, the future\n\t\t\t\tstatus of the health check can't be predicted and may change. This will affect the\n\t\t\t\trouting of DNS queries for your DNS failover configuration. For more information,\n\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html#health-checks-deleting.html\">Replacing and Deleting Health Checks</a> in the <i>Amazon Route 53\n\t\t\t\t\tDeveloper Guide</i>.</p>\n         </important>\n         <p>If you're using Cloud Map and you configured Cloud Map to create a Route 53\n\t\t\thealth check when you register an instance, you can't use the Route 53\n\t\t\t\t<code>DeleteHealthCheck</code> command to delete the health check. The health check\n\t\t\tis deleted automatically when you deregister the instance; there can be a delay of\n\t\t\tseveral hours before the health check is deleted from Route 53. </p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/healthcheck/{HealthCheckId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteHealthCheckRequest": {
+            "type": "structure",
+            "members": {
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the health check that you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This action deletes a health check.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteHealthCheckResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>An empty element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#HostedZoneNotEmpty"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidDomainName"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a hosted zone.</p>\n         <p>If the hosted zone was created by another service, such as Cloud Map, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DeleteHostedZone.html#delete-public-hosted-zone-created-by-another-service\">Deleting Public Hosted Zones That Were Created by Another Service</a> in the\n\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i> for information\n\t\t\tabout how to delete it. (The process is the same for public and private hosted zones\n\t\t\tthat were created by another service.)</p>\n         <p>If you want to keep your domain registration but you want to stop routing internet\n\t\t\ttraffic to your website or web application, we recommend that you delete resource record\n\t\t\tsets in the hosted zone instead of deleting the hosted zone.</p>\n         <important>\n            <p>If you delete a hosted zone, you can't undelete it. You must create a new hosted\n\t\t\t\tzone and update the name servers for your domain registration, which can require up\n\t\t\t\tto 48 hours to take effect. (If you delegated responsibility for a subdomain to a\n\t\t\t\thosted zone and you delete the child hosted zone, you must update the name servers\n\t\t\t\tin the parent hosted zone.) In addition, if you delete a hosted zone, someone could\n\t\t\t\thijack the domain and route traffic to their own resources using your domain\n\t\t\t\tname.</p>\n         </important>\n         <p>If you want to avoid the monthly charge for the hosted zone, you can transfer DNS\n\t\t\tservice for the domain to a free DNS service. When you transfer DNS service, you have to\n\t\t\tupdate the name servers for the domain registration. If the domain is registered with\n\t\t\t\tRoute 53, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_UpdateDomainNameservers.html\">UpdateDomainNameservers</a> for information about how to replace Route 53 name servers with name servers for the new DNS service. If the domain is\n\t\t\tregistered with another registrar, use the method provided by the registrar to update\n\t\t\tname servers for the domain registration. For more information, perform an internet\n\t\t\tsearch on \"free DNS service.\"</p>\n         <p>You can delete a hosted zone only if it contains only the default SOA record and NS\n\t\t\tresource record sets. If the hosted zone contains other resource record sets, you must\n\t\t\tdelete them before you can delete the hosted zone. If you try to delete a hosted zone\n\t\t\tthat contains other resource record sets, the request fails, and Route 53\n\t\t\treturns a <code>HostedZoneNotEmpty</code> error. For information about deleting records\n\t\t\tfrom your hosted zone, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html\">ChangeResourceRecordSets</a>.</p>\n         <p>To verify that the hosted zone has been deleted, do one of the following:</p>\n         <ul>\n            <li>\n               <p>Use the <code>GetHostedZone</code> action to request information about the\n\t\t\t\t\thosted zone.</p>\n            </li>\n            <li>\n               <p>Use the <code>ListHostedZones</code> action to get a list of the hosted zones\n\t\t\t\t\tassociated with the current Amazon Web Services account.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/hostedzone/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete a hosted zone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the ID, the status, and the date and time of a request to\n\t\t\tdelete a hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>DeleteHostedZone</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteKeySigningKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteKeySigningKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteKeySigningKeyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKMSArn"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidSigningStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchKeySigningKey"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a key-signing key (KSK). Before you can delete a KSK, you must deactivate it.\n\t\t\tThe KSK must be deactivated before you can delete it regardless of whether the hosted\n\t\t\tzone is enabled for DNSSEC signing.</p>\n         <p>You can use <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeactivateKeySigningKey.html\">DeactivateKeySigningKey</a> to deactivate the key before you delete it.</p>\n         <p>Use <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetDNSSEC.html\">GetDNSSEC</a> to verify that the KSK is in an <code>INACTIVE</code>\n\t\t\tstatus.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/keysigningkey/{HostedZoneId}/{Name}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteKeySigningKeyRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#SigningKeyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to identify a key-signing key (KSK).</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteKeySigningKeyResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteQueryLoggingConfig": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteQueryLoggingConfigRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteQueryLoggingConfigResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchQueryLoggingConfig"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a configuration for DNS query logging. If you delete a configuration, Amazon\n\t\t\tRoute 53 stops sending query logs to CloudWatch Logs. Route 53 doesn't delete any logs\n\t\t\tthat are already in CloudWatch Logs.</p>\n         <p>For more information about DNS query logs, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateQueryLoggingConfig.html\">CreateQueryLoggingConfig</a>.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/queryloggingconfig/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteQueryLoggingConfigRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfigId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the configuration that you want to delete. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteQueryLoggingConfigResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteReusableDelegationSet": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteReusableDelegationSetRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteReusableDelegationSetResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#DelegationSetInUse"
+                },
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotReusable"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchDelegationSet"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a reusable delegation set.</p>\n         <important>\n            <p>You can delete a reusable delegation set only if it isn't associated with any\n\t\t\t\thosted zones.</p>\n         </important>\n         <p>To verify that the reusable delegation set is not associated with any hosted zones,\n\t\t\tsubmit a <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetReusableDelegationSet.html\">GetReusableDelegationSet</a> request and specify the ID of the reusable\n\t\t\tdelegation set that you want to delete.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/delegationset/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteReusableDelegationSetRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the reusable delegation set that you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete a reusable delegation set.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteReusableDelegationSetResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>An empty element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicy": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteTrafficPolicyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteTrafficPolicyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#TrafficPolicyInUse"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a traffic policy.</p>\n         <p>When you delete a traffic policy, Route 53 sets a flag on the policy to indicate that\n\t\t\tit has been deleted. However, Route 53 never fully deletes the traffic policy. Note the\n\t\t\tfollowing:</p>\n         <ul>\n            <li>\n               <p>Deleted traffic policies aren't listed if you run <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListTrafficPolicies.html\">ListTrafficPolicies</a>.</p>\n            </li>\n            <li>\n               <p> There's no way to get a list of deleted policies.</p>\n            </li>\n            <li>\n               <p>If you retain the ID of the policy, you can get information about the policy,\n\t\t\t\t\tincluding the traffic policy document, by running <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetTrafficPolicy.html\">GetTrafficPolicy</a>.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/trafficpolicy/{Id}/{Version}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicyInstance": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteTrafficPolicyInstanceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteTrafficPolicyInstanceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a traffic policy instance and all of the resource record sets that Amazon\n\t\t\tRoute 53 created when you created the instance.</p>\n         <note>\n            <p>In the Route 53 console, traffic policy instances are known as policy\n\t\t\t\trecords.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2013-04-01/trafficpolicyinstance/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicyInstanceRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy instance that you want to delete. </p>\n         <important>\n            <p>When you delete a traffic policy instance, Amazon Route 53 also deletes all of the\n\t\t\t\tresource record sets that were created when you created the traffic policy\n\t\t\t\tinstance.</p>\n         </important>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete a specified traffic policy instance.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicyInstanceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>An empty element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicyRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy that you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number of the traffic policy that you want to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete a specified traffic policy version.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteTrafficPolicyResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>An empty element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteVPCAssociationAuthorization": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DeleteVPCAssociationAuthorizationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DeleteVPCAssociationAuthorizationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidVPCId"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#VPCAssociationAuthorizationNotFound"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Removes authorization to submit an <code>AssociateVPCWithHostedZone</code> request to\n\t\t\tassociate a specified VPC with a hosted zone that was created by a different account.\n\t\t\tYou must use the account that created the hosted zone to submit a\n\t\t\t\t<code>DeleteVPCAssociationAuthorization</code> request.</p>\n         <important>\n            <p>Sending this request only prevents the Amazon Web Services account that created the\n\t\t\t\tVPC from associating the VPC with the Amazon Route 53 hosted zone in the future. If\n\t\t\t\tthe VPC is already associated with the hosted zone,\n\t\t\t\t\t<code>DeleteVPCAssociationAuthorization</code> won't disassociate the VPC from\n\t\t\t\tthe hosted zone. If you want to delete an existing association, use\n\t\t\t\t\t<code>DisassociateVPCFromHostedZone</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/deauthorizevpcassociation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DeleteVPCAssociationAuthorizationRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When removing authorization to associate a VPC that was created by one Amazon Web Services account with a hosted zone that was created with a different Amazon Web Services account, the ID of the hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When removing authorization to associate a VPC that was created by one Amazon Web Services account with a hosted zone that was created with a different Amazon Web Services account, a complex type that includes the ID and region of the\n\t\t\tVPC.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to remove authorization to\n\t\t\tassociate a VPC that was created by one Amazon Web Services account with a hosted zone\n\t\t\tthat was created with a different Amazon Web Services account. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DeleteVPCAssociationAuthorizationResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Empty response for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#Dimension": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#DimensionField",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the name of one\n\t\t\tdimension.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.route53#DimensionField",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, the value of one\n\t\t\tdimension.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>For the metric that the CloudWatch alarm is associated with, a complex type that\n\t\t\tcontains information about one dimension.</p>"
+            }
+        },
+        "com.amazonaws.route53#DimensionField": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#DimensionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#Dimension",
+                "traits": {
+                    "smithy.api#xmlName": "Dimension"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.route53#DisableHostedZoneDNSSEC": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DisableHostedZoneDNSSECRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DisableHostedZoneDNSSECResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#DNSSECNotFound"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidArgument"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKMSArn"
+                },
+                {
+                    "target": "com.amazonaws.route53#KeySigningKeyInParentDSRecord"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Disables DNSSEC signing in a specific hosted zone. This action does not deactivate any\n\t\t\tkey-signing keys (KSKs) that are active in the hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/disable-dnssec",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DisableHostedZoneDNSSECRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DisableHostedZoneDNSSECResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#Disabled": {
+            "type": "boolean"
+        },
+        "com.amazonaws.route53#DisassociateVPCComment": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#DisassociateVPCFromHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#DisassociateVPCFromHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#DisassociateVPCFromHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidVPCId"
+                },
+                {
+                    "target": "com.amazonaws.route53#LastVPCAssociation"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#VPCAssociationNotFound"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Disassociates an Amazon Virtual Private Cloud (Amazon VPC) from an Amazon Route 53\n\t\t\tprivate hosted zone. Note the following:</p>\n         <ul>\n            <li>\n               <p>You can't disassociate the last Amazon VPC from a private hosted zone.</p>\n            </li>\n            <li>\n               <p>You can't convert a private hosted zone into a public hosted zone.</p>\n            </li>\n            <li>\n               <p>You can submit a <code>DisassociateVPCFromHostedZone</code> request using\n\t\t\t\t\teither the account that created the hosted zone or the account that created the\n\t\t\t\t\tAmazon VPC.</p>\n            </li>\n            <li>\n               <p>Some services, such as Cloud Map and Amazon Elastic File System\n\t\t\t\t\t(Amazon EFS) automatically create hosted zones and associate VPCs with the\n\t\t\t\t\thosted zones. A service can create a hosted zone using your account or using its\n\t\t\t\t\town account. You can disassociate a VPC from a hosted zone only if the service\n\t\t\t\t\tcreated the hosted zone using your account.</p>\n               <p>When you run <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByVPC.html\">DisassociateVPCFromHostedZone</a>, if the hosted zone has a value for\n\t\t\t\t\t\t<code>OwningAccount</code>, you can use\n\t\t\t\t\t\t<code>DisassociateVPCFromHostedZone</code>. If the hosted zone has a value\n\t\t\t\t\tfor <code>OwningService</code>, you can't use\n\t\t\t\t\t\t<code>DisassociateVPCFromHostedZone</code>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>When revoking access, the hosted zone and the Amazon VPC must belong to\n\t\t\t\tthe same partition. A partition is a group of Amazon Web Services Regions. Each\n\t\t\t\t\tAmazon Web Services account is scoped to one partition.</p>\n            <p>The following are the supported partitions:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>aws</code> - Amazon Web Services Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-cn</code> - China Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-us-gov</code> - Amazon Web Services GovCloud (US) Region</p>\n               </li>\n            </ul>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Access Management</a>\n\t\t\t\tin the <i>Amazon Web Services General Reference</i>.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/disassociatevpc",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#DisassociateVPCFromHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the private hosted zone that you want to disassociate a VPC from.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPC": {
+                    "target": "com.amazonaws.route53#VPC",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the VPC that you're disassociating from\n\t\t\tthe specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#DisassociateVPCComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Optional:</i> A comment about the disassociation request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the VPC that you want to disassociate\n\t\t\tfrom a specified private hosted zone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#DisassociateVPCFromHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that describes the changes made to the specified private hosted\n\t\t\tzone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the disassociate\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#EnableHostedZoneDNSSEC": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#EnableHostedZoneDNSSECRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#EnableHostedZoneDNSSECResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#DNSSECNotFound"
+                },
+                {
+                    "target": "com.amazonaws.route53#HostedZonePartiallyDelegated"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidArgument"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKeySigningKeyStatus"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidKMSArn"
+                },
+                {
+                    "target": "com.amazonaws.route53#KeySigningKeyWithActiveStatusNotFound"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Enables DNSSEC signing in a specific hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/enable-dnssec",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#EnableHostedZoneDNSSECRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#EnableHostedZoneDNSSECResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#EnableSNI": {
+            "type": "boolean"
+        },
+        "com.amazonaws.route53#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#ErrorMessages": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#ErrorMessage",
+                "traits": {
+                    "smithy.api#xmlName": "Message"
+                }
+            }
+        },
+        "com.amazonaws.route53#EvaluationPeriods": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#FailureThreshold": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.route53#FullyQualifiedDomainName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocation": {
+            "type": "structure",
+            "members": {
+                "ContinentCode": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The two-letter code for the continent.</p>\n         <p>Amazon Route 53 supports the following continent codes:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>AF</b>: Africa</p>\n            </li>\n            <li>\n               <p>\n                  <b>AN</b>: Antarctica</p>\n            </li>\n            <li>\n               <p>\n                  <b>AS</b>: Asia</p>\n            </li>\n            <li>\n               <p>\n                  <b>EU</b>: Europe</p>\n            </li>\n            <li>\n               <p>\n                  <b>OC</b>: Oceania</p>\n            </li>\n            <li>\n               <p>\n                  <b>NA</b>: North America</p>\n            </li>\n            <li>\n               <p>\n                  <b>SA</b>: South America</p>\n            </li>\n         </ul>\n         <p>Constraint: Specifying <code>ContinentCode</code> with either <code>CountryCode</code>\n\t\t\tor <code>SubdivisionCode</code> returns an <code>InvalidInput</code> error.</p>"
+                    }
+                },
+                "CountryCode": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For geolocation resource record sets, the two-letter code for a country.</p>\n         <p>Amazon Route 53 uses the two-letter country codes that are specified in <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO standard 3166-1\n\t\t\t\talpha-2</a>.</p>\n         <p>Route 53 also supports the country code <b>UA</b> for\n\t\t\tUkraine.</p>"
+                    }
+                },
+                "SubdivisionCode": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For geolocation resource record sets, the two-letter code for a state of the United\n\t\t\tStates. Route 53 doesn't support any other values for <code>SubdivisionCode</code>. For\n\t\t\ta list of state abbreviations, see <a href=\"https://pe.usps.com/text/pub28/28apb.htm\">Appendix B: Two–Letter State and Possession Abbreviations</a> on the United\n\t\t\tStates Postal Service website. </p>\n         <p>If you specify <code>subdivisioncode</code>, you must also specify <code>US</code> for\n\t\t\t\t<code>CountryCode</code>. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about a geographic location.</p>"
+            }
+        },
+        "com.amazonaws.route53#GeoLocationContinentCode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 2,
+                    "max": 2
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationContinentName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 32
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationCountryCode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationCountryName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationDetails": {
+            "type": "structure",
+            "members": {
+                "ContinentCode": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The two-letter code for the continent.</p>"
+                    }
+                },
+                "ContinentName": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The full name of the continent.</p>"
+                    }
+                },
+                "CountryCode": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The two-letter code for the country.</p>"
+                    }
+                },
+                "CountryName": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the country.</p>"
+                    }
+                },
+                "SubdivisionCode": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code for the subdivision, such as a particular state within the United States. For\n\t\t\ta list of US state abbreviations, see <a href=\"https://pe.usps.com/text/pub28/28apb.htm\">Appendix B: Two–Letter State and\n\t\t\t\tPossession Abbreviations</a> on the United States Postal Service website. For a\n\t\t\tlist of all supported subdivision codes, use the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListGeoLocations.html\">ListGeoLocations</a>\n\t\t\tAPI.</p>"
+                    }
+                },
+                "SubdivisionName": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The full name of the subdivision. Route 53 currently supports only states in the\n\t\t\tUnited States.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the codes and full continent, country, and subdivision\n\t\t\tnames for the specified <code>geolocation</code> code.</p>"
+            }
+        },
+        "com.amazonaws.route53#GeoLocationDetailsList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#GeoLocationDetails",
+                "traits": {
+                    "smithy.api#xmlName": "GeoLocationDetails"
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationSubdivisionCode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 3
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoLocationSubdivisionName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#GeoProximityLocation": {
+            "type": "structure",
+            "members": {
+                "AWSRegion": {
+                    "target": "com.amazonaws.route53#AWSRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Amazon Web Services Region the resource you are directing DNS traffic to, is in. </p>"
+                    }
+                },
+                "LocalZoneGroup": {
+                    "target": "com.amazonaws.route53#LocalZoneGroup",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n\t\t\tSpecifies an Amazon Web Services Local Zone Group.\n\t\t</p>\n         <p>A local Zone Group is usually the Local Zone code without the ending character. For example, \n\t\t\tif the Local Zone is <code>us-east-1-bue-1a</code> the Local Zone Group is <code>us-east-1-bue-1</code>.</p>\n         <p>You can identify the Local Zones Group for a specific Local Zone by using the <a href=\"https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-availability-zones.html\">describe-availability-zones</a> CLI command:</p>\n         <p>This command returns: <code>\"GroupName\": \"us-west-2-den-1\"</code>, specifying that the Local Zone <code>us-west-2-den-1a</code> \n\t\t\tbelongs to the Local Zone Group <code>us-west-2-den-1</code>.</p>"
+                    }
+                },
+                "Coordinates": {
+                    "target": "com.amazonaws.route53#Coordinates",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Contains the longitude and latitude for a geographic region. </p>"
+                    }
+                },
+                "Bias": {
+                    "target": "com.amazonaws.route53#Bias",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n\t\t\tThe bias increases or decreases the size of the geographic region from which Route 53 routes traffic to a resource.\n\t\t</p>\n         <p>To use <code>Bias</code> to change the size of the geographic region, specify the \n\t\t\tapplicable value for the bias:</p>\n         <ul>\n            <li>\n               <p>To expand the size of the geographic region from which Route 53 routes traffic to a resource, specify a \n\t\t\t\tpositive integer from 1 to 99 for the bias. Route 53 shrinks the size of adjacent regions. </p>\n            </li>\n            <li>\n               <p>To shrink the size of the geographic region from which Route 53 routes traffic to a resource, specify a \n\t\t\t\tnegative bias of -1 to -99. Route 53 expands the size of adjacent regions. </p>\n            </li>\n         </ul>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> (Resource record sets only): A complex type that lets you specify where your resources are\n\t\t\tlocated. Only one of <code>LocalZoneGroup</code>, <code>Coordinates</code>, or\n\t\t\t\t\t<code>Amazon Web ServicesRegion</code> is allowed per request at a time.</p>\n         <p>For more information about geoproximity routing, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html\">Geoproximity routing</a> in the\n\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>"
+            }
+        },
+        "com.amazonaws.route53#GetAccountLimit": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetAccountLimitRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetAccountLimitResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the specified limit for the current account, for example, the maximum number of\n\t\t\thealth checks that you can create using the account.</p>\n         <p>For the default limit, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>. To request a higher limit,\n\t\t\t\t<a href=\"https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-route53\">open a case</a>.</p>\n         <note>\n            <p>You can also view account limits in Amazon Web Services Trusted Advisor. Sign in to\n\t\t\t\tthe Amazon Web Services Management Console and open the Trusted Advisor console at <a href=\"https://console.aws.amazon.com/trustedadvisor\">https://console.aws.amazon.com/trustedadvisor/</a>. Then choose <b>Service limits</b> in the navigation pane.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/accountlimit/{Type}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetAccountLimitRequest": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#AccountLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit that you want to get. Valid values include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>MAX_HEALTH_CHECKS_BY_OWNER</b>: The maximum\n\t\t\t\t\tnumber of health checks that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_HOSTED_ZONES_BY_OWNER</b>: The maximum number\n\t\t\t\t\tof hosted zones that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_REUSABLE_DELEGATION_SETS_BY_OWNER</b>: The\n\t\t\t\t\tmaximum number of reusable delegation sets that you can create using the current\n\t\t\t\t\taccount.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_TRAFFIC_POLICIES_BY_OWNER</b>: The maximum\n\t\t\t\t\tnumber of traffic policies that you can create using the current account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER</b>: The\n\t\t\t\t\tmaximum number of traffic policy instances that you can create using the current\n\t\t\t\t\taccount. (Traffic policy instances are referred to as traffic flow policy\n\t\t\t\t\trecords in the Amazon Route 53 console.)</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to create a hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetAccountLimitResponse": {
+            "type": "structure",
+            "members": {
+                "Limit": {
+                    "target": "com.amazonaws.route53#AccountLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current setting for the specified limit. For example, if you specified\n\t\t\t\t<code>MAX_HEALTH_CHECKS_BY_OWNER</code> for the value of <code>Type</code> in the\n\t\t\trequest, the value of <code>Limit</code> is the maximum number of health checks that you\n\t\t\tcan create using the current account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Count": {
+                    "target": "com.amazonaws.route53#UsageCount",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The current number of entities that you have created of the specified type. For\n\t\t\texample, if you specified <code>MAX_HEALTH_CHECKS_BY_OWNER</code> for the value of\n\t\t\t\t<code>Type</code> in the request, the value of <code>Count</code> is the current\n\t\t\tnumber of health checks that you have created using the current account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the requested limit. </p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetChange": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetChangeRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetChangeResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchChange"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the current status of a change batch request. The status is one of the\n\t\t\tfollowing values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PENDING</code> indicates that the changes in this request have not\n\t\t\t\t\tpropagated to all Amazon Route 53 DNS servers managing the hosted zone. This is the initial status of all\n\t\t\t\t\tchange batch requests.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INSYNC</code> indicates that the changes have propagated to all Route 53\n\t\t\t\t\tDNS servers managing the hosted zone. </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/change/{Id}",
+                    "code": 200
+                },
+                "smithy.waiters#waitable": {
+                    "ResourceRecordSetsChanged": {
+                        "acceptors": [
+                            {
+                                "state": "success",
+                                "matcher": {
+                                    "output": {
+                                        "path": "ChangeInfo.Status",
+                                        "expected": "INSYNC",
+                                        "comparator": "stringEquals"
+                                    }
+                                }
+                            }
+                        ],
+                        "minDelay": 30
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#GetChangeRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ChangeId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the change batch request. The value that you specify here is the value that\n\t\t\t\t<code>ChangeResourceRecordSets</code> returned in the <code>Id</code> element when\n\t\t\tyou submitted the request.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input for a GetChange request.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetChangeResponse": {
+            "type": "structure",
+            "members": {
+                "ChangeInfo": {
+                    "target": "com.amazonaws.route53#ChangeInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the specified change batch.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the <code>ChangeInfo</code> element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetCheckerIpRanges": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetCheckerIpRangesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetCheckerIpRangesResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Route 53 does not perform authorization for this API because it retrieves information\n\t\t\tthat is already available to the public.</p>\n         <important>\n            <p>\n               <code>GetCheckerIpRanges</code> still works, but we recommend that you download\n\t\t\t\tip-ranges.json, which includes IP address ranges for all Amazon Web Services\n\t\t\t\tservices. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/route-53-ip-addresses.html\">IP Address Ranges\n\t\t\t\t\tof Amazon Route 53 Servers</a> in the <i>Amazon Route 53 Developer\n\t\t\t\t\tGuide</i>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/checkeripranges",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetCheckerIpRangesRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Empty request.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetCheckerIpRangesResponse": {
+            "type": "structure",
+            "members": {
+                "CheckerIpRanges": {
+                    "target": "com.amazonaws.route53#CheckerIpRanges",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains sorted list of IP ranges in CIDR format for Amazon Route\n\t\t\t53 health checkers.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the <code>CheckerIpRanges</code> element.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetDNSSEC": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetDNSSECRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetDNSSECResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidArgument"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about DNSSEC for a specific hosted zone, including the key-signing\n\t\t\tkeys (KSKs) in the hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/dnssec",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetDNSSECRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string used to identify a hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetDNSSECResponse": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.route53#DNSSECStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string representing the status of DNSSEC.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "KeySigningKeys": {
+                    "target": "com.amazonaws.route53#KeySigningKeys",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-signing keys (KSKs) in your account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetGeoLocation": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetGeoLocationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetGeoLocationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchGeoLocation"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about whether a specified geographic location is supported for Amazon\n\t\t\tRoute 53 geolocation resource record sets.</p>\n         <p>Route 53 does not perform authorization for this API because it retrieves information\n\t\t\tthat is already available to the public.</p>\n         <p>Use the following syntax to determine whether a continent is supported for\n\t\t\tgeolocation:</p>\n         <p>\n            <code>GET /2013-04-01/geolocation?continentcode=<i>two-letter abbreviation for\n\t\t\t\t\ta continent</i>\n            </code>\n         </p>\n         <p>Use the following syntax to determine whether a country is supported for\n\t\t\tgeolocation:</p>\n         <p>\n            <code>GET /2013-04-01/geolocation?countrycode=<i>two-character country\n\t\t\t\t\tcode</i>\n            </code>\n         </p>\n         <p>Use the following syntax to determine whether a subdivision of a country is supported\n\t\t\tfor geolocation:</p>\n         <p>\n            <code>GET /2013-04-01/geolocation?countrycode=<i>two-character country\n\t\t\t\t\tcode</i>&subdivisioncode=<i>subdivision\n\t\t\tcode</i>\n            </code>\n         </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/geolocation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetGeoLocationRequest": {
+            "type": "structure",
+            "members": {
+                "ContinentCode": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For geolocation resource record sets, a two-letter abbreviation that identifies a\n\t\t\tcontinent. Amazon Route 53 supports the following continent codes:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>AF</b>: Africa</p>\n            </li>\n            <li>\n               <p>\n                  <b>AN</b>: Antarctica</p>\n            </li>\n            <li>\n               <p>\n                  <b>AS</b>: Asia</p>\n            </li>\n            <li>\n               <p>\n                  <b>EU</b>: Europe</p>\n            </li>\n            <li>\n               <p>\n                  <b>OC</b>: Oceania</p>\n            </li>\n            <li>\n               <p>\n                  <b>NA</b>: North America</p>\n            </li>\n            <li>\n               <p>\n                  <b>SA</b>: South America</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpQuery": "continentcode"
+                    }
+                },
+                "CountryCode": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon Route 53 uses the two-letter country codes that are specified in <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO standard 3166-1\n\t\t\t\talpha-2</a>.</p>\n         <p>Route 53 also supports the country code <b>UA</b> for\n\t\t\tUkraine.</p>",
+                        "smithy.api#httpQuery": "countrycode"
+                    }
+                },
+                "SubdivisionCode": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code for the subdivision, such as a particular state within the United States. For\n\t\t\ta list of US state abbreviations, see <a href=\"https://pe.usps.com/text/pub28/28apb.htm\">Appendix B: Two–Letter State and\n\t\t\t\tPossession Abbreviations</a> on the United States Postal Service website. For a\n\t\t\tlist of all supported subdivision codes, use the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListGeoLocations.html\">ListGeoLocations</a>\n\t\t\tAPI.</p>",
+                        "smithy.api#httpQuery": "subdivisioncode"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request for information about whether a specified geographic location is supported\n\t\t\tfor Amazon Route 53 geolocation resource record sets.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetGeoLocationResponse": {
+            "type": "structure",
+            "members": {
+                "GeoLocationDetails": {
+                    "target": "com.amazonaws.route53#GeoLocationDetails",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the codes and full continent, country, and subdivision\n\t\t\tnames for the specified geolocation code.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the specified geolocation\n\t\t\tcode.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheck": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHealthCheckRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHealthCheckResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#IncompatibleVersion"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specified health check.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/healthcheck/{HealthCheckId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckCount": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHealthCheckCountRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHealthCheckCountResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the number of health checks that are associated with the current Amazon Web Services account.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/healthcheckcount",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckCountRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>A request for the number of health checks that are associated with the current Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckCountResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheckCount": {
+                    "target": "com.amazonaws.route53#HealthCheckCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of health checks associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>GetHealthCheckCount</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckLastFailureReason": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHealthCheckLastFailureReasonRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHealthCheckLastFailureReasonResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the reason that a specified health check failed most recently.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/healthcheck/{HealthCheckId}/lastfailurereason",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckLastFailureReasonRequest": {
+            "type": "structure",
+            "members": {
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the health check for which you want the last failure reason. When you\n\t\t\tcreated the health check, <code>CreateHealthCheck</code> returned the ID in the\n\t\t\tresponse, in the <code>HealthCheckId</code> element.</p>\n         <note>\n            <p>If you want to get the last failure reason for a calculated health check, you must\n\t\t\t\tuse the Amazon Route 53 console or the CloudWatch console. You can't use\n\t\t\t\t\t<code>GetHealthCheckLastFailureReason</code> for a calculated health\n\t\t\t\tcheck.</p>\n         </note>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request for the reason that a health check failed most recently.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckLastFailureReasonResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheckObservations": {
+                    "target": "com.amazonaws.route53#HealthCheckObservations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>Observation</code> element for each Amazon Route 53\n\t\t\thealth checker that is reporting a last failure reason. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a\n\t\t\t\t<code>GetHealthCheckLastFailureReason</code> request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckRequest": {
+            "type": "structure",
+            "members": {
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier that Amazon Route 53 assigned to the health check when you created it.\n\t\t\tWhen you add or update a resource record set, you use this value to specify which health\n\t\t\tcheck to use. The value can be up to 64 characters long.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about a specified health check. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheck": {
+                    "target": "com.amazonaws.route53#HealthCheck",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about one health check that is associated\n\t\t\twith the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>GetHealthCheck</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckStatus": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHealthCheckStatusRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHealthCheckStatusResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets status of a specified health check. </p>\n         <important>\n            <p>This API is intended for use during development to diagnose behavior. It doesn’t\n\t\t\t\tsupport production use-cases with high query rates that require immediate and\n\t\t\t\tactionable responses.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/healthcheck/{HealthCheckId}/status",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckStatusRequest": {
+            "type": "structure",
+            "members": {
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the health check that you want the current status for. When you created the\n\t\t\thealth check, <code>CreateHealthCheck</code> returned the ID in the response, in the\n\t\t\t\t<code>HealthCheckId</code> element.</p>\n         <note>\n            <p>If you want to check the status of a calculated health check, you must use the\n\t\t\t\tAmazon Route 53 console or the CloudWatch console. You can't use\n\t\t\t\t\t<code>GetHealthCheckStatus</code> to get the status of a calculated health\n\t\t\t\tcheck.</p>\n         </note>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get the status for a health check.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHealthCheckStatusResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheckObservations": {
+                    "target": "com.amazonaws.route53#HealthCheckObservations",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>HealthCheckObservation</code> element for each Amazon\n\t\t\tRoute 53 health checker that is reporting a status about the health check\n\t\t\tendpoint.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>GetHealthCheck</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specified hosted zone including the four name servers\n\t\t\tassigned to the hosted zone.</p>\n         <p>\n            <code></code> returns the VPCs associated with the specified hosted zone and does not reflect the VPC\n\t\t\tassociations by Route 53 Profiles. To get the associations to a Profile, call the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_ListProfileAssociations.html\">ListProfileAssociations</a> API.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To get information about a hosted zone",
+                        "documentation": "The following example gets information about the Z3M3LMPEXAMPLE hosted zone.",
+                        "input": {
+                            "Id": "Z3M3LMPEXAMPLE"
+                        },
+                        "output": {
+                            "HostedZone": {
+                                "ResourceRecordSetCount": 8,
+                                "CallerReference": "C741617D-04E4-F8DE-B9D7-0D150FC61C2E",
+                                "Config": {
+                                    "PrivateZone": false
+                                },
+                                "Id": "/hostedzone/Z3M3LMPEXAMPLE",
+                                "Name": "myawsbucket.com."
+                            },
+                            "DelegationSet": {
+                                "NameServers": [
+                                    "ns-2048.awsdns-64.com",
+                                    "ns-2049.awsdns-65.net",
+                                    "ns-2050.awsdns-66.org",
+                                    "ns-2051.awsdns-67.co.uk"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzone/{Id}",
+                    "code": 200
+                },
+                "smithy.test#smokeTests": [
+                    {
+                        "id": "GetHostedZoneFailure",
+                        "params": {
+                            "Id": "fake-zone"
+                        },
+                        "vendorParams": {
+                            "region": "us-east-1"
+                        },
+                        "vendorParamsShape": "aws.test#AwsVendorParams",
+                        "expect": {
+                            "failure": {}
+                        }
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneCount": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHostedZoneCountRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHostedZoneCountResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the number of hosted zones that are associated with the current Amazon Web Services account.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzonecount",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneCountRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>A request to retrieve a count of all the hosted zones that are associated with the\n\t\t\tcurrent Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneCountResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZoneCount": {
+                    "target": "com.amazonaws.route53#HostedZoneCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total number of public and private hosted zones that are associated with the\n\t\t\tcurrent Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>GetHostedZoneCount</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneLimit": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetHostedZoneLimitRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetHostedZoneLimitResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#HostedZoneNotPrivate"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the specified limit for a specified hosted zone, for example, the maximum number\n\t\t\tof records that you can create in the hosted zone. </p>\n         <p>For the default limit, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>. To request a higher limit,\n\t\t\t\t<a href=\"https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-route53\">open a case</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzonelimit/{HostedZoneId}/{Type}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneLimitRequest": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#HostedZoneLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit that you want to get. Valid values include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>MAX_RRSETS_BY_ZONE</b>: The maximum number of\n\t\t\t\t\trecords that you can create in the specified hosted zone.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_VPCS_ASSOCIATED_BY_ZONE</b>: The maximum\n\t\t\t\t\tnumber of Amazon VPCs that you can associate with the specified private hosted\n\t\t\t\t\tzone.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want to get a limit for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to create a hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneLimitResponse": {
+            "type": "structure",
+            "members": {
+                "Limit": {
+                    "target": "com.amazonaws.route53#HostedZoneLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current setting for the specified limit. For example, if you specified\n\t\t\t\t<code>MAX_RRSETS_BY_ZONE</code> for the value of <code>Type</code> in the request,\n\t\t\tthe value of <code>Limit</code> is the maximum number of records that you can create in\n\t\t\tthe specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Count": {
+                    "target": "com.amazonaws.route53#UsageCount",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The current number of entities that you have created of the specified type. For\n\t\t\texample, if you specified <code>MAX_RRSETS_BY_ZONE</code> for the value of\n\t\t\t\t<code>Type</code> in the request, the value of <code>Count</code> is the current\n\t\t\tnumber of records that you have created in the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the requested limit. </p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want to get information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about a specified hosted zone. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZone": {
+                    "target": "com.amazonaws.route53#HostedZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains general information about the specified hosted\n\t\t\tzone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DelegationSet": {
+                    "target": "com.amazonaws.route53#DelegationSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that lists the Amazon Route 53 name servers for the specified hosted\n\t\t\tzone.</p>"
+                    }
+                },
+                "VPCs": {
+                    "target": "com.amazonaws.route53#VPCs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the VPCs that are associated with the\n\t\t\tspecified hosted zone.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contain the response to a <code>GetHostedZone</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetQueryLoggingConfig": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetQueryLoggingConfigRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetQueryLoggingConfigResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchQueryLoggingConfig"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specified configuration for DNS query logging.</p>\n         <p>For more information about DNS query logs, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateQueryLoggingConfig.html\">CreateQueryLoggingConfig</a> and <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html\">Logging DNS\n\t\t\tQueries</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/queryloggingconfig/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetQueryLoggingConfigRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfigId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the configuration for DNS query logging that you want to get information\n\t\t\tabout.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetQueryLoggingConfigResponse": {
+            "type": "structure",
+            "members": {
+                "QueryLoggingConfig": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the query logging configuration that\n\t\t\tyou specified in a <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetQueryLoggingConfig.html\">GetQueryLoggingConfig</a> request.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSet": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetReusableDelegationSetRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetReusableDelegationSetResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotReusable"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchDelegationSet"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves information about a specified reusable delegation set, including the four\n\t\t\tname servers that are assigned to the delegation set.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/delegationset/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSetLimit": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetReusableDelegationSetLimitRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetReusableDelegationSetLimitResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchDelegationSet"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the maximum number of hosted zones that you can associate with the specified\n\t\t\treusable delegation set.</p>\n         <p>For the default limit, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>. To request a higher limit,\n\t\t\t\t<a href=\"https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-route53\">open a case</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/reusabledelegationsetlimit/{DelegationSetId}/{Type}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSetLimitRequest": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#ReusableDelegationSetLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify <code>MAX_ZONES_BY_REUSABLE_DELEGATION_SET</code> to get the maximum number of\n\t\t\thosted zones that you can associate with the specified reusable delegation set.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "DelegationSetId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the delegation set that you want to get the limit for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the request to create a hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSetLimitResponse": {
+            "type": "structure",
+            "members": {
+                "Limit": {
+                    "target": "com.amazonaws.route53#ReusableDelegationSetLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current setting for the limit on hosted zones that you can associate with the\n\t\t\tspecified reusable delegation set.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Count": {
+                    "target": "com.amazonaws.route53#UsageCount",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The current number of hosted zones that you can associate with the specified reusable\n\t\t\tdelegation set.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the requested limit. </p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSetRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the reusable delegation set that you want to get a list of name servers\n\t\t\tfor.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about a specified reusable delegation set.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetReusableDelegationSetResponse": {
+            "type": "structure",
+            "members": {
+                "DelegationSet": {
+                    "target": "com.amazonaws.route53#DelegationSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the reusable delegation set.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to the <code>GetReusableDelegationSet</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicy": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specific traffic policy version.</p>\n         <p>For information about how of deleting a traffic policy affects the response from\n\t\t\t\t<code>GetTrafficPolicy</code>, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteTrafficPolicy.html\">DeleteTrafficPolicy</a>. </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicy/{Id}/{Version}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstance": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyInstanceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyInstanceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specified traffic policy instance.</p>\n         <note>\n            <p>\n\t\t\t\tUse <code>GetTrafficPolicyInstance</code> with the <code>id</code> of new traffic policy instance to confirm that the \n\t\t\t\t<code>CreateTrafficPolicyInstance</code> or an <code>UpdateTrafficPolicyInstance</code> request completed successfully. \n\t\t\t\tFor more information, see the <code>State</code> response\n\t\t\t\telement.</p>\n         </note>\n         <note>\n            <p>In the Route 53 console, traffic policy instances are known as policy\n\t\t\t\trecords.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicyinstance/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstanceCount": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyInstanceCountRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#GetTrafficPolicyInstanceCountResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the number of traffic policy instances that are associated with the current\n\t\t\t\tAmazon Web Services account.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicyinstancecount",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstanceCountRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Request to get the number of traffic policy instances that are associated with the\n\t\t\tcurrent Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstanceCountResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstanceCount": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of traffic policy instances that are associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the resource record sets that Amazon\n\t\t\tRoute 53 created based on a specified traffic policy.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstanceRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy instance that you want to get information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specified traffic policy instance.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyInstanceResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstance": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstance",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the resource record sets that Amazon\n\t\t\tRoute 53 created based on a specified traffic policy.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy that you want to get information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number of the traffic policy that you want to get information\n\t\t\tabout.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a specific traffic policy version.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#GetTrafficPolicyResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicy": {
+                    "target": "com.amazonaws.route53#TrafficPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the specified traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#HealthCheck": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier that Amazon Route 53 assigned to the health check when you created it.\n\t\t\tWhen you add or update a resource record set, you use this value to specify which health\n\t\t\tcheck to use. The value can be up to 64 characters long. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#HealthCheckNonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique string that you specified when you created the health check.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "LinkedService": {
+                    "target": "com.amazonaws.route53#LinkedService",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the health check was created by another service, the service that created the\n\t\t\thealth check. When a health check is created by another service, you can't edit or\n\t\t\tdelete it using Amazon Route 53. </p>"
+                    }
+                },
+                "HealthCheckConfig": {
+                    "target": "com.amazonaws.route53#HealthCheckConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains detailed information about one health check.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HealthCheckVersion": {
+                    "target": "com.amazonaws.route53#HealthCheckVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the health check. You can optionally pass this value in a call to\n\t\t\t\t<code>UpdateHealthCheck</code> to prevent overwriting another change to the health\n\t\t\tcheck.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CloudWatchAlarmConfiguration": {
+                    "target": "com.amazonaws.route53#CloudWatchAlarmConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the CloudWatch alarm that Amazon Route\n\t\t\t53 is monitoring for this health check.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about one health check that is associated\n\t\t\twith the current Amazon Web Services account.</p>"
+            }
+        },
+        "com.amazonaws.route53#HealthCheckAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The health check you're attempting to create already exists. Amazon Route 53 returns\n\t\t\tthis error when you submit a request that has the following values:</p>\n         <ul>\n            <li>\n               <p>The same value for <code>CallerReference</code> as an existing health check,\n\t\t\t\t\tand one or more values that differ from the existing health check that has the\n\t\t\t\t\tsame caller reference.</p>\n            </li>\n            <li>\n               <p>The same value for <code>CallerReference</code> as a health check that you\n\t\t\t\t\tcreated and later deleted, regardless of the other settings in the\n\t\t\t\t\trequest.</p>\n            </li>\n         </ul>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#HealthCheckConfig": {
+            "type": "structure",
+            "members": {
+                "IPAddress": {
+                    "target": "com.amazonaws.route53#IPAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IPv4 or IPv6 IP address of the endpoint that you want Amazon Route 53 to perform\n\t\t\thealth checks on. If you don't specify a value for <code>IPAddress</code>, Route 53\n\t\t\tsends a DNS request to resolve the domain name that you specify in\n\t\t\t\t<code>FullyQualifiedDomainName</code> at the interval that you specify in\n\t\t\t\t<code>RequestInterval</code>. Using an IP address returned by DNS, Route 53 then\n\t\t\tchecks the health of the endpoint.</p>\n         <p>Use one of the following formats for the value of <code>IPAddress</code>: </p>\n         <ul>\n            <li>\n               <p>\n                  <b>IPv4 address</b>: four values between 0 and 255,\n\t\t\t\t\tseparated by periods (.), for example, <code>192.0.2.44</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>IPv6 address</b>: eight groups of four\n\t\t\t\t\thexadecimal values, separated by colons (:), for example,\n\t\t\t\t\t\t<code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>. You can also shorten\n\t\t\t\t\tIPv6 addresses as described in RFC 5952, for example,\n\t\t\t\t\t\t<code>2001:db8:85a3::abcd:1:2345</code>.</p>\n            </li>\n         </ul>\n         <p>If the endpoint is an EC2 instance, we recommend that you create an Elastic IP\n\t\t\taddress, associate it with your EC2 instance, and specify the Elastic IP address for\n\t\t\t\t<code>IPAddress</code>. This ensures that the IP address of your instance will never\n\t\t\tchange.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-FullyQualifiedDomainName\">FullyQualifiedDomainName</a>. </p>\n         <p>Constraints: Route 53 can't check the health of endpoints for which the IP address is\n\t\t\tin local, private, non-routable, or multicast ranges. For more information about IP\n\t\t\taddresses for which you can't create health checks, see the following documents:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc5735\">RFC 5735, Special Use IPv4\n\t\t\t\t\t\tAddresses</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc6598\">RFC 6598, IANA-Reserved IPv4\n\t\t\t\t\t\tPrefix for Shared Address Space</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc5156\">RFC 5156, Special-Use IPv6\n\t\t\t\t\t\tAddresses</a>\n               </p>\n            </li>\n         </ul>\n         <p>When the value of <code>Type</code> is <code>CALCULATED</code> or\n\t\t\t\t<code>CLOUDWATCH_METRIC</code>, omit <code>IPAddress</code>.</p>"
+                    }
+                },
+                "Port": {
+                    "target": "com.amazonaws.route53#Port",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port on the endpoint that you want Amazon Route 53 to perform health checks\n\t\t\ton.</p>\n         <note>\n            <p>Don't specify a value for <code>Port</code> when you specify a value for\n\t\t\t\t\t<code>Type</code> of <code>CLOUDWATCH_METRIC</code> or\n\t\t\t\t<code>CALCULATED</code>.</p>\n         </note>"
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.route53#HealthCheckType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of health check that you want to create, which indicates how Amazon Route 53\n\t\t\tdetermines whether an endpoint is healthy.</p>\n         <important>\n            <p>You can't change the value of <code>Type</code> after you create a health\n\t\t\t\tcheck.</p>\n         </important>\n         <p>You can create the following types of health checks:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>HTTP</b>: Route 53 tries to establish a TCP\n\t\t\t\t\tconnection. If successful, Route 53 submits an HTTP request and waits for an\n\t\t\t\t\tHTTP status code of 200 or greater and less than 400.</p>\n            </li>\n            <li>\n               <p>\n                  <b>HTTPS</b>: Route 53 tries to establish a TCP\n\t\t\t\t\tconnection. If successful, Route 53 submits an HTTPS request and waits for an\n\t\t\t\t\tHTTP status code of 200 or greater and less than 400.</p>\n               <important>\n                  <p>If you specify <code>HTTPS</code> for the value of <code>Type</code>, the endpoint must\n\t\t\t\t\t\tsupport TLS v1.0, v1.1, or v1.2.</p>\n               </important>\n            </li>\n            <li>\n               <p>\n                  <b>HTTP_STR_MATCH</b>: Route 53 tries to establish a\n\t\t\t\t\tTCP connection. If successful, Route 53 submits an HTTP request and searches the\n\t\t\t\t\tfirst 5,120 bytes of the response body for the string that you specify in\n\t\t\t\t\t\t<code>SearchString</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>HTTPS_STR_MATCH</b>: Route 53 tries to establish\n\t\t\t\t\ta TCP connection. If successful, Route 53 submits an <code>HTTPS</code> request\n\t\t\t\t\tand searches the first 5,120 bytes of the response body for the string that you\n\t\t\t\t\tspecify in <code>SearchString</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>TCP</b>: Route 53 tries to establish a TCP\n\t\t\t\t\tconnection.</p>\n            </li>\n            <li>\n               <p>\n                  <b>CLOUDWATCH_METRIC</b>: The health check is\n\t\t\t\t\tassociated with a CloudWatch alarm. If the state of the alarm is\n\t\t\t\t\t<code>OK</code>, the health check is considered healthy. If the state is\n\t\t\t\t\t\t<code>ALARM</code>, the health check is considered unhealthy. If CloudWatch\n\t\t\t\t\tdoesn't have sufficient data to determine whether the state is <code>OK</code>\n\t\t\t\t\tor <code>ALARM</code>, the health check status depends on the setting for\n\t\t\t\t\t\t<code>InsufficientDataHealthStatus</code>: <code>Healthy</code>,\n\t\t\t\t\t\t<code>Unhealthy</code>, or <code>LastKnownStatus</code>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>CALCULATED</b>: For health checks that monitor\n\t\t\t\t\tthe status of other health checks, Route 53 adds up the number of health checks\n\t\t\t\t\tthat Route 53 health checkers consider to be healthy and compares that number\n\t\t\t\t\twith the value of <code>HealthThreshold</code>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>RECOVERY_CONTROL</b>: The health check is associated with a\n\t\t\t\t\tRoute53 Application Recovery Controller routing control. If the routing control\n\t\t\t\t\tstate is <code>ON</code>, the health check is considered healthy. If the state\n\t\t\t\t\tis <code>OFF</code>, the health check is considered unhealthy. </p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Route 53 Determines Whether an Endpoint Is Healthy</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResourcePath": {
+                    "target": "com.amazonaws.route53#ResourcePath",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path, if any, that you want Amazon Route 53 to request when performing health\n\t\t\tchecks. The path can be any value for which your endpoint will return an HTTP status\n\t\t\tcode of 2xx or 3xx when the endpoint is healthy, for example, the file\n\t\t\t/docs/route53-health-check.html. You can also include query string parameters, for\n\t\t\texample, <code>/welcome.html?language=jp&login=y</code>. </p>"
+                    }
+                },
+                "FullyQualifiedDomainName": {
+                    "target": "com.amazonaws.route53#FullyQualifiedDomainName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon Route 53 behavior depends on whether you specify a value for\n\t\t\t\t<code>IPAddress</code>.</p>\n         <p>\n            <b>If you specify a value for</b>\n            <code>IPAddress</code>:</p>\n         <p>Amazon Route 53 sends health check requests to the specified IPv4 or IPv6 address and\n\t\t\tpasses the value of <code>FullyQualifiedDomainName</code> in the <code>Host</code>\n\t\t\theader for all health checks except TCP health checks. This is typically the fully\n\t\t\tqualified DNS name of the endpoint on which you want Route 53 to perform health\n\t\t\tchecks.</p>\n         <p>When Route 53 checks the health of an endpoint, here is how it constructs the\n\t\t\t\t<code>Host</code> header:</p>\n         <ul>\n            <li>\n               <p>If you specify a value of <code>80</code> for <code>Port</code> and\n\t\t\t\t\t\t<code>HTTP</code> or <code>HTTP_STR_MATCH</code> for <code>Type</code>,\n\t\t\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> to the\n\t\t\t\t\tendpoint in the Host header. </p>\n            </li>\n            <li>\n               <p>If you specify a value of <code>443</code> for <code>Port</code> and\n\t\t\t\t\t\t<code>HTTPS</code> or <code>HTTPS_STR_MATCH</code> for <code>Type</code>,\n\t\t\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> to the\n\t\t\t\t\tendpoint in the <code>Host</code> header.</p>\n            </li>\n            <li>\n               <p>If you specify another value for <code>Port</code> and any value except\n\t\t\t\t\t\t<code>TCP</code> for <code>Type</code>, Route 53 passes\n\t\t\t\t\t\t<code>FullyQualifiedDomainName:Port</code> to the endpoint in the\n\t\t\t\t\t\t<code>Host</code> header.</p>\n            </li>\n         </ul>\n         <p>If you don't specify a value for <code>FullyQualifiedDomainName</code>, Route 53\n\t\t\tsubstitutes the value of <code>IPAddress</code> in the <code>Host</code> header in each\n\t\t\tof the preceding cases.</p>\n         <p>\n            <b>If you don't specify a value for</b>\n            <code>IPAddress</code>:</p>\n         <p>Route 53 sends a DNS request to the domain that you specify for\n\t\t\t\t<code>FullyQualifiedDomainName</code> at the interval that you specify for\n\t\t\t\t<code>RequestInterval</code>. Using an IPv4 address that DNS returns, Route 53 then\n\t\t\tchecks the health of the endpoint.</p>\n         <note>\n            <p>If you don't specify a value for <code>IPAddress</code>, Route 53 uses only IPv4\n\t\t\t\tto send health checks to the endpoint. If there's no resource record set with a type\n\t\t\t\tof A for the name that you specify for <code>FullyQualifiedDomainName</code>, the\n\t\t\t\thealth check fails with a \"DNS resolution failed\" error.</p>\n         </note>\n         <p>If you want to check the health of weighted, latency, or failover resource record sets\n\t\t\tand you choose to specify the endpoint only by <code>FullyQualifiedDomainName</code>, we\n\t\t\trecommend that you create a separate health check for each endpoint. For example, create\n\t\t\ta health check for each HTTP server that is serving content for www.example.com. For the\n\t\t\tvalue of <code>FullyQualifiedDomainName</code>, specify the domain name of the server\n\t\t\t(such as us-east-2-www.example.com), not the name of the resource record sets\n\t\t\t(www.example.com).</p>\n         <important>\n            <p>In this configuration, if you create a health check for which the value of\n\t\t\t\t\t<code>FullyQualifiedDomainName</code> matches the name of the resource record\n\t\t\t\tsets and you then associate the health check with those resource record sets, health\n\t\t\t\tcheck results will be unpredictable.</p>\n         </important>\n         <p>In addition, if the value that you specify for <code>Type</code> is <code>HTTP</code>,\n\t\t\t\t<code>HTTPS</code>, <code>HTTP_STR_MATCH</code>, or <code>HTTPS_STR_MATCH</code>,\n\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> in the\n\t\t\t\t<code>Host</code> header, as it does when you specify a value for\n\t\t\t\t<code>IPAddress</code>. If the value of <code>Type</code> is <code>TCP</code>, Route\n\t\t\t53 doesn't pass a <code>Host</code> header.</p>"
+                    }
+                },
+                "SearchString": {
+                    "target": "com.amazonaws.route53#SearchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of Type is <code>HTTP_STR_MATCH</code> or <code>HTTPS_STR_MATCH</code>,\n\t\t\tthe string that you want Amazon Route 53 to search for in the response body from the\n\t\t\tspecified resource. If the string appears in the response body, Route 53 considers the\n\t\t\tresource healthy.</p>\n         <p>Route 53 considers case when searching for <code>SearchString</code> in the response\n\t\t\tbody. </p>"
+                    }
+                },
+                "RequestInterval": {
+                    "target": "com.amazonaws.route53#RequestInterval",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of seconds between the time that Amazon Route 53 gets a response from your\n\t\t\tendpoint and the time that it sends the next health check request. Each Route 53 health\n\t\t\tchecker makes requests at this interval.</p>\n         <important>\n            <p>You can't change the value of <code>RequestInterval</code> after you create a\n\t\t\t\thealth check.</p>\n         </important>\n         <p>If you don't specify a value for <code>RequestInterval</code>, the default value is\n\t\t\t\t<code>30</code> seconds.</p>"
+                    }
+                },
+                "FailureThreshold": {
+                    "target": "com.amazonaws.route53#FailureThreshold",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of consecutive health checks that an endpoint must pass or fail for Amazon\n\t\t\tRoute 53 to change the current status of the endpoint from unhealthy to healthy or vice\n\t\t\tversa. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>If you don't specify a value for <code>FailureThreshold</code>, the default value is\n\t\t\tthree health checks.</p>"
+                    }
+                },
+                "MeasureLatency": {
+                    "target": "com.amazonaws.route53#MeasureLatency",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether you want Amazon Route 53 to measure the latency between health\n\t\t\tcheckers in multiple Amazon Web Services regions and your endpoint, and to display\n\t\t\tCloudWatch latency graphs on the <b>Health Checks</b> page in\n\t\t\tthe Route 53 console.</p>\n         <important>\n            <p>You can't change the value of <code>MeasureLatency</code> after you create a\n\t\t\t\thealth check.</p>\n         </important>"
+                    }
+                },
+                "Inverted": {
+                    "target": "com.amazonaws.route53#Inverted",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether you want Amazon Route 53 to invert the status of a health check, for\n\t\t\texample, to consider a health check unhealthy when it otherwise would be considered\n\t\t\thealthy.</p>"
+                    }
+                },
+                "Disabled": {
+                    "target": "com.amazonaws.route53#Disabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Stops Route 53 from performing health checks. When you disable a health check, here's\n\t\t\twhat happens:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Health checks that check the health of\n\t\t\t\t\t\tendpoints:</b> Route 53 stops submitting requests to your\n\t\t\t\t\tapplication, server, or other resource.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Calculated health checks:</b> Route 53 stops\n\t\t\t\t\taggregating the status of the referenced health checks.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Health checks that monitor CloudWatch alarms:</b>\n\t\t\t\t\tRoute 53 stops monitoring the corresponding CloudWatch metrics.</p>\n            </li>\n         </ul>\n         <p>After you disable a health check, Route 53 considers the status of the health check to\n\t\t\talways be healthy. If you configured DNS failover, Route 53 continues to route traffic\n\t\t\tto the corresponding resources. If you want to stop routing traffic to a resource,\n\t\t\tchange the value of <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-Inverted\">Inverted</a>. </p>\n         <p>Charges for a health check still apply when the health check is disabled. For more\n\t\t\tinformation, see <a href=\"http://aws.amazon.com/route53/pricing/\">Amazon Route 53\n\t\t\t\tPricing</a>.</p>"
+                    }
+                },
+                "HealthThreshold": {
+                    "target": "com.amazonaws.route53#HealthThreshold",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of child health checks that are associated with a <code>CALCULATED</code>\n\t\t\thealth check that Amazon Route 53 must consider healthy for the <code>CALCULATED</code>\n\t\t\thealth check to be considered healthy. To specify the child health checks that you want\n\t\t\tto associate with a <code>CALCULATED</code> health check, use the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-ChildHealthChecks\">ChildHealthChecks</a> element.</p>\n         <p>Note the following:</p>\n         <ul>\n            <li>\n               <p>If you specify a number greater than the number of child health checks, Route\n\t\t\t\t\t53 always considers this health check to be unhealthy.</p>\n            </li>\n            <li>\n               <p>If you specify <code>0</code>, Route 53 always considers this health check to\n\t\t\t\t\tbe healthy.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "ChildHealthChecks": {
+                    "target": "com.amazonaws.route53#ChildHealthCheckList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(CALCULATED Health Checks Only) A complex type that contains one\n\t\t\t\t<code>ChildHealthCheck</code> element for each health check that you want to\n\t\t\tassociate with a <code>CALCULATED</code> health check.</p>"
+                    }
+                },
+                "EnableSNI": {
+                    "target": "com.amazonaws.route53#EnableSNI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether you want Amazon Route 53 to send the value of\n\t\t\t\t<code>FullyQualifiedDomainName</code> to the endpoint in the\n\t\t\t\t<code>client_hello</code> message during TLS negotiation. This allows the endpoint\n\t\t\tto respond to <code>HTTPS</code> health check requests with the applicable SSL/TLS\n\t\t\tcertificate.</p>\n         <p>Some endpoints require that <code>HTTPS</code> requests include the host name in the\n\t\t\t\t<code>client_hello</code> message. If you don't enable SNI, the status of the health\n\t\t\tcheck will be <code>SSL alert handshake_failure</code>. A health check can also have\n\t\t\tthat status for other reasons. If SNI is enabled and you're still getting the error,\n\t\t\tcheck the SSL/TLS configuration on your endpoint and confirm that your certificate is\n\t\t\tvalid.</p>\n         <p>The SSL/TLS certificate on your endpoint includes a domain name in the <code>Common\n\t\t\t\tName</code> field and possibly several more in the <code>Subject Alternative\n\t\t\t\tNames</code> field. One of the domain names in the certificate should match the\n\t\t\tvalue that you specify for <code>FullyQualifiedDomainName</code>. If the endpoint\n\t\t\tresponds to the <code>client_hello</code> message with a certificate that does not\n\t\t\tinclude the domain name that you specified in <code>FullyQualifiedDomainName</code>, a\n\t\t\thealth checker will retry the handshake. In the second attempt, the health checker will\n\t\t\tomit <code>FullyQualifiedDomainName</code> from the <code>client_hello</code>\n\t\t\tmessage.</p>"
+                    }
+                },
+                "Regions": {
+                    "target": "com.amazonaws.route53#HealthCheckRegionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>Region</code> element for each region from\n\t\t\twhich you want Amazon Route 53 health checkers to check the specified endpoint.</p>\n         <p>If you don't specify any regions, Route 53 health checkers automatically performs\n\t\t\tchecks from all of the regions that are listed under <b>Valid\n\t\t\t\tValues</b>.</p>\n         <p>If you update a health check to remove a region that has been performing health\n\t\t\tchecks, Route 53 will briefly continue to perform checks from that region to ensure that\n\t\t\tsome health checkers are always checking the endpoint (for example, if you replace three\n\t\t\tregions with four different regions). </p>"
+                    }
+                },
+                "AlarmIdentifier": {
+                    "target": "com.amazonaws.route53#AlarmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53\n\t\t\thealth checkers to use to determine whether the specified health check is\n\t\t\thealthy.</p>"
+                    }
+                },
+                "InsufficientDataHealthStatus": {
+                    "target": "com.amazonaws.route53#InsufficientDataHealthStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When CloudWatch has insufficient data about the metric to determine the alarm state,\n\t\t\tthe status that you want Amazon Route 53 to assign to the health check:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Healthy</code>: Route 53 considers the health check to be\n\t\t\t\t\thealthy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Unhealthy</code>: Route 53 considers the health check to be\n\t\t\t\t\tunhealthy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LastKnownStatus</code>: Route 53 uses the status of the health check\n\t\t\t\t\tfrom the last time that CloudWatch had sufficient data to determine the alarm\n\t\t\t\t\tstate. For new health checks that have no last known status, the default status\n\t\t\t\t\tfor the health check is healthy.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "RoutingControlArn": {
+                    "target": "com.amazonaws.route53#RoutingControlArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller\n\t\t\trouting control.</p>\n         <p>For more information about Route 53 Application Recovery Controller, see <a href=\"https://docs.aws.amazon.com/r53recovery/latest/dg/what-is-route-53-recovery.html\">Route 53 Application Recovery Controller Developer Guide.</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the health check.</p>"
+            }
+        },
+        "com.amazonaws.route53#HealthCheckCount": {
+            "type": "long"
+        },
+        "com.amazonaws.route53#HealthCheckId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckInUse": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#deprecated": {},
+                "smithy.api#documentation": "<p>This error code is not in use.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#HealthCheckNonce": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckObservation": {
+            "type": "structure",
+            "members": {
+                "Region": {
+                    "target": "com.amazonaws.route53#HealthCheckRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The region of the Amazon Route 53 health checker that provided the status in\n\t\t\t\t<code>StatusReport</code>.</p>"
+                    }
+                },
+                "IPAddress": {
+                    "target": "com.amazonaws.route53#IPAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IP address of the Amazon Route 53 health checker that provided the failure reason\n\t\t\tin <code>StatusReport</code>.</p>"
+                    }
+                },
+                "StatusReport": {
+                    "target": "com.amazonaws.route53#StatusReport",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the last failure reason as reported by one Amazon Route\n\t\t\t53 health checker and the time of the failed health check.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the last failure reason as reported by one Amazon Route\n\t\t\t53 health checker.</p>"
+            }
+        },
+        "com.amazonaws.route53#HealthCheckObservations": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HealthCheckObservation",
+                "traits": {
+                    "smithy.api#xmlName": "HealthCheckObservation"
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckRegion": {
+            "type": "enum",
+            "members": {
+                "us_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-1"
+                    }
+                },
+                "us_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-1"
+                    }
+                },
+                "us_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-2"
+                    }
+                },
+                "eu_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-1"
+                    }
+                },
+                "ap_southeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-1"
+                    }
+                },
+                "ap_southeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-2"
+                    }
+                },
+                "ap_northeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-1"
+                    }
+                },
+                "sa_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sa-east-1"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckRegionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HealthCheckRegion",
+                "traits": {
+                    "smithy.api#xmlName": "Region"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckType": {
+            "type": "enum",
+            "members": {
+                "HTTP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTP"
+                    }
+                },
+                "HTTPS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTPS"
+                    }
+                },
+                "HTTP_STR_MATCH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTP_STR_MATCH"
+                    }
+                },
+                "HTTPS_STR_MATCH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTPS_STR_MATCH"
+                    }
+                },
+                "TCP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TCP"
+                    }
+                },
+                "CALCULATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CALCULATED"
+                    }
+                },
+                "CLOUDWATCH_METRIC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CLOUDWATCH_METRIC"
+                    }
+                },
+                "RECOVERY_CONTROL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RECOVERY_CONTROL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckVersion": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthCheckVersionMismatch": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The value of <code>HealthCheckVersion</code> in the request doesn't match the value of\n\t\t\t\t<code>HealthCheckVersion</code> in the health check.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#HealthChecks": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HealthCheck",
+                "traits": {
+                    "smithy.api#xmlName": "HealthCheck"
+                }
+            }
+        },
+        "com.amazonaws.route53#HealthThreshold": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.route53#HostedZone": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigned to the hosted zone when you created it.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the domain. For public hosted zones, this is the name that you have\n\t\t\tregistered with your DNS registrar.</p>\n         <p>For information about how to specify characters other than <code>a-z</code>,\n\t\t\t\t<code>0-9</code>, and <code>-</code> (hyphen) and how to specify internationalized\n\t\t\tdomain names, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html\">CreateHostedZone</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CallerReference": {
+                    "target": "com.amazonaws.route53#Nonce",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for <code>CallerReference</code> when you created the\n\t\t\thosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Config": {
+                    "target": "com.amazonaws.route53#HostedZoneConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that includes the <code>Comment</code> and <code>PrivateZone</code>\n\t\t\telements. If you omitted the <code>HostedZoneConfig</code> and <code>Comment</code>\n\t\t\telements from the request, the <code>Config</code> and <code>Comment</code> elements\n\t\t\tdon't appear in the response.</p>"
+                    }
+                },
+                "ResourceRecordSetCount": {
+                    "target": "com.amazonaws.route53#HostedZoneRRSetCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of resource record sets in the hosted zone.</p>"
+                    }
+                },
+                "LinkedService": {
+                    "target": "com.amazonaws.route53#LinkedService",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the hosted zone was created by another service, the service that created the hosted\n\t\t\tzone. When a hosted zone is created by another service, you can't edit or delete it\n\t\t\tusing Route 53. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains general information about the hosted zone.</p>"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The hosted zone you're trying to create already exists. Amazon Route 53 returns this\n\t\t\terror when a hosted zone has already been created with the specified\n\t\t\t\t<code>CallerReference</code>.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#HostedZoneConfig": {
+            "type": "structure",
+            "members": {
+                "Comment": {
+                    "target": "com.amazonaws.route53#ResourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Any comments that you want to include about the hosted zone.</p>"
+                    }
+                },
+                "PrivateZone": {
+                    "target": "com.amazonaws.route53#IsPrivateZone",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A value that indicates whether this is a private hosted zone.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains an optional comment about your hosted zone. If you don't\n\t\t\twant to specify a comment, omit both the <code>HostedZoneConfig</code> and\n\t\t\t\t<code>Comment</code> elements.</p>"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneCount": {
+            "type": "long"
+        },
+        "com.amazonaws.route53#HostedZoneLimit": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#HostedZoneLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit that you requested. Valid values include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>MAX_RRSETS_BY_ZONE</b>: The maximum number of\n\t\t\t\t\trecords that you can create in the specified hosted zone.</p>\n            </li>\n            <li>\n               <p>\n                  <b>MAX_VPCS_ASSOCIATED_BY_ZONE</b>: The maximum\n\t\t\t\t\tnumber of Amazon VPCs that you can associate with the specified private hosted\n\t\t\t\t\tzone.</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.route53#LimitValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current value for the limit that is specified by <code>Type</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the type of limit that you specified in the request and\n\t\t\tthe current value for that limit.</p>"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneLimitType": {
+            "type": "enum",
+            "members": {
+                "MAX_RRSETS_BY_ZONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_RRSETS_BY_ZONE"
+                    }
+                },
+                "MAX_VPCS_ASSOCIATED_BY_ZONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_VPCS_ASSOCIATED_BY_ZONE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#HostedZoneNotEmpty": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The hosted zone contains resource records that are not SOA or NS records.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#HostedZoneNotFound": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified HostedZone can't be found.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneNotPrivate": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified hosted zone is a public hosted zone, not a private hosted zone.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneOwner": {
+            "type": "structure",
+            "members": {
+                "OwningAccount": {
+                    "target": "com.amazonaws.route53#AWSAccountID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the hosted zone was created by an Amazon Web Services account, or was created by an\n\t\t\t\tAmazon Web Services service that creates hosted zones using the current account,\n\t\t\t\t<code>OwningAccount</code> contains the account ID of that account. For example,\n\t\t\twhen you use Cloud Map to create a hosted zone, Cloud Map creates the hosted\n\t\t\tzone using the current Amazon Web Services account. </p>"
+                    }
+                },
+                "OwningService": {
+                    "target": "com.amazonaws.route53#HostedZoneOwningService",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If an Amazon Web Services service uses its own account to create a hosted zone and\n\t\t\tassociate the specified VPC with that hosted zone, <code>OwningService</code> contains\n\t\t\tan abbreviation that identifies the service. For example, if Amazon Elastic File System\n\t\t\t(Amazon EFS) created a hosted zone and associated a VPC with the hosted zone, the value\n\t\t\tof <code>OwningService</code> is <code>efs.amazonaws.com</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that identifies a hosted zone that a specified Amazon VPC is associated\n\t\t\twith and the owner of the hosted zone. If there is a value for\n\t\t\t\t<code>OwningAccount</code>, there is no value for <code>OwningService</code>, and\n\t\t\tvice versa. </p>"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneOwningService": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#HostedZonePartiallyDelegated": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The hosted zone nameservers don't match the parent nameservers. The hosted zone and\n\t\t\tparent must have the same nameservers.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneRRSetCount": {
+            "type": "long"
+        },
+        "com.amazonaws.route53#HostedZoneSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HostedZoneSummary",
+                "traits": {
+                    "smithy.api#xmlName": "HostedZoneSummary"
+                }
+            }
+        },
+        "com.amazonaws.route53#HostedZoneSummary": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Route 53 hosted zone ID of a private hosted zone that the specified VPC is\n\t\t\tassociated with.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the private hosted zone, such as <code>example.com</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Owner": {
+                    "target": "com.amazonaws.route53#HostedZoneOwner",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The owner of a private hosted zone that the specified VPC is associated with. The\n\t\t\towner can be either an Amazon Web Services account or an Amazon Web Services\n\t\t\tservice.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>In the response to a <code>ListHostedZonesByVPC</code> request, the\n\t\t\t\t<code>HostedZoneSummaries</code> element contains one <code>HostedZoneSummary</code>\n\t\t\telement for each hosted zone that the specified Amazon VPC is associated with. Each\n\t\t\t\t<code>HostedZoneSummary</code> element contains the hosted zone name and ID, and\n\t\t\tinformation about who owns the hosted zone.</p>"
+            }
+        },
+        "com.amazonaws.route53#HostedZoneType": {
+            "type": "enum",
+            "members": {
+                "PRIVATE_HOSTED_ZONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PrivateHostedZone"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#HostedZones": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#HostedZone",
+                "traits": {
+                    "smithy.api#xmlName": "HostedZone"
+                }
+            }
+        },
+        "com.amazonaws.route53#IPAddress": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 45
+                },
+                "smithy.api#pattern": "^(^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$|^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)$"
+            }
+        },
+        "com.amazonaws.route53#IPAddressCidr": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#IncompatibleVersion": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The resource you're trying to access is unsupported on this Amazon Route 53\n\t\t\tendpoint.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InsufficientCloudWatchLogsResourcePolicy": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Amazon Route 53 doesn't have the permissions required to create log streams and send\n\t\t\tquery logs to log streams. Possible causes include the following:</p>\n         <ul>\n            <li>\n               <p>There is no resource policy that specifies the log group ARN in the value for\n\t\t\t\t\t\t<code>Resource</code>.</p>\n            </li>\n            <li>\n               <p>The resource policy that includes the log group ARN in the value for\n\t\t\t\t\t\t<code>Resource</code> doesn't have the necessary permissions.</p>\n            </li>\n            <li>\n               <p>The resource policy hasn't finished propagating yet.</p>\n            </li>\n            <li>\n               <p>The Key management service (KMS) key you specified doesn’t exist or it can’t\n\t\t\t\t\tbe used with the log group associated with query log. Update or provide a\n\t\t\t\t\tresource policy to grant permissions for the KMS key.</p>\n            </li>\n            <li>\n               <p>The Key management service (KMS) key you specified is marked as \n\t\t\t\tdisabled for the log group associated with query log. Update or provide \n\t\t\t\ta resource policy to grant permissions for the KMS key.</p>\n            </li>\n         </ul>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InsufficientDataHealthStatus": {
+            "type": "enum",
+            "members": {
+                "Healthy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Healthy"
+                    }
+                },
+                "Unhealthy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Unhealthy"
+                    }
+                },
+                "LastKnownStatus": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LastKnownStatus"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#InvalidArgument": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Parameter name is not valid.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#InvalidChangeBatch": {
+            "type": "structure",
+            "members": {
+                "messages": {
+                    "target": "com.amazonaws.route53#ErrorMessages",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This exception contains a list of messages that might contain one or more error\n\t\t\tmessages. Each error message indicates one error in the change batch.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#InvalidDomainName": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified domain name is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidInput": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidKMSArn": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The KeyManagementServiceArn that you specified isn't valid to use with DNSSEC\n\t\t\tsigning.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#InvalidKeySigningKeyName": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The key-signing key (KSK) name that you specified isn't a valid name.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidKeySigningKeyStatus": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The key-signing key (KSK) status isn't valid or another KSK has the status\n\t\t\t\t<code>INTERNAL_FAILURE</code>.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidPaginationToken": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The value that you specified to get the second or subsequent page of results is\n\t\t\tinvalid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidSigningStatus": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Your hosted zone status isn't valid for this operation. In the hosted zone, change the\n\t\t\tstatus to enable <code>DNSSEC</code> or disable <code>DNSSEC</code>.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#InvalidTrafficPolicyDocument": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The format of the traffic policy document that you specified in the\n\t\t\t\t<code>Document</code> element is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#InvalidVPCId": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The VPC ID that you specified either isn't a valid ID or the current account is not\n\t\t\tauthorized to access this VPC.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#Inverted": {
+            "type": "boolean"
+        },
+        "com.amazonaws.route53#IsPrivateZone": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.route53#KeySigningKey": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#SigningKeyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to identify a key-signing key (KSK). <code>Name</code> can include\n\t\t\tnumbers, letters, and underscores (_). <code>Name</code> must be unique for each\n\t\t\tkey-signing key in the same hosted zone.</p>"
+                    }
+                },
+                "KmsArn": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon resource name (ARN) used to identify the customer managed key in Key Management Service (KMS). The <code>KmsArn</code> must be unique for each\n\t\t\tkey-signing key (KSK) in a single hosted zone.</p>\n         <p>You must configure the customer managed key as follows:</p>\n         <dl>\n            <dt>Status</dt>\n            <dd>\n               <p>Enabled</p>\n            </dd>\n            <dt>Key spec</dt>\n            <dd>\n               <p>ECC_NIST_P256</p>\n            </dd>\n            <dt>Key usage</dt>\n            <dd>\n               <p>Sign and verify</p>\n            </dd>\n            <dt>Key policy</dt>\n            <dd>\n               <p>The key policy must give permission for the following actions:</p>\n               <ul>\n                  <li>\n                     <p>DescribeKey</p>\n                  </li>\n                  <li>\n                     <p>GetPublicKey</p>\n                  </li>\n                  <li>\n                     <p>Sign</p>\n                  </li>\n               </ul>\n               <p>The key policy must also include the Amazon Route 53 service in the\n\t\t\t\t\t\tprincipal for your account. Specify the following:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>\"Service\": \"dnssec-route53.amazonaws.com\"</code>\n                     </p>\n                  </li>\n               </ul>\n            </dd>\n         </dl>\n         <p>For more information about working with the customer managed key in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html\">Key Management Service\n\t\t\t\tconcepts</a>.</p>"
+                    }
+                },
+                "Flag": {
+                    "target": "com.amazonaws.route53#SigningKeyInteger",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>An integer that specifies how the key is used. For key-signing key (KSK), this value\n\t\t\tis always 257.</p>"
+                    }
+                },
+                "SigningAlgorithmMnemonic": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to represent the signing algorithm. This value must follow the\n\t\t\tguidelines provided by <a href=\"https://tools.ietf.org/html/rfc8624#section-3.1\">RFC-8624 Section 3.1</a>. </p>"
+                    }
+                },
+                "SigningAlgorithmType": {
+                    "target": "com.amazonaws.route53#SigningKeyInteger",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>An integer used to represent the signing algorithm. This value must follow the\n\t\t\tguidelines provided by <a href=\"https://tools.ietf.org/html/rfc8624#section-3.1\">RFC-8624 Section 3.1</a>. </p>"
+                    }
+                },
+                "DigestAlgorithmMnemonic": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string used to represent the delegation signer digest algorithm. This value must\n\t\t\tfollow the guidelines provided by <a href=\"https://tools.ietf.org/html/rfc8624#section-3.3\">RFC-8624 Section 3.3</a>.\n\t\t</p>"
+                    }
+                },
+                "DigestAlgorithmType": {
+                    "target": "com.amazonaws.route53#SigningKeyInteger",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>An integer used to represent the delegation signer digest algorithm. This value must\n\t\t\tfollow the guidelines provided by <a href=\"https://tools.ietf.org/html/rfc8624#section-3.3\">RFC-8624 Section\n\t\t\t3.3</a>.</p>"
+                    }
+                },
+                "KeyTag": {
+                    "target": "com.amazonaws.route53#SigningKeyTag",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>An integer used to identify the DNSSEC record for the domain name. The process used to\n\t\t\tcalculate the value is described in <a href=\"https://tools.ietf.org/rfc/rfc4034.txt\">RFC-4034 Appendix B</a>.</p>"
+                    }
+                },
+                "DigestValue": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A cryptographic digest of a DNSKEY resource record (RR). DNSKEY records are used to\n\t\t\tpublish the public key that resolvers can use to verify DNSSEC signatures that are used\n\t\t\tto secure certain kinds of information provided by the DNS system.</p>"
+                    }
+                },
+                "PublicKey": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The public key, represented as a Base64 encoding, as required by <a href=\"https://tools.ietf.org/rfc/rfc4034.txt\"> RFC-4034 Page 5</a>.</p>"
+                    }
+                },
+                "DSRecord": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string that represents a delegation signer (DS) record.</p>"
+                    }
+                },
+                "DNSKEYRecord": {
+                    "target": "com.amazonaws.route53#SigningKeyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string that represents a DNSKEY record.</p>"
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.route53#SigningKeyStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string that represents the current key-signing key (KSK) status.</p>\n         <p>Status can have one of the following values:</p>\n         <dl>\n            <dt>ACTIVE</dt>\n            <dd>\n               <p>The KSK is being used for signing.</p>\n            </dd>\n            <dt>INACTIVE</dt>\n            <dd>\n               <p>The KSK is not being used for signing.</p>\n            </dd>\n            <dt>DELETING</dt>\n            <dd>\n               <p>The KSK is in the process of being deleted.</p>\n            </dd>\n            <dt>ACTION_NEEDED</dt>\n            <dd>\n               <p>There is a problem with the KSK that requires you to take action to\n\t\t\t\t\t\tresolve. For example, the customer managed key might have been deleted,\n\t\t\t\t\t\tor the permissions for the customer managed key might have been\n\t\t\t\t\t\tchanged.</p>\n            </dd>\n            <dt>INTERNAL_FAILURE</dt>\n            <dd>\n               <p>There was an error during a request. Before you can continue to work with\n\t\t\t\t\t\tDNSSEC signing, including actions that involve this KSK, you must correct\n\t\t\t\t\t\tthe problem. For example, you may need to activate or deactivate the\n\t\t\t\t\t\tKSK.</p>\n            </dd>\n         </dl>"
+                    }
+                },
+                "StatusMessage": {
+                    "target": "com.amazonaws.route53#SigningKeyStatusMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status message provided for the following key-signing key (KSK) statuses:\n\t\t\t\t<code>ACTION_NEEDED</code> or <code>INTERNAL_FAILURE</code>. The status message\n\t\t\tincludes information about what the problem might be and steps that you can take to\n\t\t\tcorrect the issue.</p>"
+                    }
+                },
+                "CreatedDate": {
+                    "target": "com.amazonaws.route53#TimeStamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date when the key-signing key (KSK) was created.</p>"
+                    }
+                },
+                "LastModifiedDate": {
+                    "target": "com.amazonaws.route53#TimeStamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The last time that the key-signing key (KSK) was changed.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A key-signing key (KSK) is a complex type that represents a public/private key pair.\n\t\t\tThe private key is used to generate a digital signature for the zone signing key (ZSK).\n\t\t\tThe public key is stored in the DNS and is used to authenticate the ZSK. A KSK is always\n\t\t\tassociated with a hosted zone; it cannot exist by itself.</p>"
+            }
+        },
+        "com.amazonaws.route53#KeySigningKeyAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You've already created a key-signing key (KSK) with this name or with the same customer managed key ARN.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#KeySigningKeyInParentDSRecord": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The key-signing key (KSK) is specified in a parent DS record.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#KeySigningKeyInUse": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The key-signing key (KSK) that you specified can't be deactivated because it's the\n\t\t\tonly KSK for a currently-enabled DNSSEC. Disable DNSSEC signing, or add or enable\n\t\t\tanother KSK.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#KeySigningKeyWithActiveStatusNotFound": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A key-signing key (KSK) with <code>ACTIVE</code> status wasn't found.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#KeySigningKeys": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#KeySigningKey"
+            }
+        },
+        "com.amazonaws.route53#LastVPCAssociation": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The VPC that you're trying to disassociate from the private hosted zone is the last\n\t\t\tVPC that is associated with the hosted zone. Amazon Route 53 doesn't support\n\t\t\tdisassociating the last VPC from a hosted zone.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#Latitude": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 6
+                },
+                "smithy.api#pattern": "^[-+]?[0-9]{1,2}(\\.[0-9]{0,2})?$"
+            }
+        },
+        "com.amazonaws.route53#LimitValue": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#LimitsExceeded": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This operation can't be completed because the current account has reached the\n\t\t\tlimit on the resource you are trying to create. To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a case</a> with the Amazon Web Services Support\n\t\t\tCenter.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#LinkedService": {
+            "type": "structure",
+            "members": {
+                "ServicePrincipal": {
+                    "target": "com.amazonaws.route53#ServicePrincipal",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the health check or hosted zone was created by another service, the service that\n\t\t\tcreated the resource. When a resource is created by another service, you can't edit or\n\t\t\tdelete it using Amazon Route 53. </p>"
+                    }
+                },
+                "Description": {
+                    "target": "com.amazonaws.route53#ResourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the health check or hosted zone was created by another service, an optional\n\t\t\tdescription that can be provided by the other service. When a resource is created by\n\t\t\tanother service, you can't edit or delete it using Amazon Route 53. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>If a health check or hosted zone was created by another service,\n\t\t\t\t<code>LinkedService</code> is a complex type that describes the service that created\n\t\t\tthe resource. When a resource is created by another service, you can't edit or delete it\n\t\t\tusing Amazon Route 53. </p>"
+            }
+        },
+        "com.amazonaws.route53#ListCidrBlocks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListCidrBlocksRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListCidrBlocksResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCidrCollectionException"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCidrLocationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a paginated list of location objects and their CIDR blocks.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/cidrcollection/{CollectionId}/cidrblocks",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "items": "CidrBlocks",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.route53#ListCidrBlocksRequest": {
+            "type": "structure",
+            "members": {
+                "CollectionId": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The UUID of the CIDR collection.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "LocationName": {
+                    "target": "com.amazonaws.route53#CidrLocationNameDefaultNotAllowed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CIDR collection location.</p>",
+                        "smithy.api#httpQuery": "location"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                },
+                "MaxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Maximum number of results you want returned.</p>",
+                        "smithy.api#httpQuery": "maxresults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListCidrBlocksResponse": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults. </p>\n         <p>If no value is provided, the listing of results starts from the beginning.</p>"
+                    }
+                },
+                "CidrBlocks": {
+                    "target": "com.amazonaws.route53#CidrBlockSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the CIDR blocks.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListCidrCollections": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListCidrCollectionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListCidrCollectionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a paginated list of CIDR collections in the Amazon Web Services account\n\t\t\t(metadata only).</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/cidrcollection",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "items": "CidrCollections",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.route53#ListCidrCollectionsRequest": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults.</p>\n         <p>If no value is provided, the listing of results starts from the beginning.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                },
+                "MaxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of CIDR collections to return in the response.</p>",
+                        "smithy.api#httpQuery": "maxresults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListCidrCollectionsResponse": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults.</p>\n         <p>If no value is provided, the listing of results starts from the beginning.</p>"
+                    }
+                },
+                "CidrCollections": {
+                    "target": "com.amazonaws.route53#CollectionSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type with information about the CIDR collection.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListCidrLocations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListCidrLocationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListCidrLocationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchCidrCollectionException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a paginated list of CIDR locations for the given collection (metadata only,\n\t\t\tdoes not include CIDR blocks).</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/cidrcollection/{CollectionId}",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "items": "CidrLocations",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.route53#ListCidrLocationsRequest": {
+            "type": "structure",
+            "members": {
+                "CollectionId": {
+                    "target": "com.amazonaws.route53#UUID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CIDR collection ID.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults.</p>\n         <p>If no value is provided, the listing of results starts from the beginning.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                },
+                "MaxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of CIDR collection locations to return in the response.</p>",
+                        "smithy.api#httpQuery": "maxresults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListCidrLocationsResponse": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token to indicate where the service is to begin enumerating\n\t\t\tresults.</p>\n         <p>If no value is provided, the listing of results starts from the beginning.</p>"
+                    }
+                },
+                "CidrLocations": {
+                    "target": "com.amazonaws.route53#LocationSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains information about the list of CIDR locations.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListGeoLocations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListGeoLocationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListGeoLocationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of supported geographic locations.</p>\n         <p>Countries are listed first, and continents are listed last. If Amazon Route 53\n\t\t\tsupports subdivisions for a country (for example, states or provinces), the subdivisions\n\t\t\tfor that country are listed in alphabetical order immediately after the corresponding\n\t\t\tcountry.</p>\n         <p>Route 53 does not perform authorization for this API because it retrieves information\n\t\t\tthat is already available to the public.</p>\n         <p>For a list of supported geolocation codes, see the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GeoLocation.html\">GeoLocation</a> data\n\t\t\ttype.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/geolocations",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListGeoLocationsRequest": {
+            "type": "structure",
+            "members": {
+                "StartContinentCode": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code for the continent with which you want to start listing locations that Amazon\n\t\t\tRoute 53 supports for geolocation. If Route 53 has already returned a page or more of\n\t\t\tresults, if <code>IsTruncated</code> is true, and if <code>NextContinentCode</code> from\n\t\t\tthe previous response has a value, enter that value in <code>startcontinentcode</code>\n\t\t\tto return the next page of results.</p>\n         <p>Include <code>startcontinentcode</code> only if you want to list continents. Don't\n\t\t\tinclude <code>startcontinentcode</code> when you're listing countries or countries with\n\t\t\ttheir subdivisions.</p>",
+                        "smithy.api#httpQuery": "startcontinentcode"
+                    }
+                },
+                "StartCountryCode": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code for the country with which you want to start listing locations that Amazon\n\t\t\tRoute 53 supports for geolocation. If Route 53 has already returned a page or more of\n\t\t\tresults, if <code>IsTruncated</code> is <code>true</code>, and if\n\t\t\t\t<code>NextCountryCode</code> from the previous response has a value, enter that\n\t\t\tvalue in <code>startcountrycode</code> to return the next page of results.</p>",
+                        "smithy.api#httpQuery": "startcountrycode"
+                    }
+                },
+                "StartSubdivisionCode": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code for the state of the United States with which you want to start listing\n\t\t\tlocations that Amazon Route 53 supports for geolocation. If Route 53 has already\n\t\t\treturned a page or more of results, if <code>IsTruncated</code> is <code>true</code>,\n\t\t\tand if <code>NextSubdivisionCode</code> from the previous response has a value, enter\n\t\t\tthat value in <code>startsubdivisioncode</code> to return the next page of\n\t\t\tresults.</p>\n         <p>To list subdivisions (U.S. states), you must include both\n\t\t\t\t<code>startcountrycode</code> and <code>startsubdivisioncode</code>.</p>",
+                        "smithy.api#httpQuery": "startsubdivisioncode"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of geolocations to be included in the response body for this\n\t\t\trequest. If more than <code>maxitems</code> geolocations remain to be listed, then the\n\t\t\tvalue of the <code>IsTruncated</code> element in the response is\n\t\t\t<code>true</code>.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get a list of geographic locations that Amazon Route 53 supports for\n\t\t\tgeolocation resource record sets. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListGeoLocationsResponse": {
+            "type": "structure",
+            "members": {
+                "GeoLocationDetailsList": {
+                    "target": "com.amazonaws.route53#GeoLocationDetailsList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>GeoLocationDetails</code> element for each\n\t\t\tlocation that Amazon Route 53 supports for geolocation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A value that indicates whether more locations remain to be listed after the last\n\t\t\tlocation in this response. If so, the value of <code>IsTruncated</code> is\n\t\t\t\t<code>true</code>. To get more values, submit another request and include the values\n\t\t\tof <code>NextContinentCode</code>, <code>NextCountryCode</code>, and\n\t\t\t\t<code>NextSubdivisionCode</code> in the <code>startcontinentcode</code>,\n\t\t\t\t<code>startcountrycode</code>, and <code>startsubdivisioncode</code>, as\n\t\t\tapplicable.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextContinentCode": {
+                    "target": "com.amazonaws.route53#GeoLocationContinentCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to\n\t\t\tdisplay more locations. Enter the value of <code>NextContinentCode</code> in the\n\t\t\t\t<code>startcontinentcode</code> parameter in another <code>ListGeoLocations</code>\n\t\t\trequest.</p>"
+                    }
+                },
+                "NextCountryCode": {
+                    "target": "com.amazonaws.route53#GeoLocationCountryCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to\n\t\t\tdisplay more locations. Enter the value of <code>NextCountryCode</code> in the\n\t\t\t\t<code>startcountrycode</code> parameter in another <code>ListGeoLocations</code>\n\t\t\trequest.</p>"
+                    }
+                },
+                "NextSubdivisionCode": {
+                    "target": "com.amazonaws.route53#GeoLocationSubdivisionCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to\n\t\t\tdisplay more locations. Enter the value of <code>NextSubdivisionCode</code> in the\n\t\t\t\t<code>startsubdivisioncode</code> parameter in another <code>ListGeoLocations</code>\n\t\t\trequest.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for <code>MaxItems</code> in the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListHealthChecks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListHealthChecksRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListHealthChecksResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#IncompatibleVersion"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieve a list of the health checks that are associated with the current Amazon Web Services account. </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/healthcheck",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "Marker",
+                    "outputToken": "NextMarker",
+                    "items": "HealthChecks",
+                    "pageSize": "MaxItems"
+                }
+            }
+        },
+        "com.amazonaws.route53#ListHealthChecksRequest": {
+            "type": "structure",
+            "members": {
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more health checks. To get another group, submit another\n\t\t\t\t<code>ListHealthChecks</code> request. </p>\n         <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code>\n\t\t\tfrom the previous response, which is the ID of the first health check that Amazon Route\n\t\t\t53 will return if you submit another request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more health checks to get.</p>",
+                        "smithy.api#httpQuery": "marker"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of health checks that you want <code>ListHealthChecks</code> to\n\t\t\treturn in response to the current request. Amazon Route 53 returns a maximum of 1000\n\t\t\titems. If you set <code>MaxItems</code> to a value greater than 1000, Route 53 returns\n\t\t\tonly the first 1000 health checks. </p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to retrieve a list of the health checks that are associated with the current\n\t\t\t\tAmazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListHealthChecksResponse": {
+            "type": "structure",
+            "members": {
+                "HealthChecks": {
+                    "target": "com.amazonaws.route53#HealthChecks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>HealthCheck</code> element for each health\n\t\t\tcheck that is associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the second and subsequent calls to <code>ListHealthChecks</code>,\n\t\t\t\t<code>Marker</code> is the value that you specified for the <code>marker</code>\n\t\t\tparameter in the previous request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more health checks to be listed. If the\n\t\t\tresponse was truncated, you can get the next group of health checks by submitting\n\t\t\tanother <code>ListHealthChecks</code> request and specifying the value of\n\t\t\t\t<code>NextMarker</code> in the <code>marker</code> parameter.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextMarker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code>\n\t\t\tidentifies the first health check that Amazon Route 53 returns if you submit another\n\t\t\t\t<code>ListHealthChecks</code> request and specify the value of\n\t\t\t\t<code>NextMarker</code> in the <code>marker</code> parameter.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>maxitems</code> parameter in the call to\n\t\t\t\t<code>ListHealthChecks</code> that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>ListHealthChecks</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZones": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListHostedZonesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListHostedZonesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#DelegationSetNotReusable"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchDelegationSet"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of the public and private hosted zones that are associated with the\n\t\t\tcurrent Amazon Web Services account. The response includes a <code>HostedZones</code>\n\t\t\tchild element for each hosted zone.</p>\n         <p>Amazon Route 53 returns a maximum of 100 items in each response. If you have a lot of\n\t\t\thosted zones, you can use the <code>maxitems</code> parameter to list them in groups of\n\t\t\tup to 100.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzone",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "Marker",
+                    "outputToken": "NextMarker",
+                    "items": "HostedZones",
+                    "pageSize": "MaxItems"
+                },
+                "smithy.test#smokeTests": [
+                    {
+                        "id": "ListHostedZonesSuccess",
+                        "params": {},
+                        "vendorParams": {
+                            "region": "us-east-1"
+                        },
+                        "vendorParamsShape": "aws.test#AwsVendorParams",
+                        "expect": {
+                            "success": {}
+                        }
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByName": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListHostedZonesByNameRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListHostedZonesByNameResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidDomainName"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of your hosted zones in lexicographic order. The response includes a\n\t\t\t\t<code>HostedZones</code> child element for each hosted zone created by the current\n\t\t\t\tAmazon Web Services account. </p>\n         <p>\n            <code>ListHostedZonesByName</code> sorts hosted zones by name with the labels\n\t\t\treversed. For example:</p>\n         <p>\n            <code>com.example.www.</code>\n         </p>\n         <p>Note the trailing dot, which can change the sort order in some circumstances.</p>\n         <p>If the domain name includes escape characters or Punycode,\n\t\t\t\t<code>ListHostedZonesByName</code> alphabetizes the domain name using the escaped or\n\t\t\tPunycoded value, which is the format that Amazon Route 53 saves in its database. For\n\t\t\texample, to create a hosted zone for exämple.com, you specify ex\\344mple.com for\n\t\t\tthe domain name. <code>ListHostedZonesByName</code> alphabetizes it as:</p>\n         <p>\n            <code>com.ex\\344mple.</code>\n         </p>\n         <p>The labels are reversed and alphabetized using the escaped value. For more information\n\t\t\tabout valid domain name formats, including internationalized domain names, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html\">DNS\n\t\t\t\tDomain Name Format</a> in the <i>Amazon Route 53 Developer\n\t\t\t\tGuide</i>.</p>\n         <p>Route 53 returns up to 100 items in each response. If you have a lot of hosted zones,\n\t\t\tuse the <code>MaxItems</code> parameter to list them in groups of up to 100. The\n\t\t\tresponse includes values that help navigate from one group of <code>MaxItems</code>\n\t\t\thosted zones to the next:</p>\n         <ul>\n            <li>\n               <p>The <code>DNSName</code> and <code>HostedZoneId</code> elements in the\n\t\t\t\t\tresponse contain the values, if any, specified for the <code>dnsname</code> and\n\t\t\t\t\t\t<code>hostedzoneid</code> parameters in the request that produced the\n\t\t\t\t\tcurrent response.</p>\n            </li>\n            <li>\n               <p>The <code>MaxItems</code> element in the response contains the value, if any,\n\t\t\t\t\tthat you specified for the <code>maxitems</code> parameter in the request that\n\t\t\t\t\tproduced the current response.</p>\n            </li>\n            <li>\n               <p>If the value of <code>IsTruncated</code> in the response is true, there are\n\t\t\t\t\tmore hosted zones associated with the current Amazon Web Services account. </p>\n               <p>If <code>IsTruncated</code> is false, this response includes the last hosted\n\t\t\t\t\tzone that is associated with the current account. The <code>NextDNSName</code>\n\t\t\t\t\telement and <code>NextHostedZoneId</code> elements are omitted from the\n\t\t\t\t\tresponse.</p>\n            </li>\n            <li>\n               <p>The <code>NextDNSName</code> and <code>NextHostedZoneId</code> elements in the\n\t\t\t\t\tresponse contain the domain name and the hosted zone ID of the next hosted zone\n\t\t\t\t\tthat is associated with the current Amazon Web Services account. If you want to\n\t\t\t\t\tlist more hosted zones, make another call to <code>ListHostedZonesByName</code>,\n\t\t\t\t\tand specify the value of <code>NextDNSName</code> and\n\t\t\t\t\t\t<code>NextHostedZoneId</code> in the <code>dnsname</code> and\n\t\t\t\t\t\t<code>hostedzoneid</code> parameters, respectively.</p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzonesbyname",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByNameRequest": {
+            "type": "structure",
+            "members": {
+                "DNSName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) For your first request to <code>ListHostedZonesByName</code>, include the\n\t\t\t\t<code>dnsname</code> parameter only if you want to specify the name of the first\n\t\t\thosted zone in the response. If you don't include the <code>dnsname</code> parameter,\n\t\t\tAmazon Route 53 returns all of the hosted zones that were created by the current Amazon Web Services account, in ASCII order. For subsequent requests, include both\n\t\t\t\t<code>dnsname</code> and <code>hostedzoneid</code> parameters. For\n\t\t\t\t<code>dnsname</code>, specify the value of <code>NextDNSName</code> from the\n\t\t\tprevious response.</p>",
+                        "smithy.api#httpQuery": "dnsname"
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) For your first request to <code>ListHostedZonesByName</code>, do not\n\t\t\tinclude the <code>hostedzoneid</code> parameter.</p>\n         <p>If you have more hosted zones than the value of <code>maxitems</code>,\n\t\t\t\t<code>ListHostedZonesByName</code> returns only the first <code>maxitems</code>\n\t\t\thosted zones. To get the next group of <code>maxitems</code> hosted zones, submit\n\t\t\tanother request to <code>ListHostedZonesByName</code> and include both\n\t\t\t\t<code>dnsname</code> and <code>hostedzoneid</code> parameters. For the value of\n\t\t\t\t<code>hostedzoneid</code>, specify the value of the <code>NextHostedZoneId</code>\n\t\t\telement from the previous response.</p>",
+                        "smithy.api#httpQuery": "hostedzoneid"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of hosted zones to be included in the response body for this\n\t\t\trequest. If you have more than <code>maxitems</code> hosted zones, then the value of the\n\t\t\t\t<code>IsTruncated</code> element in the response is true, and the values of\n\t\t\t\t<code>NextDNSName</code> and <code>NextHostedZoneId</code> specify the first hosted\n\t\t\tzone in the next group of <code>maxitems</code> hosted zones. </p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of the public and private hosted zones that are associated with the\n\t\t\tcurrent Amazon Web Services account in ASCII order by domain name. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByNameResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZones": {
+                    "target": "com.amazonaws.route53#HostedZones",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains general information about the hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DNSName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the second and subsequent calls to <code>ListHostedZonesByName</code>,\n\t\t\t\t<code>DNSName</code> is the value that you specified for the <code>dnsname</code>\n\t\t\tparameter in the request that produced the current response.</p>"
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigned to the hosted zone when you created it.</p>"
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more hosted zones to be listed. If the\n\t\t\tresponse was truncated, you can get the next group of <code>maxitems</code> hosted zones\n\t\t\tby calling <code>ListHostedZonesByName</code> again and specifying the values of\n\t\t\t\t<code>NextDNSName</code> and <code>NextHostedZoneId</code> elements in the\n\t\t\t\t<code>dnsname</code> and <code>hostedzoneid</code> parameters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextDNSName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is true, the value of <code>NextDNSName</code> is the name\n\t\t\tof the first hosted zone in the next group of <code>maxitems</code> hosted zones. Call\n\t\t\t\t<code>ListHostedZonesByName</code> again and specify the value of\n\t\t\t\t<code>NextDNSName</code> and <code>NextHostedZoneId</code> in the\n\t\t\t\t<code>dnsname</code> and <code>hostedzoneid</code> parameters, respectively.</p>\n         <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"
+                    }
+                },
+                "NextHostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, the value of\n\t\t\t\t<code>NextHostedZoneId</code> identifies the first hosted zone in the next group of\n\t\t\t\t<code>maxitems</code> hosted zones. Call <code>ListHostedZonesByName</code> again\n\t\t\tand specify the value of <code>NextDNSName</code> and <code>NextHostedZoneId</code> in\n\t\t\tthe <code>dnsname</code> and <code>hostedzoneid</code> parameters, respectively.</p>\n         <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>maxitems</code> parameter in the call to\n\t\t\t\t<code>ListHostedZonesByName</code> that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByVPC": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListHostedZonesByVPCRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListHostedZonesByVPCResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidPaginationToken"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists all the private hosted zones that a specified VPC is associated with, regardless\n\t\t\tof which Amazon Web Services account or Amazon Web Services service owns the hosted zones.\n\t\t\tThe <code>HostedZoneOwner</code> structure in the response contains one of the following\n\t\t\tvalues:</p>\n         <ul>\n            <li>\n               <p>An <code>OwningAccount</code> element, which contains the account number of\n\t\t\t\t\teither the current Amazon Web Services account or another Amazon Web Services account. Some services, such as Cloud Map, create\n\t\t\t\t\thosted zones using the current account. </p>\n            </li>\n            <li>\n               <p>An <code>OwningService</code> element, which identifies the Amazon Web Services\n\t\t\t\t\tservice that created and owns the hosted zone. For example, if a hosted zone was\n\t\t\t\t\tcreated by Amazon Elastic File System (Amazon EFS), the value of\n\t\t\t\t\t\t<code>Owner</code> is <code>efs.amazonaws.com</code>. </p>\n            </li>\n         </ul>\n         <p>\n            <code>ListHostedZonesByVPC</code> returns the hosted zones associated with the specified VPC and does not reflect the hosted zone\n\t\t\tassociations to VPCs via Route 53 Profiles. To get the associations to a Profile, call the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_ListProfileResourceAssociations.html\">ListProfileResourceAssociations</a> API.</p>\n         <note>\n            <p>When listing private hosted zones, the hosted zone and the Amazon VPC must\n\t\t\t\tbelong to the same partition where the hosted zones were created. A partition is a\n\t\t\t\tgroup of Amazon Web Services Regions. Each Amazon Web Services account is scoped to\n\t\t\t\tone partition.</p>\n            <p>The following are the supported partitions:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>aws</code> - Amazon Web Services Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-cn</code> - China Regions</p>\n               </li>\n               <li>\n                  <p>\n                     <code>aws-us-gov</code> - Amazon Web Services GovCloud (US) Region</p>\n               </li>\n            </ul>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Access Management</a>\n\t\t\t\tin the <i>Amazon Web Services General Reference</i>.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzonesbyvpc",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByVPCRequest": {
+            "type": "structure",
+            "members": {
+                "VPCId": {
+                    "target": "com.amazonaws.route53#VPCId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the Amazon VPC that you want to list hosted zones for.</p>",
+                        "smithy.api#httpQuery": "vpcid",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VPCRegion": {
+                    "target": "com.amazonaws.route53#VPCRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the Amazon VPC that you specified for <code>VPCId</code>, the Amazon Web Services\n\t\t\tRegion that you created the VPC in. </p>",
+                        "smithy.api#httpQuery": "vpcregion",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of hosted zones that you want Amazon Route 53 to return.\n\t\t\tIf the specified VPC is associated with more than <code>MaxItems</code> hosted zones,\n\t\t\tthe response includes a <code>NextToken</code> element. <code>NextToken</code> contains\n\t\t\tan encrypted token that identifies the first hosted zone that Route 53 will return if\n\t\t\tyou submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the previous response included a <code>NextToken</code> element, the specified VPC\n\t\t\tis associated with more hosted zones. To get more hosted zones, submit another\n\t\t\t\t<code>ListHostedZonesByVPC</code> request. </p>\n         <p>For the value of <code>NextToken</code>, specify the value of <code>NextToken</code>\n\t\t\tfrom the previous response.</p>\n         <p>If the previous response didn't include a <code>NextToken</code> element, there are no\n\t\t\tmore hosted zones to get.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Lists all the private hosted zones that a specified VPC is associated with, regardless\n\t\t\tof which Amazon Web Services account created the hosted zones.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesByVPCResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZoneSummaries": {
+                    "target": "com.amazonaws.route53#HostedZoneSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>HostedZoneSummary</code> element for each hosted zone\n\t\t\tthat the specified Amazon VPC is associated with. Each <code>HostedZoneSummary</code>\n\t\t\telement contains the hosted zone name and ID, and information about who owns the hosted\n\t\t\tzone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for <code>MaxItems</code> in the most recent\n\t\t\t\t<code>ListHostedZonesByVPC</code> request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you will use for <code>NextToken</code> in the next\n\t\t\t\t<code>ListHostedZonesByVPC</code> request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesRequest": {
+            "type": "structure",
+            "members": {
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more hosted zones. To get more hosted zones, submit\n\t\t\tanother <code>ListHostedZones</code> request. </p>\n         <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code>\n\t\t\tfrom the previous response, which is the ID of the first hosted zone that Amazon Route\n\t\t\t53 will return if you submit another request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more hosted zones to get.</p>",
+                        "smithy.api#httpQuery": "marker"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of hosted zones that you want Amazon Route 53 to return.\n\t\t\tIf you have more than <code>maxitems</code> hosted zones, the value of\n\t\t\t\t<code>IsTruncated</code> in the response is <code>true</code>, and the value of\n\t\t\t\t<code>NextMarker</code> is the hosted zone ID of the first hosted zone that Route 53\n\t\t\twill return if you submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                },
+                "DelegationSetId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you're using reusable delegation sets and you want to list all of the hosted zones\n\t\t\tthat are associated with a reusable delegation set, specify the ID of that reusable\n\t\t\tdelegation set. </p>",
+                        "smithy.api#httpQuery": "delegationsetid"
+                    }
+                },
+                "HostedZoneType": {
+                    "target": "com.amazonaws.route53#HostedZoneType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n\t\t\t(Optional) Specifies if the hosted zone is private.\n\t\t</p>",
+                        "smithy.api#httpQuery": "hostedzonetype"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to retrieve a list of the public and private hosted zones that are\n\t\t\tassociated with the current Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListHostedZonesResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZones": {
+                    "target": "com.amazonaws.route53#HostedZones",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains general information about the hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the second and subsequent calls to <code>ListHostedZones</code>,\n\t\t\t\t<code>Marker</code> is the value that you specified for the <code>marker</code>\n\t\t\tparameter in the request that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag indicating whether there are more hosted zones to be listed. If the response\n\t\t\twas truncated, you can get more hosted zones by submitting another\n\t\t\t\t<code>ListHostedZones</code> request and specifying the value of\n\t\t\t\t<code>NextMarker</code> in the <code>marker</code> parameter.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextMarker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code>\n\t\t\tidentifies the first hosted zone in the next group of hosted zones. Submit another\n\t\t\t\t<code>ListHostedZones</code> request, and specify the value of\n\t\t\t\t<code>NextMarker</code> from the response in the <code>marker</code>\n\t\t\tparameter.</p>\n         <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>maxitems</code> parameter in the call to\n\t\t\t\t<code>ListHostedZones</code> that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListQueryLoggingConfigs": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListQueryLoggingConfigsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListQueryLoggingConfigsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidPaginationToken"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the configurations for DNS query logging that are associated with the current\n\t\t\t\tAmazon Web Services account or the configuration that is associated with a specified\n\t\t\thosted zone.</p>\n         <p>For more information about DNS query logs, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateQueryLoggingConfig.html\">CreateQueryLoggingConfig</a>. Additional information, including the format of\n\t\t\tDNS query logs, appears in <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html\">Logging DNS Queries</a> in\n\t\t\tthe <i>Amazon Route 53 Developer Guide</i>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/queryloggingconfig",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "items": "QueryLoggingConfigs",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.route53#ListQueryLoggingConfigsRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) If you want to list the query logging configuration that is associated with\n\t\t\ta hosted zone, specify the ID in <code>HostedZoneId</code>. </p>\n         <p>If you don't specify a hosted zone ID, <code>ListQueryLoggingConfigs</code> returns\n\t\t\tall of the configurations that are associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#httpQuery": "hostedzoneid"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) If the current Amazon Web Services account has more than\n\t\t\t\t<code>MaxResults</code> query logging configurations, use <code>NextToken</code> to\n\t\t\tget the second and subsequent pages of results.</p>\n         <p>For the first <code>ListQueryLoggingConfigs</code> request, omit this value.</p>\n         <p>For the second and subsequent requests, get the value of <code>NextToken</code> from\n\t\t\tthe previous response and specify that value for <code>NextToken</code> in the\n\t\t\trequest.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                },
+                "MaxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of query logging configurations that you want Amazon\n\t\t\tRoute 53 to return in response to the current request. If the current Amazon Web Services account has more than <code>MaxResults</code> configurations, use the\n\t\t\tvalue of <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListQueryLoggingConfigs.html#API_ListQueryLoggingConfigs_RequestSyntax\">NextToken</a> in the response to get the next page of results.</p>\n         <p>If you don't specify a value for <code>MaxResults</code>, Route 53 returns up to 100\n\t\t\tconfigurations.</p>",
+                        "smithy.api#httpQuery": "maxresults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListQueryLoggingConfigsResponse": {
+            "type": "structure",
+            "members": {
+                "QueryLoggingConfigs": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfigs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array that contains one <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_QueryLoggingConfig.html\">QueryLoggingConfig</a> element for each configuration for DNS query logging\n\t\t\tthat is associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If a response includes the last of the query logging configurations that are\n\t\t\tassociated with the current Amazon Web Services account, <code>NextToken</code> doesn't\n\t\t\tappear in the response.</p>\n         <p>If a response doesn't include the last of the configurations, you can get more\n\t\t\tconfigurations by submitting another <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListQueryLoggingConfigs.html\">ListQueryLoggingConfigs</a> request. Get the value of <code>NextToken</code>\n\t\t\tthat Amazon Route 53 returned in the previous response and include it in\n\t\t\t\t<code>NextToken</code> in the next request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListResourceRecordSets": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListResourceRecordSetsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListResourceRecordSetsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the resource record sets in a specified hosted zone.</p>\n         <p>\n            <code>ListResourceRecordSets</code> returns up to 300 resource record sets at a time\n\t\t\tin ASCII order, beginning at a position specified by the <code>name</code> and\n\t\t\t\t<code>type</code> elements.</p>\n         <p>\n            <b>Sort order</b>\n         </p>\n         <p>\n            <code>ListResourceRecordSets</code> sorts results first by DNS name with the labels\n\t\t\treversed, for example:</p>\n         <p>\n            <code>com.example.www.</code>\n         </p>\n         <p>Note the trailing dot, which can change the sort order when the record name contains\n\t\t\tcharacters that appear before <code>.</code> (decimal 46) in the ASCII table. These\n\t\t\tcharacters include the following: <code>! \" # $ % & ' ( ) * + , -</code>\n         </p>\n         <p>When multiple records have the same DNS name, <code>ListResourceRecordSets</code>\n\t\t\tsorts results by the record type.</p>\n         <p>\n            <b>Specifying where to start listing records</b>\n         </p>\n         <p>You can use the name and type elements to specify the resource record set that the\n\t\t\tlist begins with:</p>\n         <dl>\n            <dt>If you do not specify Name or Type</dt>\n            <dd>\n               <p>The results begin with the first resource record set that the hosted zone\n\t\t\t\t\t\tcontains.</p>\n            </dd>\n            <dt>If you specify Name but not Type</dt>\n            <dd>\n               <p>The results begin with the first resource record set in the list whose\n\t\t\t\t\t\tname is greater than or equal to <code>Name</code>.</p>\n            </dd>\n            <dt>If you specify Type but not Name</dt>\n            <dd>\n               <p>Amazon Route 53 returns the <code>InvalidInput</code> error.</p>\n            </dd>\n            <dt>If you specify both Name and Type</dt>\n            <dd>\n               <p>The results begin with the first resource record set in the list whose\n\t\t\t\t\t\tname is greater than or equal to <code>Name</code>, and whose type is\n\t\t\t\t\t\tgreater than or equal to <code>Type</code>.</p>\n            </dd>\n         </dl>\n         <p>\n            <b>Resource record sets that are PENDING</b>\n         </p>\n         <p>This action returns the most current version of the records. This includes records\n\t\t\tthat are <code>PENDING</code>, and that are not yet available on all Route 53 DNS\n\t\t\tservers.</p>\n         <p>\n            <b>Changing resource record sets</b>\n         </p>\n         <p>To ensure that you get an accurate listing of the resource record sets for a hosted\n\t\t\tzone at a point in time, do not submit a <code>ChangeResourceRecordSets</code> request\n\t\t\twhile you're paging through the results of a <code>ListResourceRecordSets</code>\n\t\t\trequest. If you do, some pages may display results without the latest changes while\n\t\t\tother pages display results with the latest changes.</p>\n         <p>\n            <b>Displaying the next page of results</b>\n         </p>\n         <p>If a <code>ListResourceRecordSets</code> command returns more than one page of\n\t\t\tresults, the value of <code>IsTruncated</code> is <code>true</code>. To display the next\n\t\t\tpage of results, get the values of <code>NextRecordName</code>,\n\t\t\t\t<code>NextRecordType</code>, and <code>NextRecordIdentifier</code> (if any) from the\n\t\t\tresponse. Then submit another <code>ListResourceRecordSets</code> request, and specify\n\t\t\tthose values for <code>StartRecordName</code>, <code>StartRecordType</code>, and\n\t\t\t\t<code>StartRecordIdentifier</code>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/rrset",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListResourceRecordSetsRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that contains the resource record sets that you want to\n\t\t\tlist.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "StartRecordName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The first name in the lexicographic ordering of resource record sets that you want to\n\t\t\tlist. If the specified record name doesn't exist, the results begin with the first\n\t\t\tresource record set that has a name greater than the value of <code>name</code>.</p>",
+                        "smithy.api#httpQuery": "name"
+                    }
+                },
+                "StartRecordType": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of resource record set to begin the record listing from.</p>\n         <p>Valid values for basic resource record sets: <code>A</code> | <code>AAAA</code> |\n\t\t\t\t<code>CAA</code> | <code>CNAME</code> | <code>MX</code> | <code>NAPTR</code> |\n\t\t\t\t<code>NS</code> | <code>PTR</code> | <code>SOA</code> | <code>SPF</code> |\n\t\t\t\t<code>SRV</code> | <code>TXT</code>\n         </p>\n         <p>Values for weighted, latency, geolocation, and failover resource record sets:\n\t\t\t\t<code>A</code> | <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> |\n\t\t\t\t<code>MX</code> | <code>NAPTR</code> | <code>PTR</code> | <code>SPF</code> |\n\t\t\t\t<code>SRV</code> | <code>TXT</code>\n         </p>\n         <p>Values for alias resource record sets: </p>\n         <ul>\n            <li>\n               <p>\n                  <b>API Gateway custom regional API or edge-optimized\n\t\t\t\t\t\tAPI</b>: A</p>\n            </li>\n            <li>\n               <p>\n                  <b>CloudFront distribution</b>: A or AAAA</p>\n            </li>\n            <li>\n               <p>\n                  <b>Elastic Beanstalk environment that has a regionalized\n\t\t\t\t\t\tsubdomain</b>: A</p>\n            </li>\n            <li>\n               <p>\n                  <b>Elastic Load Balancing load balancer</b>: A |\n\t\t\t\t\tAAAA</p>\n            </li>\n            <li>\n               <p>\n                  <b>S3 bucket</b>: A</p>\n            </li>\n            <li>\n               <p>\n                  <b>VPC interface VPC endpoint</b>: A</p>\n            </li>\n            <li>\n               <p>\n                  <b>Another resource record set in this hosted\n\t\t\t\t\t\tzone:</b> The type of the resource record set that the alias\n\t\t\t\t\treferences.</p>\n            </li>\n         </ul>\n         <p>Constraint: Specifying <code>type</code> without specifying <code>name</code> returns\n\t\t\tan <code>InvalidInput</code> error.</p>",
+                        "smithy.api#httpQuery": "type"
+                    }
+                },
+                "StartRecordIdentifier": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Resource record sets that have a routing policy other than\n\t\t\t\tsimple:</i> If results were truncated for a given DNS name and type, specify\n\t\t\tthe value of <code>NextRecordIdentifier</code> from the previous response to get the\n\t\t\tnext resource record set that has the current DNS name and type.</p>",
+                        "smithy.api#httpQuery": "identifier"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of resource records sets to include in the response body\n\t\t\tfor this request. If the response includes more than <code>maxitems</code> resource\n\t\t\trecord sets, the value of the <code>IsTruncated</code> element in the response is\n\t\t\t\t<code>true</code>, and the values of the <code>NextRecordName</code> and\n\t\t\t\t<code>NextRecordType</code> elements in the response identify the first resource\n\t\t\trecord set in the next group of <code>maxitems</code> resource record sets.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request for the resource record sets that are associated with a specified hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListResourceRecordSetsResponse": {
+            "type": "structure",
+            "members": {
+                "ResourceRecordSets": {
+                    "target": "com.amazonaws.route53#ResourceRecordSets",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about multiple resource record sets.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether more resource record sets remain to be listed. If your\n\t\t\tresults were truncated, you can make a follow-up pagination request by using the\n\t\t\t\t<code>NextRecordName</code> element.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextRecordName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the results were truncated, the name of the next record in the list.</p>\n         <p>This element is present only if <code>IsTruncated</code> is true. </p>"
+                    }
+                },
+                "NextRecordType": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the results were truncated, the type of the next record in the list.</p>\n         <p>This element is present only if <code>IsTruncated</code> is true. </p>"
+                    }
+                },
+                "NextRecordIdentifier": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Resource record sets that have a routing policy other than\n\t\t\t\tsimple:</i> If results were truncated for a given DNS name and type, the\n\t\t\tvalue of <code>SetIdentifier</code> for the next resource record set that has the\n\t\t\tcurrent DNS name and type.</p>\n         <p>For information about routing policies, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html\">Choosing a Routing\n\t\t\t\tPolicy</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of records you requested.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains list information for the resource record set.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListReusableDelegationSets": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListReusableDelegationSetsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListReusableDelegationSetsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of the reusable delegation sets that are associated with the current\n\t\t\t\tAmazon Web Services account.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/delegationset",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListReusableDelegationSetsRequest": {
+            "type": "structure",
+            "members": {
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more reusable delegation sets. To get another group,\n\t\t\tsubmit another <code>ListReusableDelegationSets</code> request. </p>\n         <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code>\n\t\t\tfrom the previous response, which is the ID of the first reusable delegation set that\n\t\t\tAmazon Route 53 will return if you submit another request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more reusable delegation sets to get.</p>",
+                        "smithy.api#httpQuery": "marker"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of reusable delegation sets that you want Amazon Route 53 to return in the\n\t\t\tresponse to this request. If you specify a value greater than 100, Route 53 returns only\n\t\t\tthe first 100 reusable delegation sets.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get a list of the reusable delegation sets that are associated with the\n\t\t\tcurrent Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListReusableDelegationSetsResponse": {
+            "type": "structure",
+            "members": {
+                "DelegationSets": {
+                    "target": "com.amazonaws.route53#DelegationSets",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>DelegationSet</code> element for each reusable\n\t\t\tdelegation set that was created by the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Marker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For the second and subsequent calls to <code>ListReusableDelegationSets</code>,\n\t\t\t\t<code>Marker</code> is the value that you specified for the <code>marker</code>\n\t\t\tparameter in the request that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more reusable delegation sets to be\n\t\t\tlisted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextMarker": {
+                    "target": "com.amazonaws.route53#PageMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code>\n\t\t\tidentifies the next reusable delegation set that Amazon Route 53 will return if you\n\t\t\tsubmit another <code>ListReusableDelegationSets</code> request and specify the value of\n\t\t\t\t<code>NextMarker</code> in the <code>marker</code> parameter.</p>"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>maxitems</code> parameter in the call to\n\t\t\t\t<code>ListReusableDelegationSets</code> that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the reusable delegation sets that are\n\t\t\tassociated with the current Amazon Web Services account.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTagsForResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                },
+                {
+                    "target": "com.amazonaws.route53#ThrottlingException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists tags for one health check or hosted zone. </p>\n         <p>For information about using tags for cost allocation, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using Cost Allocation\n\t\t\t\tTags</a> in the <i>Billing and Cost Management User Guide</i>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/tags/{ResourceType}/{ResourceId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceType": {
+                    "target": "com.amazonaws.route53#TagResourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource.</p>\n         <ul>\n            <li>\n               <p>The resource type for health checks is <code>healthcheck</code>.</p>\n            </li>\n            <li>\n               <p>The resource type for hosted zones is <code>hostedzone</code>.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResourceId": {
+                    "target": "com.amazonaws.route53#TagResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the resource for which you want to retrieve tags.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing information about a request for a list of the tags that are\n\t\t\tassociated with an individual resource.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "ResourceTagSet": {
+                    "target": "com.amazonaws.route53#ResourceTagSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A <code>ResourceTagSet</code> containing tags associated with the specified\n\t\t\tresource.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the health checks or hosted zones for\n\t\t\twhich you want to list tags.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResources": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTagsForResourcesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTagsForResourcesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                },
+                {
+                    "target": "com.amazonaws.route53#ThrottlingException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists tags for up to 10 health checks or hosted zones.</p>\n         <p>For information about using tags for cost allocation, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using Cost Allocation\n\t\t\t\tTags</a> in the <i>Billing and Cost Management User Guide</i>.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/tags/{ResourceType}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResourcesRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceType": {
+                    "target": "com.amazonaws.route53#TagResourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resources.</p>\n         <ul>\n            <li>\n               <p>The resource type for health checks is <code>healthcheck</code>.</p>\n            </li>\n            <li>\n               <p>The resource type for hosted zones is <code>hostedzone</code>.</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResourceIds": {
+                    "target": "com.amazonaws.route53#TagResourceIdList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the ResourceId element for each resource for which you\n\t\t\twant to get a list of tags.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the health checks or hosted zones for\n\t\t\twhich you want to list tags.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTagsForResourcesResponse": {
+            "type": "structure",
+            "members": {
+                "ResourceTagSets": {
+                    "target": "com.amazonaws.route53#ResourceTagSetList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of <code>ResourceTagSet</code>s containing tags associated with the specified\n\t\t\tresources.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing tags for the specified resources.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicies": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTrafficPoliciesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTrafficPoliciesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the latest version for every traffic policy that is associated\n\t\t\twith the current Amazon Web Services account. Policies are listed in the order that they\n\t\t\twere created in. </p>\n         <p>For information about how of deleting a traffic policy affects the response from\n\t\t\t\t<code>ListTrafficPolicies</code>, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteTrafficPolicy.html\">DeleteTrafficPolicy</a>. </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicies",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPoliciesRequest": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyIdMarker": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Conditional) For your first request to <code>ListTrafficPolicies</code>, don't\n\t\t\tinclude the <code>TrafficPolicyIdMarker</code> parameter.</p>\n         <p>If you have more traffic policies than the value of <code>MaxItems</code>,\n\t\t\t\t<code>ListTrafficPolicies</code> returns only the first <code>MaxItems</code>\n\t\t\ttraffic policies. To get the next group of policies, submit another request to\n\t\t\t\t<code>ListTrafficPolicies</code>. For the value of\n\t\t\t\t<code>TrafficPolicyIdMarker</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyIdMarker</code> that was returned in the previous\n\t\t\tresponse.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyid"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Optional) The maximum number of traffic policies that you want Amazon Route 53 to\n\t\t\treturn in response to this request. If you have more than <code>MaxItems</code> traffic\n\t\t\tpolicies, the value of <code>IsTruncated</code> in the response is <code>true</code>,\n\t\t\tand the value of <code>TrafficPolicyIdMarker</code> is the ID of the first traffic\n\t\t\tpolicy that Route 53 will return if you submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the information about the request to list the traffic\n\t\t\tpolicies that are associated with the current Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPoliciesResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicySummaries": {
+                    "target": "com.amazonaws.route53#TrafficPolicySummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>TrafficPolicySummary</code> element for each traffic\n\t\t\tpolicy that was created by the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more traffic policies to be listed. If the\n\t\t\tresponse was truncated, you can get the next group of traffic policies by submitting\n\t\t\tanother <code>ListTrafficPolicies</code> request and specifying the value of\n\t\t\t\t<code>TrafficPolicyIdMarker</code> in the <code>TrafficPolicyIdMarker</code> request\n\t\t\tparameter.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyIdMarker": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyIdMarker</code> is the ID of the first traffic policy in the next\n\t\t\tgroup of <code>MaxItems</code> traffic policies.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>MaxItems</code> parameter in the\n\t\t\t\t<code>ListTrafficPolicies</code> request that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstances": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the traffic policy instances that you created by using the\n\t\t\tcurrent Amazon Web Services account.</p>\n         <note>\n            <p>After you submit an <code>UpdateTrafficPolicyInstance</code> request, there's a\n\t\t\t\tbrief delay while Amazon Route 53 creates the resource record sets that are\n\t\t\t\tspecified in the traffic policy definition. For more information, see the\n\t\t\t\t\t<code>State</code> response element.</p>\n         </note>\n         <p>Route 53 returns a maximum of 100 items in each response. If you have a lot of traffic\n\t\t\tpolicy instances, you can use the <code>MaxItems</code> parameter to list them in groups\n\t\t\tof up to 100.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicyinstances",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZone": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZoneRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZoneResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the traffic policy instances that you created in a specified\n\t\t\thosted zone.</p>\n         <note>\n            <p>After you submit a <code>CreateTrafficPolicyInstance</code> or an\n\t\t\t\t\t<code>UpdateTrafficPolicyInstance</code> request, there's a brief delay while\n\t\t\t\tAmazon Route 53 creates the resource record sets that are specified in the traffic\n\t\t\t\tpolicy definition. For more information, see the <code>State</code> response\n\t\t\t\telement.</p>\n         </note>\n         <p>Route 53 returns a maximum of 100 items in each response. If you have a lot of traffic\n\t\t\tpolicy instances, you can use the <code>MaxItems</code> parameter to list them in groups\n\t\t\tof up to 100.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicyinstances/hostedzone",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZoneRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want to list traffic policy instances for.</p>",
+                        "smithy.api#httpQuery": "id",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response is true, you have\n\t\t\tmore traffic policy instances. To get more traffic policy instances, submit another\n\t\t\t\t<code>ListTrafficPolicyInstances</code> request. For the value of\n\t\t\t\t<code>trafficpolicyinstancename</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is\n\t\t\tthe name of the first traffic policy instance in the next group of traffic policy\n\t\t\tinstances.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancename"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response is true, you have\n\t\t\tmore traffic policy instances. To get more traffic policy instances, submit another\n\t\t\t\t<code>ListTrafficPolicyInstances</code> request. For the value of\n\t\t\t\t<code>trafficpolicyinstancetype</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is\n\t\t\tthe type of the first traffic policy instance in the next group of traffic policy\n\t\t\tinstances.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancetype"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of traffic policy instances to be included in the response body for\n\t\t\tthis request. If you have more than <code>MaxItems</code> traffic policy instances, the\n\t\t\tvalue of the <code>IsTruncated</code> element in the response is <code>true</code>, and\n\t\t\tthe values of <code>HostedZoneIdMarker</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code>, and\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy\n\t\t\tinstance that Amazon Route 53 will return if you submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request for the traffic policy instances that you created in a specified hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByHostedZoneResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstances": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstances",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic\n\t\t\tpolicy instance that matches the elements in the request. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy\n\t\t\tinstance in the next group of traffic policy instances.</p>"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is true, <code>TrafficPolicyInstanceTypeMarker</code> is\n\t\t\tthe DNS type of the resource record sets that are associated with the first traffic\n\t\t\tpolicy instance in the next group of traffic policy instances.</p>"
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more traffic policy instances to be listed. If\n\t\t\tthe response was truncated, you can get the next group of traffic policy instances by\n\t\t\tsubmitting another <code>ListTrafficPolicyInstancesByHostedZone</code> request and\n\t\t\tspecifying the values of <code>HostedZoneIdMarker</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code>, and\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request\n\t\t\tparameters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>MaxItems</code> parameter in the\n\t\t\t\t<code>ListTrafficPolicyInstancesByHostedZone</code> request that produced the\n\t\t\tcurrent response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicy": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicyResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the traffic policy instances that you created by using a\n\t\t\tspecify traffic policy version.</p>\n         <note>\n            <p>After you submit a <code>CreateTrafficPolicyInstance</code> or an\n\t\t\t\t\t<code>UpdateTrafficPolicyInstance</code> request, there's a brief delay while\n\t\t\t\tAmazon Route 53 creates the resource record sets that are specified in the traffic\n\t\t\t\tpolicy definition. For more information, see the <code>State</code> response\n\t\t\t\telement.</p>\n         </note>\n         <p>Route 53 returns a maximum of 100 items in each response. If you have a lot of traffic\n\t\t\tpolicy instances, you can use the <code>MaxItems</code> parameter to list them in groups\n\t\t\tof up to 100.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicyinstances/trafficpolicy",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicyRequest": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyId": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy for which you want to list traffic policy\n\t\t\tinstances.</p>",
+                        "smithy.api#httpQuery": "id",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersion": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the traffic policy for which you want to list traffic policy instances.\n\t\t\tThe version must be associated with the traffic policy that is specified by\n\t\t\t\t<code>TrafficPolicyId</code>.</p>",
+                        "smithy.api#httpQuery": "version",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneIdMarker": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code>\n\t\t\trequest. </p>\n         <p>For the value of <code>hostedzoneid</code>, specify the value of\n\t\t\t\t<code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone\n\t\t\tID of the first traffic policy instance that Amazon Route 53 will return if you submit\n\t\t\tanother request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "hostedzoneid"
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code>\n\t\t\trequest.</p>\n         <p>For the value of <code>trafficpolicyinstancename</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is\n\t\t\tthe name of the first traffic policy instance that Amazon Route 53 will return if you\n\t\t\tsubmit another request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancename"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code>\n\t\t\trequest.</p>\n         <p>For the value of <code>trafficpolicyinstancetype</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is\n\t\t\tthe name of the first traffic policy instance that Amazon Route 53 will return if you\n\t\t\tsubmit another request.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancetype"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of traffic policy instances to be included in the response body for\n\t\t\tthis request. If you have more than <code>MaxItems</code> traffic policy instances, the\n\t\t\tvalue of the <code>IsTruncated</code> element in the response is <code>true</code>, and\n\t\t\tthe values of <code>HostedZoneIdMarker</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code>, and\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy\n\t\t\tinstance that Amazon Route 53 will return if you submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the information about the request to list your traffic\n\t\t\tpolicy instances.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesByPolicyResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstances": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstances",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic\n\t\t\tpolicy instance that matches the elements in the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneIdMarker": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is\n\t\t\tthe ID of the hosted zone of the first traffic policy instance in the next group of\n\t\t\ttraffic policy instances.</p>"
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy\n\t\t\tinstance in the next group of <code>MaxItems</code> traffic policy instances.</p>"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> is the DNS type of the resource record\n\t\t\tsets that are associated with the first traffic policy instance in the next group of\n\t\t\t\t<code>MaxItems</code> traffic policy instances.</p>"
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more traffic policy instances to be listed. If\n\t\t\tthe response was truncated, you can get the next group of traffic policy instances by\n\t\t\tcalling <code>ListTrafficPolicyInstancesByPolicy</code> again and specifying the values\n\t\t\tof the <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>,\n\t\t\tand <code>TrafficPolicyInstanceTypeMarker</code> elements in the corresponding request\n\t\t\tparameters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>MaxItems</code> parameter in the call to\n\t\t\t\t<code>ListTrafficPolicyInstancesByPolicy</code> that produced the current\n\t\t\tresponse.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneIdMarker": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstances</code> request. For\n\t\t\tthe value of <code>HostedZoneId</code>, specify the value of\n\t\t\t\t<code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone\n\t\t\tID of the first traffic policy instance in the next group of traffic policy\n\t\t\tinstances.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "hostedzoneid"
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstances</code> request. For\n\t\t\tthe value of <code>trafficpolicyinstancename</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is\n\t\t\tthe name of the first traffic policy instance in the next group of traffic policy\n\t\t\tinstances.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancename"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>true</code>, you have more traffic policy instances. To get more traffic\n\t\t\tpolicy instances, submit another <code>ListTrafficPolicyInstances</code> request. For\n\t\t\tthe value of <code>trafficpolicyinstancetype</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is\n\t\t\tthe type of the first traffic policy instance in the next group of traffic policy\n\t\t\tinstances.</p>\n         <p>If the value of <code>IsTruncated</code> in the previous response was\n\t\t\t\t<code>false</code>, there are no more traffic policy instances to get.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyinstancetype"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of traffic policy instances that you want Amazon Route 53 to return\n\t\t\tin response to a <code>ListTrafficPolicyInstances</code> request. If you have more than\n\t\t\t\t<code>MaxItems</code> traffic policy instances, the value of the\n\t\t\t\t<code>IsTruncated</code> element in the response is <code>true</code>, and the\n\t\t\tvalues of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>,\n\t\t\tand <code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy\n\t\t\tinstance in the next group of <code>MaxItems</code> traffic policy instances.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about the traffic policy instances that you created by\n\t\t\tusing the current Amazon Web Services account.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyInstancesResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstances": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstances",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic\n\t\t\tpolicy instance that matches the elements in the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneIdMarker": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is\n\t\t\tthe ID of the hosted zone of the first traffic policy instance that Route 53 will return\n\t\t\tif you submit another <code>ListTrafficPolicyInstances</code> request. </p>"
+                    }
+                },
+                "TrafficPolicyInstanceNameMarker": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy\n\t\t\tinstance that Route 53 will return if you submit another\n\t\t\t\t<code>ListTrafficPolicyInstances</code> request. </p>"
+                    }
+                },
+                "TrafficPolicyInstanceTypeMarker": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>,\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> is the DNS type of the resource record\n\t\t\tsets that are associated with the first traffic policy instance that Amazon Route 53\n\t\t\twill return if you submit another <code>ListTrafficPolicyInstances</code> request.\n\t\t</p>"
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more traffic policy instances to be listed. If\n\t\t\tthe response was truncated, you can get more traffic policy instances by calling\n\t\t\t\t<code>ListTrafficPolicyInstances</code> again and specifying the values of the\n\t\t\t\t<code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and\n\t\t\t\t<code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request\n\t\t\tparameters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>MaxItems</code> parameter in the call to\n\t\t\t\t<code>ListTrafficPolicyInstances</code> that produced the current response.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyVersionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListTrafficPolicyVersionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about all of the versions for a specified traffic policy.</p>\n         <p>Traffic policy versions are listed in numerical order by\n\t\t\t<code>VersionNumber</code>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/trafficpolicies/{Id}/versions",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyVersionsRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the value of <code>Id</code> of the traffic policy for which you want to list\n\t\t\tall versions.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersionMarker": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersionMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For your first request to <code>ListTrafficPolicyVersions</code>, don't include the\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> parameter.</p>\n         <p>If you have more traffic policy versions than the value of <code>MaxItems</code>,\n\t\t\t\t<code>ListTrafficPolicyVersions</code> returns only the first group of\n\t\t\t\t<code>MaxItems</code> versions. To get more traffic policy versions, submit another\n\t\t\t\t<code>ListTrafficPolicyVersions</code> request. For the value of\n\t\t\t\t<code>TrafficPolicyVersionMarker</code>, specify the value of\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> in the previous response.</p>",
+                        "smithy.api#httpQuery": "trafficpolicyversion"
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of traffic policy versions that you want Amazon Route 53 to include\n\t\t\tin the response body for this request. If the specified traffic policy has more than\n\t\t\t\t<code>MaxItems</code> versions, the value of <code>IsTruncated</code> in the\n\t\t\tresponse is <code>true</code>, and the value of the\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> element is the ID of the first version that\n\t\t\tRoute 53 will return if you submit another request.</p>",
+                        "smithy.api#httpQuery": "maxitems"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the information about the request to list your traffic\n\t\t\tpolicies.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListTrafficPolicyVersionsResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicies": {
+                    "target": "com.amazonaws.route53#TrafficPolicies",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains one <code>TrafficPolicy</code> element for each traffic policy\n\t\t\tversion that is associated with the specified traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "IsTruncated": {
+                    "target": "com.amazonaws.route53#PageTruncated",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A flag that indicates whether there are more traffic policies to be listed. If the\n\t\t\tresponse was truncated, you can get the next group of traffic policies by submitting\n\t\t\tanother <code>ListTrafficPolicyVersions</code> request and specifying the value of\n\t\t\t\t<code>NextMarker</code> in the <code>marker</code> parameter.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersionMarker": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersionMarker",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>IsTruncated</code> is <code>true</code>, the value of\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> identifies the first traffic policy that\n\t\t\tAmazon Route 53 will return if you submit another request. Call\n\t\t\t\t<code>ListTrafficPolicyVersions</code> again and specify the value of\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> in the\n\t\t\t\t<code>TrafficPolicyVersionMarker</code> request parameter.</p>\n         <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxItems": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value that you specified for the <code>maxitems</code> parameter in the\n\t\t\t\t<code>ListTrafficPolicyVersions</code> request that produced the current\n\t\t\tresponse.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#ListVPCAssociationAuthorizations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#ListVPCAssociationAuthorizationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#ListVPCAssociationAuthorizationsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidPaginationToken"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a list of the VPCs that were created by other accounts and that can be associated\n\t\t\twith a specified hosted zone because you've submitted one or more\n\t\t\t\t<code>CreateVPCAssociationAuthorization</code> requests. </p>\n         <p>The response includes a <code>VPCs</code> element with a <code>VPC</code> child\n\t\t\telement for each VPC that can be associated with the hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/hostedzone/{HostedZoneId}/authorizevpcassociation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#ListVPCAssociationAuthorizationsRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone for which you want a list of VPCs that can be associated\n\t\t\twith the hosted zone.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Optional</i>: If a response includes a <code>NextToken</code>\n\t\t\telement, there are more VPCs that can be associated with the specified hosted zone. To\n\t\t\tget the next page of results, submit another request, and include the value of\n\t\t\t\t<code>NextToken</code> from the response in the <code>nexttoken</code> parameter in\n\t\t\tanother <code>ListVPCAssociationAuthorizations</code> request.</p>",
+                        "smithy.api#httpQuery": "nexttoken"
+                    }
+                },
+                "MaxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Optional</i>: An integer that specifies the maximum number of VPCs\n\t\t\tthat you want Amazon Route 53 to return. If you don't specify a value for\n\t\t\t\t<code>MaxResults</code>, Route 53 returns up to 50 VPCs per page.</p>",
+                        "smithy.api#httpQuery": "maxresults"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about that can be associated with your hosted\n\t\t\tzone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#ListVPCAssociationAuthorizationsResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you can associate the listed VPCs with.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.route53#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the response includes a <code>NextToken</code> element, there are more VPCs that\n\t\t\tcan be associated with the specified hosted zone. To get the next page of VPCs, submit\n\t\t\tanother <code>ListVPCAssociationAuthorizations</code> request, and include the value of\n\t\t\tthe <code>NextToken</code> element from the response in the <code>nexttoken</code>\n\t\t\trequest parameter.</p>"
+                    }
+                },
+                "VPCs": {
+                    "target": "com.amazonaws.route53#VPCs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of VPCs that are authorized to be associated with the specified hosted\n\t\t\tzone.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the request.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#LocalZoneGroup": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#LocationSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#LocationSummary"
+            }
+        },
+        "com.amazonaws.route53#LocationSummary": {
+            "type": "structure",
+            "members": {
+                "LocationName": {
+                    "target": "com.amazonaws.route53#CidrLocationNameDefaultAllowed",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string that specifies a location name.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the CIDR location.</p>"
+            }
+        },
+        "com.amazonaws.route53#Longitude": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 7
+                },
+                "smithy.api#pattern": "^[-+]?[0-9]{1,3}(\\.[0-9]{0,2})?$"
+            }
+        },
+        "com.amazonaws.route53#MeasureLatency": {
+            "type": "boolean"
+        },
+        "com.amazonaws.route53#Message": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#MetricName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#Nameserver": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#Namespace": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#NoSuchChange": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A change with the specified change ID does not exist.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchCidrCollectionException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The CIDR collection you specified, doesn't exist.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchCidrLocationException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The CIDR collection location doesn't match any locations in your account.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchCloudWatchLogsLogGroup": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>There is no CloudWatch Logs log group with the specified ARN.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchDelegationSet": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A reusable delegation set with the specified ID does not exist.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#NoSuchGeoLocation": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Amazon Route 53 doesn't support the specified geographic location. For a list of\n\t\t\tsupported geolocation codes, see the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GeoLocation.html\">GeoLocation</a> data\n\t\t\ttype.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchHealthCheck": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>No health check exists with the specified ID.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchHostedZone": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>No hosted zone exists with the ID that you specified.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchKeySigningKey": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified key-signing key (KSK) doesn't exist.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchQueryLoggingConfig": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>There is no DNS query logging configuration with the specified ID.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchTrafficPolicy": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>No traffic policy exists with the specified ID.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#NoSuchTrafficPolicyInstance": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>No traffic policy instance exists with the specified ID.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#Nonce": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#NotAuthorizedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Associating the specified VPC with the specified hosted zone has not been\n\t\t\tauthorized.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 401
+            }
+        },
+        "com.amazonaws.route53#PageMarker": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#PageTruncated": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.route53#PaginationToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#Period": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 60
+                }
+            }
+        },
+        "com.amazonaws.route53#Port": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 65535
+                }
+            }
+        },
+        "com.amazonaws.route53#PriorRequestNotComplete": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>If Amazon Route 53 can't process a request before the next request arrives, it will\n\t\t\treject subsequent requests for the same hosted zone and return an <code>HTTP 400\n\t\t\t\terror</code> (<code>Bad request</code>). If Route 53 returns this error repeatedly\n\t\t\tfor the same request, we recommend that you wait, in intervals of increasing duration,\n\t\t\tbefore you try the request again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#PublicZoneVPCAssociation": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You're trying to associate a VPC with a public hosted zone. Amazon Route 53 doesn't\n\t\t\tsupport associating a VPC with a public hosted zone.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#QueryLoggingConfig": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#QueryLoggingConfigId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for a configuration for DNS query logging.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that CloudWatch Logs is logging queries for. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CloudWatchLogsLogGroupArn": {
+                    "target": "com.amazonaws.route53#CloudWatchLogsLogGroupArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the CloudWatch Logs log group that Amazon Route 53\n\t\t\tis publishing logs to.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about a configuration for DNS query\n\t\t\tlogging.</p>"
+            }
+        },
+        "com.amazonaws.route53#QueryLoggingConfigAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You can create only one query logging configuration for a hosted zone, and a query\n\t\t\tlogging configuration already exists for this hosted zone.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#QueryLoggingConfigId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 36
+                }
+            }
+        },
+        "com.amazonaws.route53#QueryLoggingConfigs": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#QueryLoggingConfig",
+                "traits": {
+                    "smithy.api#xmlName": "QueryLoggingConfig"
+                }
+            }
+        },
+        "com.amazonaws.route53#RData": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4000
+                }
+            }
+        },
+        "com.amazonaws.route53#RRType": {
+            "type": "enum",
+            "members": {
+                "SOA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SOA"
+                    }
+                },
+                "A": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "A"
+                    }
+                },
+                "TXT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TXT"
+                    }
+                },
+                "NS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NS"
+                    }
+                },
+                "CNAME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CNAME"
+                    }
+                },
+                "MX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MX"
+                    }
+                },
+                "NAPTR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NAPTR"
+                    }
+                },
+                "PTR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PTR"
+                    }
+                },
+                "SRV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SRV"
+                    }
+                },
+                "SPF": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SPF"
+                    }
+                },
+                "AAAA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AAAA"
+                    }
+                },
+                "CAA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CAA"
+                    }
+                },
+                "DS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DS"
+                    }
+                },
+                "TLSA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TLSA"
+                    }
+                },
+                "SSHFP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SSHFP"
+                    }
+                },
+                "SVCB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SVCB"
+                    }
+                },
+                "HTTPS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTPS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#RecordData": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#RecordDataEntry",
+                "traits": {
+                    "smithy.api#xmlName": "RecordDataEntry"
+                }
+            }
+        },
+        "com.amazonaws.route53#RecordDataEntry": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "<p>A value that Amazon Route 53 returned for this resource record set. A\n\t\t\t\t<code>RecordDataEntry</code> element is one of the following:</p>\n         <ul>\n            <li>\n               <p>For non-alias resource record sets, a <code>RecordDataEntry</code> element\n\t\t\t\t\tcontains one value in the resource record set. If the resource record set\n\t\t\t\t\tcontains multiple values, the response includes one <code>RecordDataEntry</code>\n\t\t\t\t\telement for each value.</p>\n            </li>\n            <li>\n               <p>For multiple resource record sets that have the same name and type, which\n\t\t\t\t\tincludes weighted, latency, geolocation, and failover, a\n\t\t\t\t\t\t<code>RecordDataEntry</code> element contains the value from the appropriate\n\t\t\t\t\tresource record set based on the request.</p>\n            </li>\n            <li>\n               <p>For alias resource record sets that refer to Amazon Web Services resources\n\t\t\t\t\tother than another resource record set, the <code>RecordDataEntry</code> element\n\t\t\t\t\tcontains an IP address or a domain name for the Amazon Web Services resource,\n\t\t\t\t\tdepending on the type of resource.</p>\n            </li>\n            <li>\n               <p>For alias resource record sets that refer to other resource record sets, a\n\t\t\t\t\t\t<code>RecordDataEntry</code> element contains one value from the referenced\n\t\t\t\t\tresource record set. If the referenced resource record set contains multiple\n\t\t\t\t\tvalues, the response includes one <code>RecordDataEntry</code> element for each\n\t\t\t\t\tvalue.</p>\n            </li>\n         </ul>",
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 512
+                }
+            }
+        },
+        "com.amazonaws.route53#RequestInterval": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 10,
+                    "max": 30
+                }
+            }
+        },
+        "com.amazonaws.route53#ResettableElementName": {
+            "type": "enum",
+            "members": {
+                "FullyQualifiedDomainName": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FullyQualifiedDomainName"
+                    }
+                },
+                "Regions": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Regions"
+                    }
+                },
+                "ResourcePath": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ResourcePath"
+                    }
+                },
+                "ChildHealthChecks": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ChildHealthChecks"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#ResettableElementNameList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#ResettableElementName",
+                "traits": {
+                    "smithy.api#xmlName": "ResettableElementName"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceDescription": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 32
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourcePath": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecord": {
+            "type": "structure",
+            "members": {
+                "Value": {
+                    "target": "com.amazonaws.route53#RData",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current or new DNS record value, not to exceed 4,000 characters. In the case of a\n\t\t\t\t<code>DELETE</code> action, if the current value does not match the actual value, an\n\t\t\terror is returned. For descriptions about how to format <code>Value</code> for different\n\t\t\trecord types, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html\">Supported DNS Resource\n\t\t\t\tRecord Types</a> in the <i>Amazon Route 53 Developer\n\t\t\tGuide</i>.</p>\n         <p>You can specify more than one value for all record types except <code>CNAME</code> and\n\t\t\t\t<code>SOA</code>. </p>\n         <note>\n            <p>If you're creating an alias resource record set, omit <code>Value</code>.</p>\n         </note>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information specific to the resource record.</p>\n         <note>\n            <p>If you're creating an alias resource record set, omit\n\t\t\t\t<code>ResourceRecord</code>.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSet": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For <code>ChangeResourceRecordSets</code> requests, the name of the record that you\n\t\t\twant to create, update, or delete. For <code>ListResourceRecordSets</code> responses,\n\t\t\tthe name of a record in the specified hosted zone.</p>\n         <p>\n            <b>ChangeResourceRecordSets Only</b>\n         </p>\n         <p>Enter a fully qualified domain name, for example, <code>www.example.com</code>. You\n\t\t\tcan optionally include a trailing dot. If you omit the trailing dot, Amazon Route 53\n\t\t\tassumes that the domain name that you specify is fully qualified. This means that Route\n\t\t\t53 treats <code>www.example.com</code> (without a trailing dot) and\n\t\t\t\t<code>www.example.com.</code> (with a trailing dot) as identical.</p>\n         <p>For information about how to specify characters other than <code>a-z</code>,\n\t\t\t\t<code>0-9</code>, and <code>-</code> (hyphen) and how to specify internationalized\n\t\t\tdomain names, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html\">DNS Domain Name\n\t\t\t\tFormat</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>You can use the asterisk (*) wildcard to replace the leftmost label in a domain name,\n\t\t\tfor example, <code>*.example.com</code>. Note the following:</p>\n         <ul>\n            <li>\n               <p>The * must replace the entire label. For example, you can't specify\n\t\t\t\t\t\t<code>*prod.example.com</code> or <code>prod*.example.com</code>.</p>\n            </li>\n            <li>\n               <p>The * can't replace any of the middle labels, for example,\n\t\t\t\t\tmarketing.*.example.com.</p>\n            </li>\n            <li>\n               <p>If you include * in any position other than the leftmost label in a domain\n\t\t\t\t\tname, DNS treats it as an * character (ASCII 42), not as a wildcard.</p>\n               <important>\n                  <p>You can't use the * wildcard for resource records sets that have a type of\n\t\t\t\t\t\tNS.</p>\n               </important>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DNS record type. For information about different record types and how data is\n\t\t\tencoded for them, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html\">Supported DNS Resource\n\t\t\t\tRecord Types</a> in the <i>Amazon Route 53 Developer\n\t\t\tGuide</i>.</p>\n         <p>Valid values for basic resource record sets: <code>A</code> | <code>AAAA</code> |\n\t\t\t\t<code>CAA</code> | <code>CNAME</code> | <code>DS</code> |<code>MX</code> |\n\t\t\t\t<code>NAPTR</code> | <code>NS</code> | <code>PTR</code> | <code>SOA</code> |\n\t\t\t<code>SPF</code> | <code>SRV</code> | <code>TXT</code>| <code>TLSA</code>| <code>SSHFP</code>| <code>SVCB</code>| <code>HTTPS</code>\n         </p>\n         <p>Values for weighted, latency, geolocation, and failover resource record sets: <code>A</code>\n\t\t\t| <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> | <code>MX</code> |\n\t\t\t\t<code>NAPTR</code> | <code>PTR</code> | <code>SPF</code> | <code>SRV</code> |\n\t\t\t\t<code>TXT</code>| <code>TLSA</code>| <code>SSHFP</code>| <code>SVCB</code>|\n\t\t\t\t<code>HTTPS</code>. When creating a group of weighted, latency, geolocation,\n\t\t\tor\n\t\t\tfailover resource record sets, specify the same value for all of the resource record\n\t\t\tsets in the group.</p>\n         <p>Valid values for multivalue answer resource record sets: <code>A</code> |\n\t\t\t\t<code>AAAA</code> | <code>MX</code> | <code>NAPTR</code> | <code>PTR</code> |\n\t\t\t<code>SPF</code> | <code>SRV</code> | <code>TXT</code>| <code>CAA</code>| <code>TLSA</code>| <code>SSHFP</code>| <code>SVCB</code>| <code>HTTPS</code>\n         </p>\n         <note>\n            <p>SPF records were formerly used to verify the identity of the sender of email\n\t\t\t\tmessages. However, we no longer recommend that you create resource record sets for\n\t\t\t\twhich the value of <code>Type</code> is <code>SPF</code>. RFC 7208, <i>Sender\n\t\t\t\t\tPolicy Framework (SPF) for Authorizing Use of Domains in Email, Version\n\t\t\t\t\t1</i>, has been updated to say, \"...[I]ts existence and mechanism defined\n\t\t\t\tin [RFC4408] have led to some interoperability issues. Accordingly, its use is no\n\t\t\t\tlonger appropriate for SPF version 1; implementations are not to use it.\" In RFC\n\t\t\t\t7208, see section 14.1, <a href=\"http://tools.ietf.org/html/rfc7208#section-14.1\">The SPF DNS Record Type</a>.</p>\n         </note>\n         <p>Values for alias resource record sets:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Amazon API Gateway custom regional APIs and\n\t\t\t\t\t\tedge-optimized APIs:</b>\n                  <code>A</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <b>CloudFront distributions:</b>\n                  <code>A</code>\n               </p>\n               <p>If IPv6 is enabled for the distribution, create two resource record sets to\n\t\t\t\t\troute traffic to your distribution, one with a value of <code>A</code> and one\n\t\t\t\t\twith a value of <code>AAAA</code>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Amazon API Gateway environment that has a regionalized\n\t\t\t\t\t\tsubdomain</b>: <code>A</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <b>ELB load balancers:</b>\n                  <code>A</code> | <code>AAAA</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <b>Amazon S3 buckets:</b>\n                  <code>A</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <b>Amazon Virtual Private Cloud interface VPC\n\t\t\t\t\t\tendpoints</b>\n                  <code>A</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <b>Another resource record set in this hosted\n\t\t\t\t\t\tzone:</b> Specify the type of the resource record set that you're\n\t\t\t\t\tcreating the alias for. All values are supported except <code>NS</code> and\n\t\t\t\t\t\t<code>SOA</code>.</p>\n               <note>\n                  <p>If you're creating an alias record that has the same name as the hosted\n\t\t\t\t\t\tzone (known as the zone apex), you can't route traffic to a record for which\n\t\t\t\t\t\tthe value of <code>Type</code> is <code>CNAME</code>. This is because the\n\t\t\t\t\t\talias record must have the same type as the record you're routing traffic\n\t\t\t\t\t\tto, and creating a CNAME record for the zone apex isn't supported even for\n\t\t\t\t\t\tan alias record.</p>\n               </note>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SetIdentifier": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Resource record sets that have a routing policy other than\n\t\t\t\tsimple:</i> An identifier that differentiates among multiple resource record\n\t\t\tsets that have the same combination of name and type, such as multiple weighted resource\n\t\t\trecord sets named acme.example.com that have a type of A. In a group of resource record\n\t\t\tsets that have the same name and type, the value of <code>SetIdentifier</code> must be\n\t\t\tunique for each resource record set. </p>\n         <p>For information about routing policies, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html\">Choosing a Routing\n\t\t\t\tPolicy</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>"
+                    }
+                },
+                "Weight": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetWeight",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Weighted resource record sets only:</i> Among resource record sets\n\t\t\tthat have the same combination of DNS name and type, a value that determines the\n\t\t\tproportion of DNS queries that Amazon Route 53 responds to using the current resource\n\t\t\trecord set. Route 53 calculates the sum of the weights for the resource record sets that\n\t\t\thave the same combination of DNS name and type. Route 53 then responds to queries based\n\t\t\ton the ratio of a resource's weight to the total. Note the following:</p>\n         <ul>\n            <li>\n               <p>You must specify a value for the <code>Weight</code> element for every\n\t\t\t\t\tweighted resource record set.</p>\n            </li>\n            <li>\n               <p>You can only specify one <code>ResourceRecord</code> per weighted resource\n\t\t\t\t\trecord set.</p>\n            </li>\n            <li>\n               <p>You can't create latency, failover, or geolocation resource record sets that\n\t\t\t\t\thave the same values for the <code>Name</code> and <code>Type</code> elements as\n\t\t\t\t\tweighted resource record sets.</p>\n            </li>\n            <li>\n               <p>You can create a maximum of 100 weighted resource record sets that have the\n\t\t\t\t\tsame values for the <code>Name</code> and <code>Type</code> elements.</p>\n            </li>\n            <li>\n               <p>For weighted (but not weighted alias) resource record sets, if you set\n\t\t\t\t\t\t<code>Weight</code> to <code>0</code> for a resource record set, Route 53\n\t\t\t\t\tnever responds to queries with the applicable value for that resource record\n\t\t\t\t\tset. However, if you set <code>Weight</code> to <code>0</code> for all resource\n\t\t\t\t\trecord sets that have the same combination of DNS name and type, traffic is\n\t\t\t\t\trouted to all resources with equal probability.</p>\n               <p>The effect of setting <code>Weight</code> to <code>0</code> is different when\n\t\t\t\t\tyou associate health checks with weighted resource record sets. For more\n\t\t\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html\">Options for Configuring Route 53 Active-Active and Active-Passive\n\t\t\t\t\t\tFailover</a> in the <i>Amazon Route 53 Developer\n\t\t\t\t\tGuide</i>.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "Region": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Latency-based resource record sets only:</i> The Amazon EC2 Region\n\t\t\twhere you created the resource that this resource record set refers to. The resource\n\t\t\ttypically is an Amazon Web Services resource, such as an EC2 instance or an ELB load\n\t\t\tbalancer, and is referred to by an IP address or a DNS domain name, depending on the\n\t\t\trecord type.</p>\n         <p>When Amazon Route 53 receives a DNS query for a domain name and type for which you\n\t\t\thave created latency resource record sets, Route 53 selects the latency resource record\n\t\t\tset that has the lowest latency between the end user and the associated Amazon EC2\n\t\t\tRegion. Route 53 then returns the value that is associated with the selected resource\n\t\t\trecord set.</p>\n         <p>Note the following:</p>\n         <ul>\n            <li>\n               <p>You can only specify one <code>ResourceRecord</code> per latency resource\n\t\t\t\t\trecord set.</p>\n            </li>\n            <li>\n               <p>You can only create one latency resource record set for each Amazon EC2\n\t\t\t\t\tRegion.</p>\n            </li>\n            <li>\n               <p>You aren't required to create latency resource record sets for all Amazon EC2\n\t\t\t\t\tRegions. Route 53 will choose the region with the best latency from among the\n\t\t\t\t\tregions that you create latency resource record sets for.</p>\n            </li>\n            <li>\n               <p>You can't create non-latency resource record sets that have the same values\n\t\t\t\t\tfor the <code>Name</code> and <code>Type</code> elements as latency resource\n\t\t\t\t\trecord sets.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "GeoLocation": {
+                    "target": "com.amazonaws.route53#GeoLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Geolocation resource record sets only:</i> A complex type that lets you\n\t\t\tcontrol how Amazon Route 53 responds to DNS queries based on the geographic origin of\n\t\t\tthe query. For example, if you want all queries from Africa to be routed to a web server\n\t\t\twith an IP address of <code>192.0.2.111</code>, create a resource record set with a\n\t\t\t\t<code>Type</code> of <code>A</code> and a <code>ContinentCode</code> of\n\t\t\t\t<code>AF</code>.</p>\n         <p>If you create separate resource record sets for overlapping geographic regions (for\n\t\t\texample, one resource record set for a continent and one for a country on the same\n\t\t\tcontinent), priority goes to the smallest geographic region. This allows you to route\n\t\t\tmost queries for a continent to one resource and to route queries for a country on that\n\t\t\tcontinent to a different resource.</p>\n         <p>You can't create two geolocation resource record sets that specify the same geographic\n\t\t\tlocation.</p>\n         <p>The value <code>*</code> in the <code>CountryCode</code> element matches all\n\t\t\tgeographic locations that aren't specified in other geolocation resource record sets\n\t\t\tthat have the same values for the <code>Name</code> and <code>Type</code>\n\t\t\telements.</p>\n         <important>\n            <p>Geolocation works by mapping IP addresses to locations. However, some IP addresses\n\t\t\t\taren't mapped to geographic locations, so even if you create geolocation resource\n\t\t\t\trecord sets that cover all seven continents, Route 53 will receive some DNS queries\n\t\t\t\tfrom locations that it can't identify. We recommend that you create a resource\n\t\t\t\trecord set for which the value of <code>CountryCode</code> is <code>*</code>. Two\n\t\t\t\tgroups of queries are routed to the resource that you specify in this record:\n\t\t\t\tqueries that come from locations for which you haven't created geolocation resource\n\t\t\t\trecord sets and queries from IP addresses that aren't mapped to a location. If you\n\t\t\t\tdon't create a <code>*</code> resource record set, Route 53 returns a \"no answer\"\n\t\t\t\tresponse for queries from those locations.</p>\n         </important>\n         <p>You can't create non-geolocation resource record sets that have the same values for\n\t\t\tthe <code>Name</code> and <code>Type</code> elements as geolocation resource record\n\t\t\tsets.</p>"
+                    }
+                },
+                "Failover": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetFailover",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Failover resource record sets only:</i> To configure failover, you\n\t\t\tadd the <code>Failover</code> element to two resource record sets. For one resource\n\t\t\trecord set, you specify <code>PRIMARY</code> as the value for <code>Failover</code>; for\n\t\t\tthe other resource record set, you specify <code>SECONDARY</code>. In addition, you\n\t\t\tinclude the <code>HealthCheckId</code> element and specify the health check that you\n\t\t\twant Amazon Route 53 to perform for each resource record set.</p>\n         <p>Except where noted, the following failover behaviors assume that you have included the\n\t\t\t\t<code>HealthCheckId</code> element in both resource record sets:</p>\n         <ul>\n            <li>\n               <p>When the primary resource record set is healthy, Route 53 responds to DNS\n\t\t\t\t\tqueries with the applicable value from the primary resource record set\n\t\t\t\t\tregardless of the health of the secondary resource record set.</p>\n            </li>\n            <li>\n               <p>When the primary resource record set is unhealthy and the secondary resource\n\t\t\t\t\trecord set is healthy, Route 53 responds to DNS queries with the applicable\n\t\t\t\t\tvalue from the secondary resource record set.</p>\n            </li>\n            <li>\n               <p>When the secondary resource record set is unhealthy, Route 53 responds to DNS\n\t\t\t\t\tqueries with the applicable value from the primary resource record set\n\t\t\t\t\tregardless of the health of the primary resource record set.</p>\n            </li>\n            <li>\n               <p>If you omit the <code>HealthCheckId</code> element for the secondary resource\n\t\t\t\t\trecord set, and if the primary resource record set is unhealthy, Route 53 always\n\t\t\t\t\tresponds to DNS queries with the applicable value from the secondary resource\n\t\t\t\t\trecord set. This is true regardless of the health of the associated\n\t\t\t\t\tendpoint.</p>\n            </li>\n         </ul>\n         <p>You can't create non-failover resource record sets that have the same values for the\n\t\t\t\t<code>Name</code> and <code>Type</code> elements as failover resource record\n\t\t\tsets.</p>\n         <p>For failover alias resource record sets, you must also include the\n\t\t\t\t<code>EvaluateTargetHealth</code> element and set the value to true.</p>\n         <p>For more information about configuring failover for Route 53, see the following topics\n\t\t\tin the <i>Amazon Route 53 Developer Guide</i>: </p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Route 53 Health Checks\n\t\t\t\t\t\tand DNS Failover</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a>\n               </p>\n            </li>\n         </ul>"
+                    }
+                },
+                "MultiValueAnswer": {
+                    "target": "com.amazonaws.route53#ResourceRecordSetMultiValueAnswer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Multivalue answer resource record sets only</i>: To route traffic\n\t\t\tapproximately randomly to multiple resources, such as web servers, create one multivalue\n\t\t\tanswer record for each resource and specify <code>true</code> for\n\t\t\t\t<code>MultiValueAnswer</code>. Note the following:</p>\n         <ul>\n            <li>\n               <p>If you associate a health check with a multivalue answer resource record set,\n\t\t\t\t\tAmazon Route 53 responds to DNS queries with the corresponding IP address only\n\t\t\t\t\twhen the health check is healthy.</p>\n            </li>\n            <li>\n               <p>If you don't associate a health check with a multivalue answer record, Route\n\t\t\t\t\t53 always considers the record to be healthy.</p>\n            </li>\n            <li>\n               <p>Route 53 responds to DNS queries with up to eight healthy records; if you have\n\t\t\t\t\teight or fewer healthy records, Route 53 responds to all DNS queries with all\n\t\t\t\t\tthe healthy records.</p>\n            </li>\n            <li>\n               <p>If you have more than eight healthy records, Route 53 responds to different\n\t\t\t\t\tDNS resolvers with different combinations of healthy records.</p>\n            </li>\n            <li>\n               <p>When all records are unhealthy, Route 53 responds to DNS queries with up to\n\t\t\t\t\teight unhealthy records.</p>\n            </li>\n            <li>\n               <p>If a resource becomes unavailable after a resolver caches a response, client\n\t\t\t\t\tsoftware typically tries another of the IP addresses in the response.</p>\n            </li>\n         </ul>\n         <p>You can't create multivalue answer alias records.</p>"
+                    }
+                },
+                "TTL": {
+                    "target": "com.amazonaws.route53#TTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource record cache time to live (TTL), in seconds. Note the following:</p>\n         <ul>\n            <li>\n               <p>If you're creating or updating an alias resource record set, omit\n\t\t\t\t\t\t<code>TTL</code>. Amazon Route 53 uses the value of <code>TTL</code> for the\n\t\t\t\t\talias target. </p>\n            </li>\n            <li>\n               <p>If you're associating this resource record set with a health check (if you're\n\t\t\t\t\tadding a <code>HealthCheckId</code> element), we recommend that you specify a\n\t\t\t\t\t\t<code>TTL</code> of 60 seconds or less so clients respond quickly to changes\n\t\t\t\t\tin health status.</p>\n            </li>\n            <li>\n               <p>All of the resource record sets in a group of weighted resource record sets\n\t\t\t\t\tmust have the same value for <code>TTL</code>.</p>\n            </li>\n            <li>\n               <p>If a group of weighted resource record sets includes one or more weighted\n\t\t\t\t\talias resource record sets for which the alias target is an ELB load balancer,\n\t\t\t\t\twe recommend that you specify a <code>TTL</code> of 60 seconds for all of the\n\t\t\t\t\tnon-alias weighted resource record sets that have the same name and type. Values\n\t\t\t\t\tother than 60 seconds (the TTL for load balancers) will change the effect of the\n\t\t\t\t\tvalues that you specify for <code>Weight</code>.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "ResourceRecords": {
+                    "target": "com.amazonaws.route53#ResourceRecords",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the resource records to act upon.</p>\n         <note>\n            <p>If you're creating an alias resource record set, omit\n\t\t\t\t<code>ResourceRecords</code>.</p>\n         </note>"
+                    }
+                },
+                "AliasTarget": {
+                    "target": "com.amazonaws.route53#AliasTarget",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i>Alias resource record sets only:</i> Information about the Amazon Web Services resource, such as a CloudFront distribution or an Amazon S3 bucket, that\n\t\t\tyou want to route traffic to. </p>\n         <p>If you're creating resource records sets for a private hosted zone, note the\n\t\t\tfollowing:</p>\n         <ul>\n            <li>\n               <p>You can't create an alias resource record set in a private hosted zone to\n\t\t\t\t\troute traffic to a CloudFront distribution.</p>\n            </li>\n            <li>\n               <p>For information about creating failover resource record sets in a private\n\t\t\t\t\thosted zone, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a> in the\n\t\t\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you want Amazon Route 53 to return this resource record set in response to a DNS\n\t\t\tquery only when the status of a health check is healthy, include the\n\t\t\t\t<code>HealthCheckId</code> element and specify the ID of the applicable health\n\t\t\tcheck.</p>\n         <p>Route 53 determines whether a resource record set is healthy based on one of the\n\t\t\tfollowing:</p>\n         <ul>\n            <li>\n               <p>By periodically sending a request to the endpoint that is specified in the\n\t\t\t\t\thealth check</p>\n            </li>\n            <li>\n               <p>By aggregating the status of a specified group of health checks (calculated\n\t\t\t\t\thealth checks)</p>\n            </li>\n            <li>\n               <p>By determining the current state of a CloudWatch alarm (CloudWatch metric\n\t\t\t\t\thealth checks)</p>\n            </li>\n         </ul>\n         <important>\n            <p>Route 53 doesn't check the health of the endpoint that is specified in the\n\t\t\t\tresource record set, for example, the endpoint specified by the IP address in the\n\t\t\t\t\t<code>Value</code> element. When you add a <code>HealthCheckId</code> element to\n\t\t\t\ta resource record set, Route 53 checks the health of the endpoint that you specified\n\t\t\t\tin the health check. </p>\n         </important>\n         <p>For more information, see the following topics in the <i>Amazon Route 53\n\t\t\t\tDeveloper Guide</i>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is\n\t\t\t\t\tHealthy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Route 53 Health Checks\n\t\t\t\t\t\tand DNS Failover</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a>\n               </p>\n            </li>\n         </ul>\n         <p>\n            <b>When to Specify HealthCheckId</b>\n         </p>\n         <p>Specifying a value for <code>HealthCheckId</code> is useful only when Route 53 is\n\t\t\tchoosing between two or more resource record sets to respond to a DNS query, and you\n\t\t\twant Route 53 to base the choice in part on the status of a health check. Configuring\n\t\t\thealth checks makes sense only in the following configurations:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Non-alias resource record sets</b>: You're\n\t\t\t\t\tchecking the health of a group of non-alias resource record sets that have the\n\t\t\t\t\tsame routing policy, name, and type (such as multiple weighted records named\n\t\t\t\t\twww.example.com with a type of A) and you specify health check IDs for all the\n\t\t\t\t\tresource record sets. </p>\n               <p>If the health check status for a resource record set is healthy, Route 53\n\t\t\t\t\tincludes the record among the records that it responds to DNS queries\n\t\t\t\t\twith.</p>\n               <p>If the health check status for a resource record set is unhealthy, Route 53\n\t\t\t\t\tstops responding to DNS queries using the value for that resource record\n\t\t\t\t\tset.</p>\n               <p>If the health check status for all resource record sets in the group is\n\t\t\t\t\tunhealthy, Route 53 considers all resource record sets in the group healthy and\n\t\t\t\t\tresponds to DNS queries accordingly. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Alias resource record sets</b>: You specify the\n\t\t\t\t\tfollowing settings:</p>\n               <ul>\n                  <li>\n                     <p>You set <code>EvaluateTargetHealth</code> to true for an alias\n\t\t\t\t\t\t\tresource record set in a group of resource record sets that have the\n\t\t\t\t\t\t\tsame routing policy, name, and type (such as multiple weighted records\n\t\t\t\t\t\t\tnamed www.example.com with a type of A). </p>\n                  </li>\n                  <li>\n                     <p>You configure the alias resource record set to route traffic to a\n\t\t\t\t\t\t\tnon-alias resource record set in the same hosted zone.</p>\n                  </li>\n                  <li>\n                     <p>You specify a health check ID for the non-alias resource record set.\n\t\t\t\t\t\t</p>\n                  </li>\n               </ul>\n               <p>If the health check status is healthy, Route 53 considers the alias resource\n\t\t\t\t\trecord set to be healthy and includes the alias record among the records that it\n\t\t\t\t\tresponds to DNS queries with.</p>\n               <p>If the health check status is unhealthy, Route 53 stops responding to DNS\n\t\t\t\t\tqueries using the alias resource record set.</p>\n               <note>\n                  <p>The alias resource record set can also route traffic to a\n\t\t\t\t\t\t\t<i>group</i> of non-alias resource record sets that have\n\t\t\t\t\t\tthe same routing policy, name, and type. In that configuration, associate\n\t\t\t\t\t\thealth checks with all of the resource record sets in the group of non-alias\n\t\t\t\t\t\tresource record sets.</p>\n               </note>\n            </li>\n         </ul>\n         <p>\n            <b>Geolocation Routing</b>\n         </p>\n         <p>For geolocation resource record sets, if an endpoint is unhealthy, Route 53 looks for\n\t\t\ta resource record set for the larger, associated geographic region. For example, suppose\n\t\t\tyou have resource record sets for a state in the United States, for the entire United\n\t\t\tStates, for North America, and a resource record set that has <code>*</code> for\n\t\t\t\t<code>CountryCode</code> is <code>*</code>, which applies to all locations. If the\n\t\t\tendpoint for the state resource record set is unhealthy, Route 53 checks for healthy\n\t\t\tresource record sets in the following order until it finds a resource record set for\n\t\t\twhich the endpoint is healthy:</p>\n         <ul>\n            <li>\n               <p>The United States</p>\n            </li>\n            <li>\n               <p>North America</p>\n            </li>\n            <li>\n               <p>The default resource record set</p>\n            </li>\n         </ul>\n         <p>\n            <b>Specifying the Health Check Endpoint by Domain\n\t\t\tName</b>\n         </p>\n         <p>If your health checks specify the endpoint only by domain name, we recommend that you\n\t\t\tcreate a separate health check for each endpoint. For example, create a health check for\n\t\t\teach <code>HTTP</code> server that is serving content for <code>www.example.com</code>.\n\t\t\tFor the value of <code>FullyQualifiedDomainName</code>, specify the domain name of the\n\t\t\tserver (such as <code>us-east-2-www.example.com</code>), not the name of the resource\n\t\t\trecord sets (<code>www.example.com</code>).</p>\n         <important>\n            <p>Health check results will be unpredictable if you do the following:</p>\n            <ul>\n               <li>\n                  <p>Create a health check that has the same value for\n\t\t\t\t\t\t\t<code>FullyQualifiedDomainName</code> as the name of a resource record\n\t\t\t\t\t\tset.</p>\n               </li>\n               <li>\n                  <p>Associate that health check with the resource record set.</p>\n               </li>\n            </ul>\n         </important>"
+                    }
+                },
+                "TrafficPolicyInstanceId": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When you create a traffic policy instance, Amazon Route 53 automatically creates a\n\t\t\tresource record set. <code>TrafficPolicyInstanceId</code> is the ID of the traffic\n\t\t\tpolicy instance that Route 53 created this resource record set for.</p>\n         <important>\n            <p>To delete the resource record set that is associated with a traffic policy\n\t\t\t\tinstance, use <code>DeleteTrafficPolicyInstance</code>. Route 53 will delete the\n\t\t\t\tresource record set automatically. If you delete the resource record set by using\n\t\t\t\t\t<code>ChangeResourceRecordSets</code>, Route 53 doesn't automatically delete the\n\t\t\t\ttraffic policy instance, and you'll continue to be charged for it even though it's\n\t\t\t\tno longer in use. </p>\n         </important>"
+                    }
+                },
+                "CidrRoutingConfig": {
+                    "target": "com.amazonaws.route53#CidrRoutingConfig"
+                },
+                "GeoProximityLocation": {
+                    "target": "com.amazonaws.route53#GeoProximityLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            <i> GeoproximityLocation resource record sets only:</i> A complex type that lets you control how\n\t\t\t\tRoute 53 responds to DNS queries based on the geographic origin of the\n\t\t\tquery and your resources. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the resource record set to create or delete.</p>"
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSetFailover": {
+            "type": "enum",
+            "members": {
+                "PRIMARY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PRIMARY"
+                    }
+                },
+                "SECONDARY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SECONDARY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSetIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSetMultiValueAnswer": {
+            "type": "boolean"
+        },
+        "com.amazonaws.route53#ResourceRecordSetRegion": {
+            "type": "enum",
+            "members": {
+                "us_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-1"
+                    }
+                },
+                "us_east_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-2"
+                    }
+                },
+                "us_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-1"
+                    }
+                },
+                "us_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-2"
+                    }
+                },
+                "ca_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-central-1"
+                    }
+                },
+                "eu_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-1"
+                    }
+                },
+                "eu_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-2"
+                    }
+                },
+                "eu_west_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-3"
+                    }
+                },
+                "eu_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-1"
+                    }
+                },
+                "eu_central_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-2"
+                    }
+                },
+                "ap_southeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-1"
+                    }
+                },
+                "ap_southeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-2"
+                    }
+                },
+                "ap_southeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-3"
+                    }
+                },
+                "ap_northeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-1"
+                    }
+                },
+                "ap_northeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-2"
+                    }
+                },
+                "ap_northeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-3"
+                    }
+                },
+                "eu_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-north-1"
+                    }
+                },
+                "sa_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sa-east-1"
+                    }
+                },
+                "cn_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-north-1"
+                    }
+                },
+                "cn_northwest_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-northwest-1"
+                    }
+                },
+                "ap_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-east-1"
+                    }
+                },
+                "me_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-south-1"
+                    }
+                },
+                "me_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-central-1"
+                    }
+                },
+                "ap_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-1"
+                    }
+                },
+                "ap_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-2"
+                    }
+                },
+                "af_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "af-south-1"
+                    }
+                },
+                "eu_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-1"
+                    }
+                },
+                "eu_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-2"
+                    }
+                },
+                "ap_southeast_4": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-4"
+                    }
+                },
+                "il_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "il-central-1"
+                    }
+                },
+                "ca_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-west-1"
+                    }
+                },
+                "ap_southeast_5": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-5"
+                    }
+                },
+                "mx_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mx-central-1"
+                    }
+                },
+                "ap_southeast_7": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-7"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSetWeight": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecordSets": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#ResourceRecordSet",
+                "traits": {
+                    "smithy.api#xmlName": "ResourceRecordSet"
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceRecords": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#ResourceRecord",
+                "traits": {
+                    "smithy.api#xmlName": "ResourceRecord"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceTagSet": {
+            "type": "structure",
+            "members": {
+                "ResourceType": {
+                    "target": "com.amazonaws.route53#TagResourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource.</p>\n         <ul>\n            <li>\n               <p>The resource type for health checks is <code>healthcheck</code>.</p>\n            </li>\n            <li>\n               <p>The resource type for hosted zones is <code>hostedzone</code>.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "ResourceId": {
+                    "target": "com.amazonaws.route53#TagResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the specified resource.</p>"
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.route53#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The tags associated with the specified resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type containing a resource and its associated tags.</p>"
+            }
+        },
+        "com.amazonaws.route53#ResourceTagSetList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#ResourceTagSet",
+                "traits": {
+                    "smithy.api#xmlName": "ResourceTagSet"
+                }
+            }
+        },
+        "com.amazonaws.route53#ResourceURI": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#ReusableDelegationSetLimit": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.route53#ReusableDelegationSetLimitType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit that you requested: <code>MAX_ZONES_BY_REUSABLE_DELEGATION_SET</code>, the\n\t\t\tmaximum number of hosted zones that you can associate with the specified reusable\n\t\t\tdelegation set.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.route53#LimitValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current value for the <code>MAX_ZONES_BY_REUSABLE_DELEGATION_SET</code>\n\t\t\tlimit.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the type of limit that you specified in the request and\n\t\t\tthe current value for that limit.</p>"
+            }
+        },
+        "com.amazonaws.route53#ReusableDelegationSetLimitType": {
+            "type": "enum",
+            "members": {
+                "MAX_ZONES_BY_REUSABLE_DELEGATION_SET": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#RoutingControlArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#SearchString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.route53#ServeSignature": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#ServicePrincipal": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#SigningKeyInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.route53#SigningKeyName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#SigningKeyStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 5,
+                    "max": 150
+                }
+            }
+        },
+        "com.amazonaws.route53#SigningKeyStatusMessage": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 512
+                }
+            }
+        },
+        "com.amazonaws.route53#SigningKeyString": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#SigningKeyTag": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0,
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 65536
+                }
+            }
+        },
+        "com.amazonaws.route53#Statistic": {
+            "type": "enum",
+            "members": {
+                "Average": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Average"
+                    }
+                },
+                "Sum": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Sum"
+                    }
+                },
+                "SampleCount": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SampleCount"
+                    }
+                },
+                "Maximum": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Maximum"
+                    }
+                },
+                "Minimum": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Minimum"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#Status": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#StatusReport": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.route53#Status",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description of the status of the health check endpoint as reported by one of the\n\t\t\tAmazon Route 53 health checkers.</p>"
+                    }
+                },
+                "CheckedTime": {
+                    "target": "com.amazonaws.route53#TimeStamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time that the health checker performed the health check in <a href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 format</a> and Coordinated\n\t\t\tUniversal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code>\n\t\t\trepresents March 27, 2017 at 17:48:16.751 UTC.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the status that one Amazon Route 53 health checker\n\t\t\treports and the time of the health check.</p>"
+            }
+        },
+        "com.amazonaws.route53#SubnetMask": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 3
+                }
+            }
+        },
+        "com.amazonaws.route53#TTL": {
+            "type": "long",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 2147483647
+                }
+            }
+        },
+        "com.amazonaws.route53#Tag": {
+            "type": "structure",
+            "members": {
+                "Key": {
+                    "target": "com.amazonaws.route53#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of <code>Key</code> depends on the operation that you want to\n\t\t\tperform:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Add a tag to a health check or hosted zone</b>:\n\t\t\t\t\t\t<code>Key</code> is the name that you want to give the new tag.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Edit a tag</b>: <code>Key</code> is the name of\n\t\t\t\t\tthe tag that you want to change the <code>Value</code> for.</p>\n            </li>\n            <li>\n               <p>\n                  <b> Delete a key</b>: <code>Key</code> is the name\n\t\t\t\t\tof the tag you want to remove.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Give a name to a health check</b>: Edit the\n\t\t\t\t\tdefault <code>Name</code> tag. In the Amazon Route 53 console, the list of your\n\t\t\t\t\thealth checks includes a <b>Name</b> column that lets\n\t\t\t\t\tyou see the name that you've given to each health check.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.route53#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of <code>Value</code> depends on the operation that you want to\n\t\t\tperform:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Add a tag to a health check or hosted zone</b>:\n\t\t\t\t\t\t<code>Value</code> is the value that you want to give the new tag.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Edit a tag</b>: <code>Value</code> is the new\n\t\t\t\t\tvalue that you want to assign the tag.</p>\n            </li>\n         </ul>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about a tag that you want to add or edit for\n\t\t\tthe specified health check or hosted zone.</p>"
+            }
+        },
+        "com.amazonaws.route53#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.route53#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#TagKey",
+                "traits": {
+                    "smithy.api#xmlName": "Key"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.route53#TagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#Tag",
+                "traits": {
+                    "smithy.api#xmlName": "Tag"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.route53#TagResourceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#TagResourceIdList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#TagResourceId",
+                "traits": {
+                    "smithy.api#xmlName": "ResourceId"
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.route53#TagResourceType": {
+            "type": "enum",
+            "members": {
+                "healthcheck": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "healthcheck"
+                    }
+                },
+                "hostedzone": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "hostedzone"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.route53#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.route53#TestDNSAnswer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#TestDNSAnswerRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#TestDNSAnswerResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the value that Amazon Route 53 returns in response to a DNS request for a\n\t\t\tspecified record name and type. You can optionally specify the IP address of a DNS\n\t\t\tresolver, an EDNS0 client subnet IP address, and a subnet mask. </p>\n         <p>This call only supports querying public hosted zones.</p>\n         <note>\n            <p>The <code>TestDnsAnswer </code> returns information similar to what you would expect from the answer\n\t\t\tsection of the <code>dig</code> command. Therefore, if you query for the name\n\t\t\tservers of a subdomain that point to the parent name servers, those will not be\n\t\t\treturned.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2013-04-01/testdnsanswer",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#TestDNSAnswerRequest": {
+            "type": "structure",
+            "members": {
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that you want Amazon Route 53 to simulate a query\n\t\t\tfor.</p>",
+                        "smithy.api#httpQuery": "hostedzoneid",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the resource record set that you want Amazon Route 53 to simulate a query\n\t\t\tfor.</p>",
+                        "smithy.api#httpQuery": "recordname",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordType": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource record set.</p>",
+                        "smithy.api#httpQuery": "recordtype",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResolverIP": {
+                    "target": "com.amazonaws.route53#IPAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you want to simulate a request from a specific DNS resolver, specify the IP address\n\t\t\tfor that resolver. If you omit this value, <code>TestDnsAnswer</code> uses the IP\n\t\t\taddress of a DNS resolver in the Amazon Web Services US East (N. Virginia) Region\n\t\t\t\t(<code>us-east-1</code>).</p>",
+                        "smithy.api#httpQuery": "resolverip"
+                    }
+                },
+                "EDNS0ClientSubnetIP": {
+                    "target": "com.amazonaws.route53#IPAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the resolver that you specified for resolverip supports EDNS0, specify the IPv4 or\n\t\t\tIPv6 address of a client in the applicable location, for example,\n\t\t\t\t<code>192.0.2.44</code> or <code>2001:db8:85a3::8a2e:370:7334</code>.</p>",
+                        "smithy.api#httpQuery": "edns0clientsubnetip"
+                    }
+                },
+                "EDNS0ClientSubnetMask": {
+                    "target": "com.amazonaws.route53#SubnetMask",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you specify an IP address for <code>edns0clientsubnetip</code>, you can optionally\n\t\t\tspecify the number of bits of the IP address that you want the checking tool to include\n\t\t\tin the DNS query. For example, if you specify <code>192.0.2.44</code> for\n\t\t\t\t<code>edns0clientsubnetip</code> and <code>24</code> for\n\t\t\t\t<code>edns0clientsubnetmask</code>, the checking tool will simulate a request from\n\t\t\t192.0.2.0/24. The default value is 24 bits for IPv4 addresses and 64 bits for IPv6\n\t\t\taddresses.</p>\n         <p>The range of valid values depends on whether <code>edns0clientsubnetip</code> is an\n\t\t\tIPv4 or an IPv6 address:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>IPv4</b>: Specify a value between 0 and 32</p>\n            </li>\n            <li>\n               <p>\n                  <b>IPv6</b>: Specify a value between 0 and\n\t\t\t\t\t128</p>\n            </li>\n         </ul>",
+                        "smithy.api#httpQuery": "edns0clientsubnetmask"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the value that Amazon Route 53 returns in response to a DNS request for a\n\t\t\tspecified record name and type. You can optionally specify the IP address of a DNS\n\t\t\tresolver, an EDNS0 client subnet IP address, and a subnet mask. </p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#TestDNSAnswerResponse": {
+            "type": "structure",
+            "members": {
+                "Nameserver": {
+                    "target": "com.amazonaws.route53#Nameserver",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Route 53 name server used to respond to the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordName": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the resource record set that you submitted a request for.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordType": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource record set that you submitted a request for.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordData": {
+                    "target": "com.amazonaws.route53#RecordData",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list that contains values that Amazon Route 53 returned for this resource record\n\t\t\tset.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ResponseCode": {
+                    "target": "com.amazonaws.route53#DNSRCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A code that indicates whether the request is valid or not. The most common response\n\t\t\tcode is <code>NOERROR</code>, meaning that the request is valid. If the response is not\n\t\t\tvalid, Amazon Route 53 returns a response code that describes the error. For a list of\n\t\t\tpossible response codes, see <a href=\"http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6\">DNS RCODES</a> on the IANA website. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Protocol": {
+                    "target": "com.amazonaws.route53#TransportProtocol",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The protocol that Amazon Route 53 used to respond to the request, either\n\t\t\t\t<code>UDP</code> or <code>TCP</code>. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to a <code>TestDNSAnswer</code> request.\n\t\t</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#Threshold": {
+            "type": "double"
+        },
+        "com.amazonaws.route53#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The limit on the number of requests per second was exceeded.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TimeStamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.route53#TooManyHealthChecks": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This health check can't be created because the current account has reached the limit\n\t\t\ton the number of active health checks.</p>\n         <p>For information about default limits, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>For information about how to get the current limit for an account, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetAccountLimit.html\">GetAccountLimit</a>. To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a case</a> with the Amazon Web Services Support\n\t\t\tCenter.</p>\n         <p>You have reached the maximum number of active health checks for an Amazon Web Services account. To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a case</a> with the Amazon Web Services Support\n\t\t\tCenter.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#TooManyHostedZones": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This operation can't be completed either because the current account has reached the\n\t\t\tlimit on the number of hosted zones or because you've reached the limit on the number of\n\t\t\thosted zones that can be associated with a reusable delegation set.</p>\n         <p>For information about default limits, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>To get the current limit on hosted zones that can be created by an account, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetAccountLimit.html\">GetAccountLimit</a>.</p>\n         <p>To get the current limit on hosted zones that can be associated with a reusable\n\t\t\tdelegation set, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetReusableDelegationSetLimit.html\">GetReusableDelegationSetLimit</a>.</p>\n         <p>To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a\n\t\t\t\tcase</a> with the Amazon Web Services Support Center.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TooManyKeySigningKeys": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You've reached the limit for the number of key-signing keys (KSKs). Remove at least\n\t\t\tone KSK, and then try again.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.route53#TooManyTrafficPolicies": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This traffic policy can't be created because the current account has reached the limit\n\t\t\ton the number of traffic policies.</p>\n         <p>For information about default limits, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>To get the current limit for an account, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetAccountLimit.html\">GetAccountLimit</a>. </p>\n         <p>To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a\n\t\t\t\tcase</a> with the Amazon Web Services Support Center.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TooManyTrafficPolicyInstances": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This traffic policy instance can't be created because the current account has reached\n\t\t\tthe limit on the number of traffic policy instances.</p>\n         <p>For information about default limits, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html\">Limits</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>For information about how to get the current limit for an account, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetAccountLimit.html\">GetAccountLimit</a>.</p>\n         <p>To request a higher limit, <a href=\"http://aws.amazon.com/route53-request\">create a\n\t\t\t\tcase</a> with the Amazon Web Services Support Center.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TooManyTrafficPolicyVersionsForCurrentPolicy": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This traffic policy version can't be created because you've reached the limit of 1000\n\t\t\ton the number of versions that you can create for the current traffic policy.</p>\n         <p>To create more traffic policy versions, you can use <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetTrafficPolicy.html\">GetTrafficPolicy</a>\n\t\t\tto get the traffic policy document for a specified traffic policy version, and then use\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateTrafficPolicy.html\">CreateTrafficPolicy</a> to create a new traffic policy using the traffic policy\n\t\t\tdocument.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TooManyVPCAssociationAuthorizations": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You've created the maximum number of authorizations that can be created for the\n\t\t\tspecified hosted zone. To authorize another VPC to be associated with the hosted zone,\n\t\t\tsubmit a <code>DeleteVPCAssociationAuthorization</code> request to remove an existing\n\t\t\tauthorization. To get a list of existing authorizations, submit a\n\t\t\t\t<code>ListVPCAssociationAuthorizations</code> request.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicies": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#TrafficPolicy",
+                "traits": {
+                    "smithy.api#xmlName": "TrafficPolicy"
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicy": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigned to a traffic policy when you created it.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number that Amazon Route 53 assigns to a traffic policy. For a new traffic\n\t\t\tpolicy, the value of <code>Version</code> is always 1.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#TrafficPolicyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name that you specified when you created the traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DNS type of the resource record sets that Amazon Route 53 creates when you use a\n\t\t\ttraffic policy to create a traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Document": {
+                    "target": "com.amazonaws.route53#TrafficPolicyDocument",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The definition of a traffic policy in JSON format. You specify the JSON document to\n\t\t\tuse for a new traffic policy in the <code>CreateTrafficPolicy</code> request. For more\n\t\t\tinformation about the JSON format, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html\">Traffic Policy Document Format</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#TrafficPolicyComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The comment that you specify in the <code>CreateTrafficPolicy</code> request, if\n\t\t\tany.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains settings for a traffic policy.</p>"
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A traffic policy that has the same value for <code>Name</code> already exists.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyComment": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyDocument": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 102400
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 36
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyInUse": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>One or more traffic policy instances were created by using the specified traffic\n\t\t\tpolicy.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyInstance": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigned to the new traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HostedZoneId": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the hosted zone that Amazon Route 53 created resource record sets in.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#DNSName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DNS name, such as www.example.com, for which Amazon Route 53 responds to queries\n\t\t\tby using the resource record sets that are associated with this traffic policy instance.\n\t\t</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TTL": {
+                    "target": "com.amazonaws.route53#TTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The TTL that Amazon Route 53 assigned to all of the resource record sets that it\n\t\t\tcreated in the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "State": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of <code>State</code> is one of the following values:</p>\n         <dl>\n            <dt>Applied</dt>\n            <dd>\n               <p>Amazon Route 53 has finished creating resource record sets, and changes\n\t\t\t\t\t\thave propagated to all Route 53 edge locations.</p>\n            </dd>\n            <dt>Creating</dt>\n            <dd>\n               <p>Route 53 is creating the resource record sets. Use\n\t\t\t\t\t\t\t<code>GetTrafficPolicyInstance</code> to confirm that the\n\t\t\t\t\t\t\t<code>CreateTrafficPolicyInstance</code> request completed\n\t\t\t\t\t\tsuccessfully.</p>\n            </dd>\n            <dt>Failed</dt>\n            <dd>\n               <p>Route 53 wasn't able to create or update the resource record sets. When\n\t\t\t\t\t\tthe value of <code>State</code> is <code>Failed</code>, see\n\t\t\t\t\t\t\t<code>Message</code> for an explanation of what caused the request to\n\t\t\t\t\t\tfail.</p>\n            </dd>\n         </dl>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Message": {
+                    "target": "com.amazonaws.route53#Message",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>State</code> is <code>Failed</code>, an explanation of the reason for the\n\t\t\tfailure. If <code>State</code> is another value, <code>Message</code> is empty.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyId": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy that Amazon Route 53 used to create resource record sets\n\t\t\tin the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersion": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the traffic policy that Amazon Route 53 used to create resource record\n\t\t\tsets in the specified hosted zone.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyType": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DNS type that Amazon Route 53 assigned to all of the resource record sets that it\n\t\t\tcreated for this traffic policy instance. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains settings for the new traffic policy instance.</p>"
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyInstanceAlreadyExists": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>There is already a traffic policy instance with the specified ID.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyInstanceCount": {
+            "type": "integer"
+        },
+        "com.amazonaws.route53#TrafficPolicyInstanceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 36
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyInstanceState": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#TrafficPolicyInstances": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#TrafficPolicyInstance",
+                "traits": {
+                    "smithy.api#xmlName": "TrafficPolicyInstance"
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 512
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicySummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#TrafficPolicySummary",
+                "traits": {
+                    "smithy.api#xmlName": "TrafficPolicySummary"
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicySummary": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID that Amazon Route 53 assigned to the traffic policy when you created it.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.route53#TrafficPolicyName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name that you specified for the traffic policy when you created it.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.route53#RRType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DNS type of the resource record sets that Amazon Route 53 creates when you use a\n\t\t\ttraffic policy to create a traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "LatestVersion": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version number of the latest version of the traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyCount": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of traffic policies that are associated with the current Amazon Web Services account.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the latest version of one traffic\n\t\t\tpolicy that is associated with the current Amazon Web Services account.</p>"
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyVersion": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.route53#TrafficPolicyVersionMarker": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4
+                }
+            }
+        },
+        "com.amazonaws.route53#TransportProtocol": {
+            "type": "string"
+        },
+        "com.amazonaws.route53#UUID": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$"
+            }
+        },
+        "com.amazonaws.route53#UpdateHealthCheck": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#UpdateHealthCheckRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#UpdateHealthCheckResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#HealthCheckVersionMismatch"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHealthCheck"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing health check. Note that some values can't be updated. </p>\n         <p>For more information about updating health checks, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html\">Creating,\n\t\t\t\tUpdating, and Deleting Health Checks</a> in the <i>Amazon Route 53\n\t\t\t\tDeveloper Guide</i>.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/healthcheck/{HealthCheckId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#UpdateHealthCheckRequest": {
+            "type": "structure",
+            "members": {
+                "HealthCheckId": {
+                    "target": "com.amazonaws.route53#HealthCheckId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the health check for which you want detailed information. When you created\n\t\t\tthe health check, <code>CreateHealthCheck</code> returned the ID in the response, in the\n\t\t\t\t<code>HealthCheckId</code> element.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "HealthCheckVersion": {
+                    "target": "com.amazonaws.route53#HealthCheckVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A sequential counter that Amazon Route 53 sets to <code>1</code> when you create a\n\t\t\thealth check and increments by 1 each time you update settings for the health\n\t\t\tcheck.</p>\n         <p>We recommend that you use <code>GetHealthCheck</code> or <code>ListHealthChecks</code>\n\t\t\tto get the current value of <code>HealthCheckVersion</code> for the health check that\n\t\t\tyou want to update, and that you include that value in your\n\t\t\t\t<code>UpdateHealthCheck</code> request. This prevents Route 53 from overwriting an\n\t\t\tintervening update:</p>\n         <ul>\n            <li>\n               <p>If the value in the <code>UpdateHealthCheck</code> request matches the value\n\t\t\t\t\tof <code>HealthCheckVersion</code> in the health check, Route 53 updates the\n\t\t\t\t\thealth check with the new settings.</p>\n            </li>\n            <li>\n               <p>If the value of <code>HealthCheckVersion</code> in the health check is\n\t\t\t\t\tgreater, the health check was changed after you got the version number. Route 53\n\t\t\t\t\tdoes not update the health check, and it returns a\n\t\t\t\t\t\t<code>HealthCheckVersionMismatch</code> error.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "IPAddress": {
+                    "target": "com.amazonaws.route53#IPAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IPv4 or IPv6 IP address for the endpoint that you want Amazon Route 53 to perform\n\t\t\thealth checks on. If you don't specify a value for <code>IPAddress</code>, Route 53\n\t\t\tsends a DNS request to resolve the domain name that you specify in\n\t\t\t\t<code>FullyQualifiedDomainName</code> at the interval that you specify in\n\t\t\t\t<code>RequestInterval</code>. Using an IP address that is returned by DNS, Route 53\n\t\t\tthen checks the health of the endpoint.</p>\n         <p>Use one of the following formats for the value of <code>IPAddress</code>: </p>\n         <ul>\n            <li>\n               <p>\n                  <b>IPv4 address</b>: four values between 0 and 255,\n\t\t\t\t\tseparated by periods (.), for example, <code>192.0.2.44</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>IPv6 address</b>: eight groups of four\n\t\t\t\t\thexadecimal values, separated by colons (:), for example,\n\t\t\t\t\t\t<code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>. You can also shorten\n\t\t\t\t\tIPv6 addresses as described in RFC 5952, for example,\n\t\t\t\t\t\t<code>2001:db8:85a3::abcd:1:2345</code>.</p>\n            </li>\n         </ul>\n         <p>If the endpoint is an EC2 instance, we recommend that you create an Elastic IP\n\t\t\taddress, associate it with your EC2 instance, and specify the Elastic IP address for\n\t\t\t\t<code>IPAddress</code>. This ensures that the IP address of your instance never\n\t\t\tchanges. For more information, see the applicable documentation:</p>\n         <ul>\n            <li>\n               <p>Linux: <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html\">Elastic IP\n\t\t\t\t\t\tAddresses (EIP)</a> in the <i>Amazon EC2 User Guide for Linux\n\t\t\t\t\t\tInstances</i>\n               </p>\n            </li>\n            <li>\n               <p>Windows: <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/elastic-ip-addresses-eip.html\">Elastic IP\n\t\t\t\t\t\tAddresses (EIP)</a> in the <i>Amazon EC2 User Guide for Windows\n\t\t\t\t\t\tInstances</i>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>If a health check already has a value for <code>IPAddress</code>, you can change\n\t\t\t\tthe value. However, you can't update an existing health check to add or remove the\n\t\t\t\tvalue of <code>IPAddress</code>. </p>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-FullyQualifiedDomainName\">FullyQualifiedDomainName</a>. </p>\n         <p>Constraints: Route 53 can't check the health of endpoints for which the IP address is\n\t\t\tin local, private, non-routable, or multicast ranges. For more information about IP\n\t\t\taddresses for which you can't create health checks, see the following documents:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc5735\">RFC 5735, Special Use IPv4\n\t\t\t\t\t\tAddresses</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc6598\">RFC 6598, IANA-Reserved IPv4\n\t\t\t\t\t\tPrefix for Shared Address Space</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://tools.ietf.org/html/rfc5156\">RFC 5156, Special-Use IPv6\n\t\t\t\t\t\tAddresses</a>\n               </p>\n            </li>\n         </ul>"
+                    }
+                },
+                "Port": {
+                    "target": "com.amazonaws.route53#Port",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port on the endpoint that you want Amazon Route 53 to perform health checks\n\t\t\ton.</p>\n         <note>\n            <p>Don't specify a value for <code>Port</code> when you specify a value for\n\t\t\t\t\t<code>Type</code> of <code>CLOUDWATCH_METRIC</code> or\n\t\t\t\t<code>CALCULATED</code>.</p>\n         </note>"
+                    }
+                },
+                "ResourcePath": {
+                    "target": "com.amazonaws.route53#ResourcePath",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path that you want Amazon Route 53 to request when performing health checks. The\n\t\t\tpath can be any value for which your endpoint will return an HTTP status code of 2xx or\n\t\t\t3xx when the endpoint is healthy, for example the file /docs/route53-health-check.html.\n\t\t\tYou can also include query string parameters, for example,\n\t\t\t\t<code>/welcome.html?language=jp&login=y</code>. </p>\n         <p>Specify this value only if you want to change it.</p>"
+                    }
+                },
+                "FullyQualifiedDomainName": {
+                    "target": "com.amazonaws.route53#FullyQualifiedDomainName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon Route 53 behavior depends on whether you specify a value for\n\t\t\t\t<code>IPAddress</code>.</p>\n         <note>\n            <p>If a health check already has a value for <code>IPAddress</code>, you can change\n\t\t\t\tthe value. However, you can't update an existing health check to add or remove the\n\t\t\t\tvalue of <code>IPAddress</code>. </p>\n         </note>\n         <p>\n            <b>If you specify a value for</b>\n            <code>IPAddress</code>:</p>\n         <p>Route 53 sends health check requests to the specified IPv4 or IPv6 address and passes\n\t\t\tthe value of <code>FullyQualifiedDomainName</code> in the <code>Host</code> header for\n\t\t\tall health checks except TCP health checks. This is typically the fully qualified DNS\n\t\t\tname of the endpoint on which you want Route 53 to perform health checks.</p>\n         <p>When Route 53 checks the health of an endpoint, here is how it constructs the\n\t\t\t\t<code>Host</code> header:</p>\n         <ul>\n            <li>\n               <p>If you specify a value of <code>80</code> for <code>Port</code> and\n\t\t\t\t\t\t<code>HTTP</code> or <code>HTTP_STR_MATCH</code> for <code>Type</code>,\n\t\t\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> to the\n\t\t\t\t\tendpoint in the <code>Host</code> header.</p>\n            </li>\n            <li>\n               <p>If you specify a value of <code>443</code> for <code>Port</code> and\n\t\t\t\t\t\t<code>HTTPS</code> or <code>HTTPS_STR_MATCH</code> for <code>Type</code>,\n\t\t\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> to the\n\t\t\t\t\tendpoint in the <code>Host</code> header.</p>\n            </li>\n            <li>\n               <p>If you specify another value for <code>Port</code> and any value except\n\t\t\t\t\t\t<code>TCP</code> for <code>Type</code>, Route 53 passes\n\t\t\t\t\t\t\t<i>\n                     <code>FullyQualifiedDomainName</code>:<code>Port</code>\n                  </i>\n\t\t\t\t\tto the endpoint in the <code>Host</code> header.</p>\n            </li>\n         </ul>\n         <p>If you don't specify a value for <code>FullyQualifiedDomainName</code>, Route 53\n\t\t\tsubstitutes the value of <code>IPAddress</code> in the <code>Host</code> header in each\n\t\t\tof the above cases.</p>\n         <p>\n            <b>If you don't specify a value for</b>\n            <code>IPAddress</code>:</p>\n         <p>If you don't specify a value for <code>IPAddress</code>, Route 53 sends a DNS request\n\t\t\tto the domain that you specify in <code>FullyQualifiedDomainName</code> at the interval\n\t\t\tyou specify in <code>RequestInterval</code>. Using an IPv4 address that is returned by\n\t\t\tDNS, Route 53 then checks the health of the endpoint.</p>\n         <p>If you don't specify a value for <code>IPAddress</code>, you can’t update the health check to remove the <code>FullyQualifiedDomainName</code>; if you don’t specify a value for <code>IPAddress</code> on creation, a \n\t\t\t<code>FullyQualifiedDomainName</code> is required.</p>\n         <note>\n            <p>If you don't specify a value for <code>IPAddress</code>, Route 53 uses only IPv4\n\t\t\t\tto send health checks to the endpoint. If there's no resource record set with a type\n\t\t\t\tof A for the name that you specify for <code>FullyQualifiedDomainName</code>, the\n\t\t\t\thealth check fails with a \"DNS resolution failed\" error.</p>\n         </note>\n         <p>If you want to check the health of weighted, latency, or failover resource record sets\n\t\t\tand you choose to specify the endpoint only by <code>FullyQualifiedDomainName</code>, we\n\t\t\trecommend that you create a separate health check for each endpoint. For example, create\n\t\t\ta health check for each HTTP server that is serving content for www.example.com. For the\n\t\t\tvalue of <code>FullyQualifiedDomainName</code>, specify the domain name of the server\n\t\t\t(such as <code>us-east-2-www.example.com</code>), not the name of the resource record\n\t\t\tsets (www.example.com).</p>\n         <important>\n            <p>In this configuration, if the value of <code>FullyQualifiedDomainName</code>\n\t\t\t\tmatches the name of the resource record sets and you then associate the health check\n\t\t\t\twith those resource record sets, health check results will be unpredictable.</p>\n         </important>\n         <p>In addition, if the value of <code>Type</code> is <code>HTTP</code>,\n\t\t\t\t<code>HTTPS</code>, <code>HTTP_STR_MATCH</code>, or <code>HTTPS_STR_MATCH</code>,\n\t\t\tRoute 53 passes the value of <code>FullyQualifiedDomainName</code> in the\n\t\t\t\t<code>Host</code> header, as it does when you specify a value for\n\t\t\t\t<code>IPAddress</code>. If the value of <code>Type</code> is <code>TCP</code>, Route\n\t\t\t53 doesn't pass a <code>Host</code> header.</p>"
+                    }
+                },
+                "SearchString": {
+                    "target": "com.amazonaws.route53#SearchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the value of <code>Type</code> is <code>HTTP_STR_MATCH</code> or\n\t\t\t\t<code>HTTPS_STR_MATCH</code>, the string that you want Amazon Route 53 to search for\n\t\t\tin the response body from the specified resource. If the string appears in the response\n\t\t\tbody, Route 53 considers the resource healthy. (You can't change the value of\n\t\t\t\t<code>Type</code> when you update a health check.)</p>"
+                    }
+                },
+                "FailureThreshold": {
+                    "target": "com.amazonaws.route53#FailureThreshold",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of consecutive health checks that an endpoint must pass or fail for Amazon\n\t\t\tRoute 53 to change the current status of the endpoint from unhealthy to healthy or vice\n\t\t\tversa. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a> in the\n\t\t\t\t<i>Amazon Route 53 Developer Guide</i>.</p>\n         <p>If you don't specify a value for <code>FailureThreshold</code>, the default value is\n\t\t\tthree health checks.</p>"
+                    }
+                },
+                "Inverted": {
+                    "target": "com.amazonaws.route53#Inverted",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether you want Amazon Route 53 to invert the status of a health check, for\n\t\t\texample, to consider a health check unhealthy when it otherwise would be considered\n\t\t\thealthy.</p>"
+                    }
+                },
+                "Disabled": {
+                    "target": "com.amazonaws.route53#Disabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Stops Route 53 from performing health checks. When you disable a health check, here's\n\t\t\twhat happens:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Health checks that check the health of\n\t\t\t\t\t\tendpoints:</b> Route 53 stops submitting requests to your\n\t\t\t\t\tapplication, server, or other resource.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Calculated health checks:</b> Route 53 stops\n\t\t\t\t\taggregating the status of the referenced health checks.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Health checks that monitor CloudWatch alarms:</b>\n\t\t\t\t\tRoute 53 stops monitoring the corresponding CloudWatch metrics.</p>\n            </li>\n         </ul>\n         <p>After you disable a health check, Route 53 considers the status of the health check to\n\t\t\talways be healthy. If you configured DNS failover, Route 53 continues to route traffic\n\t\t\tto the corresponding resources. If you want to stop routing traffic to a resource,\n\t\t\tchange the value of <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-Inverted\">Inverted</a>. </p>\n         <p>Charges for a health check still apply when the health check is disabled. For more\n\t\t\tinformation, see <a href=\"http://aws.amazon.com/route53/pricing/\">Amazon Route 53\n\t\t\t\tPricing</a>.</p>"
+                    }
+                },
+                "HealthThreshold": {
+                    "target": "com.amazonaws.route53#HealthThreshold",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of child health checks that are associated with a <code>CALCULATED</code>\n\t\t\thealth that Amazon Route 53 must consider healthy for the <code>CALCULATED</code> health\n\t\t\tcheck to be considered healthy. To specify the child health checks that you want to\n\t\t\tassociate with a <code>CALCULATED</code> health check, use the\n\t\t\t\t<code>ChildHealthChecks</code> and <code>ChildHealthCheck</code> elements.</p>\n         <p>Note the following:</p>\n         <ul>\n            <li>\n               <p>If you specify a number greater than the number of child health checks, Route\n\t\t\t\t\t53 always considers this health check to be unhealthy.</p>\n            </li>\n            <li>\n               <p>If you specify <code>0</code>, Route 53 always considers this health check to\n\t\t\t\t\tbe healthy.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "ChildHealthChecks": {
+                    "target": "com.amazonaws.route53#ChildHealthCheckList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>ChildHealthCheck</code> element for each health\n\t\t\tcheck that you want to associate with a <code>CALCULATED</code> health check.</p>"
+                    }
+                },
+                "EnableSNI": {
+                    "target": "com.amazonaws.route53#EnableSNI",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify whether you want Amazon Route 53 to send the value of\n\t\t\t\t<code>FullyQualifiedDomainName</code> to the endpoint in the\n\t\t\t\t<code>client_hello</code> message during <code>TLS</code> negotiation. This allows\n\t\t\tthe endpoint to respond to <code>HTTPS</code> health check requests with the applicable\n\t\t\tSSL/TLS certificate.</p>\n         <p>Some endpoints require that HTTPS requests include the host name in the\n\t\t\t\t<code>client_hello</code> message. If you don't enable SNI, the status of the health\n\t\t\tcheck will be SSL alert <code>handshake_failure</code>. A health check can also have\n\t\t\tthat status for other reasons. If SNI is enabled and you're still getting the error,\n\t\t\tcheck the SSL/TLS configuration on your endpoint and confirm that your certificate is\n\t\t\tvalid.</p>\n         <p>The SSL/TLS certificate on your endpoint includes a domain name in the <code>Common\n\t\t\t\tName</code> field and possibly several more in the <code>Subject Alternative\n\t\t\t\tNames</code> field. One of the domain names in the certificate should match the\n\t\t\tvalue that you specify for <code>FullyQualifiedDomainName</code>. If the endpoint\n\t\t\tresponds to the <code>client_hello</code> message with a certificate that does not\n\t\t\tinclude the domain name that you specified in <code>FullyQualifiedDomainName</code>, a\n\t\t\thealth checker will retry the handshake. In the second attempt, the health checker will\n\t\t\tomit <code>FullyQualifiedDomainName</code> from the <code>client_hello</code>\n\t\t\tmessage.</p>"
+                    }
+                },
+                "Regions": {
+                    "target": "com.amazonaws.route53#HealthCheckRegionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>Region</code> element for each region that you\n\t\t\twant Amazon Route 53 health checkers to check the specified endpoint from.</p>"
+                    }
+                },
+                "AlarmIdentifier": {
+                    "target": "com.amazonaws.route53#AlarmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53\n\t\t\thealth checkers to use to determine whether the specified health check is\n\t\t\thealthy.</p>"
+                    }
+                },
+                "InsufficientDataHealthStatus": {
+                    "target": "com.amazonaws.route53#InsufficientDataHealthStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When CloudWatch has insufficient data about the metric to determine the alarm state,\n\t\t\tthe status that you want Amazon Route 53 to assign to the health check:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Healthy</code>: Route 53 considers the health check to be\n\t\t\t\t\thealthy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Unhealthy</code>: Route 53 considers the health check to be\n\t\t\t\t\tunhealthy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LastKnownStatus</code>: By default, Route 53 uses the status of the\n\t\t\t\t\thealth check from the last time CloudWatch had sufficient data to determine the\n\t\t\t\t\talarm state. For new health checks that have no last known status, the status\n\t\t\t\t\tfor the health check is healthy.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "ResetElements": {
+                    "target": "com.amazonaws.route53#ResettableElementNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains one <code>ResettableElementName</code> element for each\n\t\t\telement that you want to reset to the default value. Valid values for\n\t\t\t\t<code>ResettableElementName</code> include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ChildHealthChecks</code>: Amazon Route 53 resets <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_HealthCheckConfig.html#Route53-Type-HealthCheckConfig-ChildHealthChecks\">ChildHealthChecks</a> to null.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FullyQualifiedDomainName</code>: Route 53 resets <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_UpdateHealthCheck.html#Route53-UpdateHealthCheck-request-FullyQualifiedDomainName\">FullyQualifiedDomainName</a>. to null.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Regions</code>: Route 53 resets the <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_HealthCheckConfig.html#Route53-Type-HealthCheckConfig-Regions\">Regions</a> list to the default set of regions. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ResourcePath</code>: Route 53 resets <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_HealthCheckConfig.html#Route53-Type-HealthCheckConfig-ResourcePath\">ResourcePath</a> to null.</p>\n            </li>\n         </ul>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about a request to update a health\n\t\t\tcheck.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateHealthCheckResponse": {
+            "type": "structure",
+            "members": {
+                "HealthCheck": {
+                    "target": "com.amazonaws.route53#HealthCheck",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the response to an <code>UpdateHealthCheck</code>\n\t\t\trequest.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to the <code>UpdateHealthCheck</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateHostedZoneComment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#UpdateHostedZoneCommentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#UpdateHostedZoneCommentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchHostedZone"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the comment for a specified hosted zone.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/hostedzone/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#UpdateHostedZoneCommentRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#ResourceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID for the hosted zone that you want to update the comment for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#ResourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new comment for the hosted zone. If you don't specify a value for\n\t\t\t\t<code>Comment</code>, Amazon Route 53 deletes the existing value of the\n\t\t\t\t<code>Comment</code> element, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to update the comment for a hosted zone.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateHostedZoneCommentResponse": {
+            "type": "structure",
+            "members": {
+                "HostedZone": {
+                    "target": "com.amazonaws.route53#HostedZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code>\n\t\t\trequest.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code>\n\t\t\trequest.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyComment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#UpdateTrafficPolicyCommentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#UpdateTrafficPolicyCommentResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConcurrentModification"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the comment for a specified traffic policy version.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/trafficpolicy/{Id}/{Version}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyCommentRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of <code>Id</code> for the traffic policy that you want to update the\n\t\t\tcomment for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of <code>Version</code> for the traffic policy that you want to update the\n\t\t\tcomment for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Comment": {
+                    "target": "com.amazonaws.route53#TrafficPolicyComment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new comment for the specified traffic policy and version.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the traffic policy that you want to\n\t\t\tupdate the comment for.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyCommentResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicy": {
+                    "target": "com.amazonaws.route53#TrafficPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the specified traffic policy.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains the response information for the traffic policy.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyInstance": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.route53#UpdateTrafficPolicyInstanceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.route53#UpdateTrafficPolicyInstanceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.route53#ConflictingTypes"
+                },
+                {
+                    "target": "com.amazonaws.route53#InvalidInput"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicy"
+                },
+                {
+                    "target": "com.amazonaws.route53#NoSuchTrafficPolicyInstance"
+                },
+                {
+                    "target": "com.amazonaws.route53#PriorRequestNotComplete"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<note>\n            <p>After you submit a <code>UpdateTrafficPolicyInstance</code> request, there's a brief delay while Route 53 creates the resource record sets \n\t\t\tthat are specified in the traffic policy definition. Use <code>GetTrafficPolicyInstance</code> with the <code>id</code> of updated traffic policy instance confirm \n\t\t\tthat the \n\t\t\t<code>UpdateTrafficPolicyInstance</code> request completed successfully. For more information, see the <code>State</code> response element.</p>\n         </note>\n         <p>Updates the resource record sets in a specified hosted zone that were created based on\n\t\t\tthe settings in a specified traffic policy version.</p>\n         <p>When you update a traffic policy instance, Amazon Route 53 continues to respond to DNS\n\t\t\tqueries for the root resource record set name (such as example.com) while it replaces\n\t\t\tone group of resource record sets with another. Route 53 performs the following\n\t\t\toperations:</p>\n         <ol>\n            <li>\n               <p>Route 53 creates a new group of resource record sets based on the specified\n\t\t\t\t\ttraffic policy. This is true regardless of how significant the differences are\n\t\t\t\t\tbetween the existing resource record sets and the new resource record sets.\n\t\t\t\t</p>\n            </li>\n            <li>\n               <p>When all of the new resource record sets have been created, Route 53 starts to\n\t\t\t\t\trespond to DNS queries for the root resource record set name (such as\n\t\t\t\t\texample.com) by using the new resource record sets.</p>\n            </li>\n            <li>\n               <p>Route 53 deletes the old group of resource record sets that are associated\n\t\t\t\t\twith the root resource record set name.</p>\n            </li>\n         </ol>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2013-04-01/trafficpolicyinstance/{Id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyInstanceRequest": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstanceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy instance that you want to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "TTL": {
+                    "target": "com.amazonaws.route53#TTL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The TTL that you want Amazon Route 53 to assign to all of the updated resource record\n\t\t\tsets.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyId": {
+                    "target": "com.amazonaws.route53#TrafficPolicyId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the traffic policy that you want Amazon Route 53 to use to update resource\n\t\t\trecord sets for the specified traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TrafficPolicyVersion": {
+                    "target": "com.amazonaws.route53#TrafficPolicyVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the traffic policy that you want Amazon Route 53 to use to update\n\t\t\tresource record sets for the specified traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the resource record sets that you want\n\t\t\tto update based on a specified traffic policy instance.</p>",
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.route53#UpdateTrafficPolicyInstanceResponse": {
+            "type": "structure",
+            "members": {
+                "TrafficPolicyInstance": {
+                    "target": "com.amazonaws.route53#TrafficPolicyInstance",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A complex type that contains settings for the updated traffic policy instance.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A complex type that contains information about the resource record sets that Amazon\n\t\t\tRoute 53 created based on a specified traffic policy.</p>",
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.route53#UsageCount": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0,
+                "smithy.api#range": {
+                    "min": 0
+                }
+            }
+        },
+        "com.amazonaws.route53#VPC": {
+            "type": "structure",
+            "members": {
+                "VPCRegion": {
+                    "target": "com.amazonaws.route53#VPCRegion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Private hosted zones only) The region that an Amazon VPC was created\n\t\t\tin.</p>"
+                    }
+                },
+                "VPCId": {
+                    "target": "com.amazonaws.route53#VPCId"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>(Private hosted zones only) A complex type that contains information about an Amazon VPC.</p>\n         <p>If you associate a private hosted zone with an Amazon VPC when you make a\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html\">CreateHostedZone</a>\n\t\t\trequest, the following parameters are also required.</p>"
+            }
+        },
+        "com.amazonaws.route53#VPCAssociationAuthorizationNotFound": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The VPC that you specified is not authorized to be associated with the hosted\n\t\t\tzone.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#VPCAssociationNotFound": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.route53#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specified VPC or hosted zone weren't found.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified VPC and hosted zone are not currently associated.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.route53#VPCId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "<p>(Private hosted zones only) The ID of an Amazon VPC. </p>",
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.route53#VPCRegion": {
+            "type": "enum",
+            "members": {
+                "us_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-1"
+                    }
+                },
+                "us_east_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-east-2"
+                    }
+                },
+                "us_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-1"
+                    }
+                },
+                "us_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-west-2"
+                    }
+                },
+                "eu_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-1"
+                    }
+                },
+                "eu_west_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-2"
+                    }
+                },
+                "eu_west_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-west-3"
+                    }
+                },
+                "eu_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-1"
+                    }
+                },
+                "eu_central_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-central-2"
+                    }
+                },
+                "ap_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-east-1"
+                    }
+                },
+                "me_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-south-1"
+                    }
+                },
+                "us_gov_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-gov-west-1"
+                    }
+                },
+                "us_gov_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-gov-east-1"
+                    }
+                },
+                "us_iso_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-iso-east-1"
+                    }
+                },
+                "us_iso_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-iso-west-1"
+                    }
+                },
+                "us_isob_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "us-isob-east-1"
+                    }
+                },
+                "me_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "me-central-1"
+                    }
+                },
+                "ap_southeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-1"
+                    }
+                },
+                "ap_southeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-2"
+                    }
+                },
+                "ap_southeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-3"
+                    }
+                },
+                "ap_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-1"
+                    }
+                },
+                "ap_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-south-2"
+                    }
+                },
+                "ap_northeast_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-1"
+                    }
+                },
+                "ap_northeast_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-2"
+                    }
+                },
+                "ap_northeast_3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-northeast-3"
+                    }
+                },
+                "eu_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-north-1"
+                    }
+                },
+                "sa_east_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sa-east-1"
+                    }
+                },
+                "ca_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-central-1"
+                    }
+                },
+                "cn_north_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-north-1"
+                    }
+                },
+                "cn_northwest_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cn-northwest-1"
+                    }
+                },
+                "af_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "af-south-1"
+                    }
+                },
+                "eu_south_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-1"
+                    }
+                },
+                "eu_south_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "eu-south-2"
+                    }
+                },
+                "ap_southeast_4": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-4"
+                    }
+                },
+                "il_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "il-central-1"
+                    }
+                },
+                "ca_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-west-1"
+                    }
+                },
+                "ap_southeast_5": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-5"
+                    }
+                },
+                "mx_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mx-central-1"
+                    }
+                },
+                "ap_southeast_7": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-7"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.route53#VPCs": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.route53#VPC",
+                "traits": {
+                    "smithy.api#xmlName": "VPC"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>(Private hosted zones only) A list of <code>VPC</code> elements.</p>",
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        }
+    }
+}

--- a/pkg/testdata/models/apis/route53/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/route53/0000-00-00/generator.yaml
@@ -1,0 +1,97 @@
+ignore:
+  field_paths:
+  - ChangeResourceRecordSetsOutput.ChangeInfo.Comment
+  - ResourceRecordSet.GeoProximityLocation
+  - ChangeResourceRecordSetsInput.ChangeBatch
+sdk_names:
+  model_name: route-53
+operations:
+  ChangeResourceRecordSets:
+    operation_type:
+    - Create
+    - Delete
+    resource_name:
+      RecordSet
+  ListResourceRecordSets:
+    operation_type:
+    - List
+    resource_name:
+      RecordSet
+resources:
+  RecordSet:
+    fields:
+      AliasTarget:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.AliasTarget
+      CidrRoutingConfig:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.CidrRoutingConfig
+      Failover:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.Failover
+      GeoLocation:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.GeoLocation
+      HealthCheckId:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.HealthCheckId
+      # Changing this value after a CR has been created could result in orphaned record sets
+      HostedZoneId:
+        references:
+          resource: HostedZone
+          path: Status.ID
+        is_required: true
+        is_immutable: true
+      ID:
+        is_primary_key: true
+        documentation: "ID represents the ChangeID that is returned after a successful 
+        ChangeResourceRecordSet request"
+      MultiValueAnswer:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.MultiValueAnswer
+      # Changing this value after a CR has been created could result in orphaned record sets.
+      # Note that the name refers to the subdomain value of a record set and not the fully
+      # qualified DNS name
+      Name:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.Name
+        is_immutable: true
+      # Changing this value after a CR has been created could result in orphaned record sets
+      RecordType:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.Type
+        is_required: true
+        is_immutable: true
+      Region:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.Region
+      ResourceRecords:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.ResourceRecords
+      # Changing this value after a CR has been created could result in orphaned record sets
+      SetIdentifier:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.SetIdentifier
+        is_immutable: true
+      Status:
+        print:
+          name: STATUS
+      TTL:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.TTL
+      Weight:
+        from:
+          operation: ListResourceRecordSets
+          path: ResourceRecordSets.Weight


### PR DESCRIPTION
Description of changes:
So currently, when you define a `from` `operation` `path`
in generator.yaml fieldConfig, the code-generator checks for
the read_only configuration to decide whether to get the field
from the input shape or the output shape.

The change introduced here tries to retrieve spec fields from input
shapes first, if not found it checks output shape.
If read_only is configured to true, it does so in reverse order
(checks output shape first, if not found, checks input shape)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
