### PR TITLE
Replace To/FromACKTags with to/fromACKTagsWithKeyOrder

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -203,6 +203,12 @@ var (
 		"GoCodeClearResolvedReferences": func(f *ackmodel.Field, targetVarName string, indentLevel int) string {
 			return code.ClearResolvedReferencesForField(f, targetVarName, indentLevel)
 		},
+		"GoCodeConvertToACKTags": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, keyOrderVarName string, indentLevel int) string {
+			return code.GoCodeConvertToACKTags(r, sourceVarName, targetVarName, keyOrderVarName, indentLevel)
+		},
+		"GoCodeFromACKTags": func(r *ackmodel.CRD, sourceVarName string, orderVarName string, targetVarName string, indentLevel int) string {
+			return code.GoCodeFromACKTags(r, sourceVarName, orderVarName, targetVarName, indentLevel)
+		},
 	}
 )
 

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -523,9 +523,11 @@ func compareSlice(
 //
 // Output code will look something like this:
 //
-//	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
-//	  delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-//	}
+//	 desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+//	 latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+//		if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
+//		  delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+//		}
 func compareTags(
 	// String representing the name of the variable that is of type
 	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
@@ -549,7 +551,9 @@ func compareTags(
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
 
-	out += fmt.Sprintf("%sif !ackcompare.MapStringStringEqual(ToACKTags(%s), ToACKTags(%s)) {\n", indent, firstResVarName, secondResVarName)
+	out += fmt.Sprintf("%sdesiredACKTags, _ := convertToOrderedACKTags(%s)\n", indent, firstResVarName)
+	out += fmt.Sprintf("%slatestACKTags, _ := convertToOrderedACKTags(%s)\n", indent, secondResVarName)
+	out += fmt.Sprintf("%sif !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {\n", indent)
 	out += fmt.Sprintf("%s\t%s.Add(\"%s\", %s, %s)\n", indent, deltaVarName, fieldPath, firstResVarName, secondResVarName)
 	out += fmt.Sprintf("%s}\n", indent)
 

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -127,7 +127,9 @@ func TestCompareResource_S3_Bucket(t *testing.T) {
 	if ackcompare.HasNilDifference(a.ko.Spec.Tagging, b.ko.Spec.Tagging) {
 		delta.Add("Spec.Tagging", a.ko.Spec.Tagging, b.ko.Spec.Tagging)
 	} else if a.ko.Spec.Tagging != nil && b.ko.Spec.Tagging != nil {
-		if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tagging.TagSet), ToACKTags(b.ko.Spec.Tagging.TagSet)) {
+		desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tagging.TagSet)
+		latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tagging.TagSet)
+		if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 			delta.Add("Spec.Tagging", a.ko.Spec.Tagging.TagSet, b.ko.Spec.Tagging.TagSet)
 		}
 	}
@@ -364,7 +366,9 @@ func TestCompareResource_Lambda_Function(t *testing.T) {
 			delta.Add("Spec.Runtime", a.ko.Spec.Runtime, b.ko.Spec.Runtime)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Timeout, b.ko.Spec.Timeout) {
@@ -533,7 +537,9 @@ func TestCompareResource_IAM_OIDC_URL(t *testing.T) {
 			delta.Add("Spec.ClientIDList", a.ko.Spec.ClientIDList, b.ko.Spec.ClientIDList)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if len(a.ko.Spec.ThumbprintList) != len(b.ko.Spec.ThumbprintList) {
@@ -586,7 +592,9 @@ func TestCompareResource_MemoryDB_User(t *testing.T) {
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 `

--- a/pkg/generate/code/tags.go
+++ b/pkg/generate/code/tags.go
@@ -1,0 +1,157 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+)
+
+// GoCodeToACKTags returns Go code that converts Resource Tags
+// to ACK Tags. If Resource Tags field is of type list, we
+// also maintain and return the order of the list as a []string
+// 
+//
+//
+// Sample output:
+//
+//	 for _, k := range keyOrder {
+//	 	v, ok := tags[k]
+//	 	if ok {
+//	 		tag := svcapitypes.Tag{Key: &k, Value: &v}
+//	 		result = append(result, &tag)
+//	 		delete(tags, k)
+//	 	}
+//	 }
+//	 for k, v := range tags {
+//	 	tag := svcapitypes.Tag{Key: &k, Value: &v}
+//	 	result = append(result, &tag)
+//	 }
+func GoCodeConvertToACKTags(r *model.CRD, sourceVarName string, targetVarName string, keyOrderVarName string, indentLevel int) string {
+
+	out := "\n"
+	indent := strings.Repeat("\t", indentLevel)
+	tagField, err := r.GetTagField()
+	if err != nil {
+		panic("error: resource does not have tags. ignore in generator.yaml")
+	}
+
+	if tagField == nil {
+		return ""
+	}
+
+	tagFieldShapeType := tagField.ShapeRef.Shape.Type
+	keyMemberName := r.GetTagKeyMemberName()
+	valueMemberName := r.GetTagValueMemberName()
+
+	out += fmt.Sprintf("%sif len(%s) == 0 {\n", indent, sourceVarName)
+	out += fmt.Sprintf("%s\treturn %s, %s\n", indent, targetVarName, keyOrderVarName)
+	out += fmt.Sprintf("%s}\n", indent)
+
+	switch tagFieldShapeType {
+	case "list":
+		out += fmt.Sprintf("%sfor _, t := range %s {\n", indent, sourceVarName)
+		out += fmt.Sprintf("%s\tif t.%s != nil {\n", indent, keyMemberName)
+		out += fmt.Sprintf("%s\t\t%s = append(%s, *t.%s)\n", indent, keyOrderVarName, keyOrderVarName, keyMemberName)
+		out += fmt.Sprintf("%s\t\tif t.%s != nil {\n", indent, valueMemberName)
+		out += fmt.Sprintf("%s\t\t\t%s[*t.%s] = *t.%s\n", indent, targetVarName, keyMemberName, valueMemberName)
+		out += fmt.Sprintf("%s\t\t} else {\n", indent)
+		out += fmt.Sprintf("%s\t\t\t%s[*t.%s] = \"\"\n", indent, targetVarName, keyMemberName)
+		out += fmt.Sprintf("%s\t\t}\n", indent)
+		out += fmt.Sprintf("%s\t}\n", indent)
+		out += fmt.Sprintf("%s}\n", indent)
+
+	case "map":
+		out += fmt.Sprintf("%sfor k, v := range %s {\n", indent, sourceVarName)
+		out += fmt.Sprintf("%s\tif v == nil {\n", indent)
+		out += fmt.Sprintf("%s\t\t%s[k] = \"\"\n", indent, targetVarName)
+		out += fmt.Sprintf("%s\t} else {\n", indent)
+		out += fmt.Sprintf("%s\t\t%s[k] = *v\n", indent, targetVarName)
+		out += fmt.Sprintf("%s\t}\n", indent)
+		out += fmt.Sprintf("%s}\n", indent)
+	default:
+		msg := "error: tag type can only be a list or a map"
+		panic(msg)
+	}
+
+	return out
+}
+
+// GoCodeFromACKTags returns Go code that converts ACKTags
+// to the Resource Tag shape type. Tag fields can only be
+// maps or lists of Tag Go type. If Tag field is a list,
+// when converting from ACK Tags, we try to preserve the 
+// original order
+// 
+//
+//
+// Sample output:
+//
+//	 for _, k := range keyOrder {
+//	 	v, ok := tags[k]
+//	 	if ok {
+//	 		tag := svcapitypes.Tag{Key: &k, Value: &v}
+//	 		result = append(result, &tag)
+//	 		delete(tags, k)
+//	 	}
+//	 }
+//	 for k, v := range tags {
+//	 	tag := svcapitypes.Tag{Key: &k, Value: &v}
+//	 	result = append(result, &tag)
+//	 }
+func GoCodeFromACKTags(r *model.CRD, tagsSourceVarName string, orderVarName string, targetVarName string, indentLevel int) string {
+	out := "\n"
+	indent := strings.Repeat("\t", indentLevel)
+	tagField, _ := r.GetTagField()
+
+	if tagField == nil {
+		return ""
+	}
+
+	tagFieldShapeType := tagField.ShapeRef.Shape.Type
+	tagFieldGoType := tagField.GoTypeElem
+	keyMemberName := r.GetTagKeyMemberName()
+	valueMemberName := r.GetTagValueMemberName()
+
+	switch tagFieldShapeType {
+	case "list":
+		out += fmt.Sprintf("%sfor _, k := range %s {\n", indent, orderVarName)
+		out += fmt.Sprintf("%s\tv, ok := %s[k]\n", indent, tagsSourceVarName)
+		out += fmt.Sprintf("%s\tif ok {\n", indent)
+		out += fmt.Sprintf("%s\t\ttag := svcapitypes.%s{%s: &k, %s: &v}\n", indent, tagFieldGoType, keyMemberName, valueMemberName)
+		out += fmt.Sprintf("%s\t\t%s = append(%s, &tag)\n", indent, targetVarName, targetVarName)
+		out += fmt.Sprintf("%s\t\tdelete(%s, k)\n", indent, tagsSourceVarName)
+		out += fmt.Sprintf("%s\t}\n", indent)
+		out += fmt.Sprintf("%s}\n", indent)
+	case "map":
+		out += fmt.Sprintf("%s_ = %s\n", indent, orderVarName)
+	default:
+		msg := "error: tag type can only be a list of a map"
+		panic(msg)
+	}
+
+	out += fmt.Sprintf("%sfor k, v := range %s {\n", indent, tagsSourceVarName)
+	switch tagFieldShapeType {
+	case "list":
+		out += fmt.Sprintf("%s\ttag := svcapitypes.%s{%s: &k, %s: &v}\n", indent, tagFieldGoType, keyMemberName, valueMemberName)
+		out += fmt.Sprintf("%s\t%s = append(%s, &tag)\n", indent, targetVarName, targetVarName)
+	case "map":
+		out += fmt.Sprintf("%s\t%s[k] = &v\n", indent, targetVarName)
+	}
+	out += fmt.Sprintf("%s}\n", indent)
+
+	return out
+}

--- a/pkg/generate/code/tags_test.go
+++ b/pkg/generate/code/tags_test.go
@@ -1,0 +1,139 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestToACKTagsForListShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
+				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
+			}
+		}
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.GoCodeConvertToACKTags(
+			crd, "tags", "result", "keyOrder", 1,
+		),
+	)
+}
+
+func TestToACKTagsForMapShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "apigatewayv2")
+
+	crd := testutil.GetCRDByName(t, g, "Api")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
+	for k, v := range tags {
+		if v == nil {
+			result[k] = ""
+		} else {
+			result[k] = *v
+		}
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.GoCodeConvertToACKTags(
+			crd, "tags", "result", "keyOrder", 1,
+		),
+	)
+}
+
+func TestFromACKTagsForListShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "ec2")
+
+	crd := testutil.GetCRDByName(t, g, "Vpc")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.GoCodeFromACKTags(
+			crd, "tags", "keyOrder", "result", 1,
+		),
+	)
+}
+
+func TestFromACKTagsForMapShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "apigatewayv2")
+
+	crd := testutil.GetCRDByName(t, g, "Api")
+	require.NotNil(crd)
+
+	expectedSyncedConditions := `
+	_ = keyOrder
+	for k, v := range tags {
+		result[k] = &v
+	}
+`
+	assert.Equal(
+		expectedSyncedConditions,
+		code.GoCodeFromACKTags(
+			crd, "tags", "keyOrder", "result", 1,
+		),
+	)
+}

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -303,10 +303,10 @@ func (rm *resourceManager) EnsureTags(
 {{ else -}}
     existingTags = r.ko.Spec.{{ $tagField.Path }}
 {{ end -}}
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
 {{ GoCodeInitializeNestedStructField .CRD "r.ko" $tagField "svcapitypes" 1 -}}
-	r.ko.Spec.{{ $tagField.Path }} = FromACKTags(tags)
+	r.ko.Spec.{{ $tagField.Path }} = fromACKTags(tags, keyOrder)
 {{- end }}
     return nil
 {{- end }}
@@ -341,10 +341,10 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
     }
 {{ end -}}
     existingTags = r.ko.Spec.{{ $tagField.Path }}
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
 {{ GoCodeInitializeNestedStructField .CRD "r.ko" $tagField "svcapitypes" 1 -}}
-	r.ko.Spec.{{ $tagField.Path }} = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.{{ $tagField.Path }} = fromACKTags(resourceTags, tagKeyOrder)
 {{- end }}
 {{- end }}
 }
@@ -393,11 +393,11 @@ func mirrorAWSTags(a *resource, b *resource) {
 	existingDesiredTags = a.ko.Spec.{{ $tagField.Path }}
 {{ end -}}
     existingLatestTags = b.ko.Spec.{{ $tagField.Path }}
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
 {{ GoCodeInitializeNestedStructField .CRD "a.ko" $tagField "svcapitypes" 1 -}}
-	a.ko.Spec.{{ $tagField.Path }} = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.{{ $tagField.Path }} = fromACKTags(desiredTags, desiredTagKeyOrder)
 {{- end }}
 {{- end }}
 }

--- a/templates/pkg/resource/tags.go.tpl
+++ b/templates/pkg/resource/tags.go.tpl
@@ -21,138 +21,36 @@ var (
 {{- if $tagField }}
 {{- $tagFieldShapeType := $tagField.ShapeRef.Shape.Type }}
 {{- $tagFieldGoType := $tagField.GoType }}
-{{- $keyMemberName := .CRD.GetTagKeyMemberName }}
-{{- $valueMemberName := .CRD.GetTagValueMemberName }}
 {{- if eq "list" $tagFieldShapeType }}
 {{- $tagFieldGoType = (print "[]*svcapitypes." $tagField.GoTypeElem) }}
 {{- end }}
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags {{ $tagFieldGoType }}) acktags.Tags {
-    result := acktags.NewTags()
-{{- if $hookCode := Hook .CRD "pre_convert_to_ack_tags" }}
-{{ $hookCode }}
-{{ end }}
-    if tags == nil || len(tags) == 0 {
-        return result
-    }
-{{ if eq "map" $tagFieldShapeType }}
-    for k, v := range tags {
-        if v == nil {
-            result[k] = ""
-        } else {
-            result[k] = *v
-        }
-    }
-{{ else if eq "list" $tagFieldShapeType }}
-    for _, t := range tags {
-        if t.{{ $keyMemberName}} != nil {
-            if t.{{ $valueMemberName }} == nil {
-                result[*t.{{ $keyMemberName}}] = ""
-            } else {
-                result[*t.{{ $keyMemberName }}] = *t.{{ $valueMemberName }}
-            }
-        }
-    }
-{{ end }}
-{{- if $hookCode := Hook .CRD "post_convert_to_ack_tags" }}
-{{ $hookCode }}
-{{ end }}
-    return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
 // default controller tags with existing resource tags. It also returns a slice
 // of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags {{ $tagFieldGoType }}) (acktags.Tags, []string) {
+func convertToOrderedACKTags(tags {{ $tagFieldGoType }}) (acktags.Tags, []string) {
     result := acktags.NewTags()
     keyOrder := []string{}
 {{- if $hookCode := Hook .CRD "pre_convert_to_ack_tags" }}
 {{ $hookCode }}
 {{ end }}
-    if tags == nil || len(tags) == 0 {
-        return result, keyOrder
-    }
-{{ if eq "map" $tagFieldShapeType }}
-    for k, v := range tags {
-        if v == nil {
-            result[k] = ""
-        } else {
-            result[k] = *v
-        }
-    }
-{{ else if eq "list" $tagFieldShapeType }}
-    for _, t := range tags {
-        if t.{{ $keyMemberName}} != nil {
-            keyOrder = append(keyOrder, *t.{{ $keyMemberName}})
-        }
-    }
-    result = ToACKTags(tags)
-{{ end }}
+{{ GoCodeConvertToACKTags .CRD "tags" "result" "keyOrder" 1 }}
 {{- if $hookCode := Hook .CRD "post_convert_to_ack_tags" }}
 {{ $hookCode }}
 {{ end }}
     return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into {{ $tagFieldGoType }} shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) {{ $tagFieldGoType }} {
-    result := {{ $tagFieldGoType }}{}
-{{- if $hookCode := Hook .CRD "pre_convert_from_ack_tags" }}
-{{ $hookCode }}
-{{ end }}
-    for k, v := range tags {
-{{- if eq "map" $tagFieldShapeType }}
-        vCopy := v
-        result[k] = &vCopy
-{{- else if eq "list" $tagFieldShapeType }}
-        kCopy := k
-        vCopy := v
-        tag := svcapitypes.{{ $tagField.GoTypeElem }}{ {{ $keyMemberName }}: &kCopy, {{ $valueMemberName }} : &vCopy}
-        result = append(result, &tag)
-{{- end }}
-    }
-{{- if $hookCode := Hook .CRD "post_convert_from_ack_tags" }}
-{{ $hookCode }}
-{{ end }}
-    return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into {{ $tagFieldGoType }} shape.
+// fromACKTags converts the tags parameter into {{ $tagFieldGoType }} shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list, 
 // it maintains the order from original 
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) {{ $tagFieldGoType }} {
+func fromACKTags(tags acktags.Tags, keyOrder []string) {{ $tagFieldGoType }} {
     result := {{ $tagFieldGoType }}{}
 {{- if $hookCode := Hook .CRD "pre_convert_from_ack_tags" }}
 {{ $hookCode }}
 {{ end }}
-
-{{- if eq "list" $tagFieldShapeType }}
-    for _, k := range keyOrder {
-		v, ok := tags[k]
-        if ok {
-            tag := svcapitypes.Tag{Key: &k, Value: &v}
-            result = append(result, &tag)
-            delete(tags, k)
-        }
-	}
-
-{{- else }}
-    _ = keyOrder
-{{- end }}
-{{- if eq "map" $tagFieldShapeType }}
-    for k, v := range tags {
-        vCopy := v
-        result[k] = &vCopy
-    }
-{{- else if eq "list" $tagFieldShapeType }}
-        result = append(result, FromACKTags(tags)...)
-{{- end }}
+{{ GoCodeFromACKTags .CRD "tags" "keyOrder" "result" 1 }}
 {{- if $hookCode := Hook .CRD "post_convert_from_ack_tags" }}
 {{ $hookCode }}
 {{ end }}


### PR DESCRIPTION
Description of changes:
This change also ensures these functions are generated using 
go code instead of templating. This keeps the code cleaner and testable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
