### PR TITLE
add support for `reconcile-resources` flag

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/generate/templateset"
 	ackmetadata "github.com/aws-controllers-k8s/code-generator/pkg/metadata"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/pkg/names"
 )
 
 var (
@@ -103,16 +104,9 @@ func Release(
 		releaseFuncMap(m.MetaVars().ControllerName),
 	)
 	metaVars := m.MetaVars()
-
-	crds, err := m.GetCRDs()
-	if err != nil {
-		return nil, err
-	}
-
-	reconcileResources := make([]string, 0)
-
-	for _, crd := range crds {
-		reconcileResources = append(reconcileResources, crd.Names.Camel)
+	reconcileResources := make([]string, len(metaVars.CRDNames))
+	for i, name := range metaVars.CRDNames {
+		reconcileResources[i] = names.New(name).Camel
 	}
 
 	releaseVars := &templateReleaseVars{

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -104,6 +104,17 @@ func Release(
 	)
 	metaVars := m.MetaVars()
 
+	crds, err := m.GetCRDs()
+	if err != nil {
+		return nil, err
+	}
+
+	reconcileResources := make([]string, 0)
+
+	for _, crd := range crds {
+		reconcileResources = append(reconcileResources, crd.Names.Camel)
+	}
+
 	releaseVars := &templateReleaseVars{
 		metaVars,
 		ImageReleaseVars{
@@ -112,6 +123,7 @@ func Release(
 		},
 		metadata,
 		serviceAccountName,
+		reconcileResources,
 	}
 	for _, path := range releaseTemplatePaths {
 		outPath := strings.TrimSuffix(path, ".tpl")
@@ -140,4 +152,6 @@ type templateReleaseVars struct {
 	Metadata *ackmetadata.ServiceMetadata
 	// ServiceAccountName is the name of the ServiceAccount used in the Helm chart
 	ServiceAccountName string
+	// ReconcileResources contains all CRD names in their original format
+	ReconcileResources []string
 }

--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -59,6 +59,8 @@ spec:
         - "$(ACK_WATCH_NAMESPACE)"
         - --watch-selectors
         - "$(ACK_WATCH_SELECTORS)"
+        - --reconcile-resources
+        - "$(RECONCILE_RESOURCES)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
 {{ "{{- if .Values.leaderElection.enabled }}" }}
@@ -107,6 +109,8 @@ spec:
           value: {{ IncludeTemplate "watch-namespace" }}
         - name: ACK_WATCH_SELECTORS
           value: {{ "{{ .Values.watchSelectors }}" }}
+        - name: RECONCILE_RESOURCES
+          value: {{ "{{ join \",\" .Values.reconcile.resources | quote }}" }}
         - name: DELETION_POLICY
           value: {{ "{{ .Values.deletionPolicy }}" }}
         - name: LEADER_ELECTION_NAMESPACE

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -245,7 +245,8 @@
           "items": {
             "type": "string"
           },
-          "description": "List of resource kinds to reconcile. If empty, all resources will be reconciled."
+          "description": "List of resource kinds to reconcile. If empty, all resources will be reconciled.",
+          "default": []
         }
       },
       "type": "object"

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -239,6 +239,13 @@
         },
         "resourceMaxConcurrentSyncs": {
           "type": "object"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of resource kinds to reconcile. If empty, all resources will be reconciled."
         }
       },
       "type": "object"

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -137,6 +137,15 @@ reconcile:
   # An object representing the reconcile max concurrent syncs configuration for each specific
   # resource.
   resourceMaxConcurrentSyncs: {}
+  
+  # Set the value of resources to specify which resource kinds to reconcile.
+  # If empty, all resources will be reconciled.
+  # If specified, only the listed resource kinds will be reconciled.
+  resources: []
+  # Available resource kinds for this controller:
+  {{- range $resource := .ReconcileResources }}
+#   - {{ $resource }}
+  {{- end }}
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -141,10 +141,9 @@ reconcile:
   # Set the value of resources to specify which resource kinds to reconcile.
   # If empty, all resources will be reconciled.
   # If specified, only the listed resource kinds will be reconciled.
-  resources: []
-  # Available resource kinds for this controller:
+  resources:
   {{- range $resource := .ReconcileResources }}
-#   - {{ $resource }}
+    - {{ $resource }}
   {{- end }}
 
 serviceAccount:


### PR DESCRIPTION
Description of changes:
https://github.com/aws-controllers-k8s/runtime/pull/176

This PR adds template changes to support the reconcile-resources flag which was recently added to the ACK runtime. This flag allows users to specify which resource kinds should be reconciled by a controller, providing more granular control over controller behavior.
When the flag is set, only the specified resource kinds will be reconciled by the controller. If unspecified, all resources will be reconciled (default behavior).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
