### PR TITLE
fix: ensuring secret generation is accurate

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1187,7 +1187,7 @@ func SetSDKForStruct(
 		)
 		switch memberShape.Type {
 		case "list", "structure", "map", "union":
-			adaptiveCollection := setSDKAdaptiveResourceCollection(memberShape, targetVarName, memberName, sourceAdaptedVarName, indent, r.IsSecretField(memberName))
+			adaptiveCollection := setSDKAdaptiveResourceCollection(memberShape, targetVarName, memberName, sourceAdaptedVarName, indent, r.IsSecretField(memberFieldPath))
 			out += adaptiveCollection
 			if adaptiveCollection != "" {
 				break
@@ -1714,7 +1714,7 @@ func setSDKForUnion(
 
 		switch memberShape.Type {
 		case "list", "structure", "map", "union":
-			adaption := setSDKAdaptiveResourceCollection(memberShape, targetVarName, memberName, sourceAdaptedVarName, indent, r.IsSecretField(memberName))
+			adaption := setSDKAdaptiveResourceCollection(memberShape, targetVarName, memberName, sourceAdaptedVarName, indent, r.IsSecretField(memberFieldPath))
 			out += adaption
 			if adaption != "" {
 				break

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -85,6 +85,67 @@ func TestSetSDK_APIGWv2_Route_Create(t *testing.T) {
 	)
 }
 
+func TestSetSDK_MemoryDB_User_Create(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "memorydb")
+
+	crd := testutil.GetCRDByName(t, g, "User")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Spec.AccessString != nil {
+		res.AccessString = r.ko.Spec.AccessString
+	}
+	if r.ko.Spec.AuthenticationMode != nil {
+		f1 := &svcsdktypes.AuthenticationMode{}
+		if r.ko.Spec.AuthenticationMode.Passwords != nil {
+			f1f0 := []string{}
+			for _, f1f0iter := range r.ko.Spec.AuthenticationMode.Passwords {
+				var f1f0elem string
+				if f1f0iter != nil {
+					tmpSecret, err := rm.rr.SecretValueFromReference(ctx, f1f0iter)
+					if err != nil {
+						return nil, ackrequeue.Needed(err)
+					}
+					if tmpSecret != "" {
+						f1f0elem = tmpSecret
+					}
+				}
+				f1f0 = append(f1f0, f1f0elem)
+			}
+			f1.Passwords = f1f0
+		}
+		if r.ko.Spec.AuthenticationMode.Type != nil {
+			f1.Type = svcsdktypes.InputAuthenticationType(*r.ko.Spec.AuthenticationMode.Type)
+		}
+		res.AuthenticationMode = f1
+	}
+	if r.ko.Spec.Tags != nil {
+		f2 := []svcsdktypes.Tag{}
+		for _, f2iter := range r.ko.Spec.Tags {
+			f2elem := &svcsdktypes.Tag{}
+			if f2iter.Key != nil {
+				f2elem.Key = f2iter.Key
+			}
+			if f2iter.Value != nil {
+				f2elem.Value = f2iter.Value
+			}
+			f2 = append(f2, *f2elem)
+		}
+		res.Tags = f2
+	}
+	if r.ko.Spec.Name != nil {
+		res.UserName = r.ko.Spec.Name
+	}
+`
+	assert.Equal(
+		expected,
+		code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1),
+	)
+}
+
 func TestSetSDK_OpenSearch_Domain_Create(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
Description of changes:
When generating SetSDK, we were passing the memberName
to check if a field is a secret. When the secret field is nested, 
we need to pass memberFieldPath. That is what this change 
accomplishing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
