### PR TITLE
feat: Add watch selector support to controller manager

### DIFF
--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -107,11 +107,20 @@ func main() {
 	for _, namespace := range namespaces {
 		watchNamespaces[namespace] = ctrlrtcache.Config{}
 	}
+	watchSelectors, err := ackCfg.ParseWatchSelectors()
+	if err != nil {
+		setupLog.Error(
+			err, "Unable to parse watch selectors.",
+			"aws.service", awsServiceAlias,
+		)
+		os.Exit(1)
+	}
 	mgr, err := ctrlrt.NewManager(ctrlrt.GetConfigOrDie(), ctrlrt.Options{
 		Scheme: scheme,
 		Cache: ctrlrtcache.Options{
-			Scheme:            scheme,
-			DefaultNamespaces: watchNamespaces,
+			Scheme:               scheme,
+			DefaultNamespaces:    watchNamespaces,
+			DefaultLabelSelector: watchSelectors,
 		},
 		WebhookServer: &ctrlrtwebhook.DefaultServer{
 			Options: ctrlrtwebhook.Options{

--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -57,6 +57,8 @@ spec:
         - "$(ACK_RESOURCE_TAGS)"
         - --watch-namespace
         - "$(ACK_WATCH_NAMESPACE)"
+        - --watch-selectors
+        - "$(ACK_WATCH_SELECTORS)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
 {{ "{{- if .Values.leaderElection.enabled }}" }}
@@ -103,6 +105,8 @@ spec:
           value: {{ "{{ .Values.aws.endpoint_url | quote }}" }}
         - name: ACK_WATCH_NAMESPACE
           value: {{ IncludeTemplate "watch-namespace" }}
+        - name: ACK_WATCH_SELECTORS
+          value: {{ "{{ .Values.watchSelectors }}" }}
         - name: DELETION_POLICY
           value: {{ "{{ .Values.deletionPolicy }}" }}
         - name: LEADER_ELECTION_NAMESPACE

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -210,7 +210,10 @@
     },
     "watchNamespace": {
       "type": "string"
-    },    
+    },
+    "watchSelectors": {
+      "type": "string"
+    },
     "resourceTags": {
       "type": "array",
       "items": {

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -110,6 +110,10 @@ installScope: cluster
 # You can set multiple namespaces by providing a comma separated list of namespaces. e.g "namespace1,namespace2"
 watchNamespace: ""
 
+# Set the value of labelsSelectors to be used by the controller to filter the resources to watch.
+# You can set multiple labelsSelectors by providing a comma separated list of a=b arguments. e.g "label1=value1,label2=value2" 
+watchSelectors: ""
+
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on
   # resources that it manages.


### PR DESCRIPTION
Adds the configured watch selectors to the controller managers cache options, allowing
filtered resource watching based on labels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
