### PR TITLE
chore: improve controller build script to pull latest tags

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -205,6 +205,7 @@ if ! $ACK_GENERATE_BIN_PATH "${apis_args[@]}"; then
 fi
 
 pushd "$SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION" 1>/dev/null
+  git pull upstream main --tags 2>/dev/null
 
 echo "Generating deepcopy code for $SERVICE"
 controller-gen object:headerFile="$BOILERPLATE_TXT_PATH" paths=./...


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This will ensure we don't accidentally push changes if the PRs 
are not up to date. Sometimes you would fetch and rebase the 
changes from upstream, but the tags for some reason
always stay behind.

This change ensures the tags are going to be up to date whenever 
you generate the controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
