### PR TITLE
chore: Enhance PopulateResourceFromAnnotation error message

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -858,7 +858,7 @@ func requiredFieldGuardContructor(
 	indent := strings.Repeat("\t", indentLevel)
 	out := fmt.Sprintf("%stmp, ok := %s[\"%s\"]\n", indent, sourceVarName, requiredField)
 	out += fmt.Sprintf("%sif !ok {\n", indent)
-	out += fmt.Sprintf("%s\treturn ackerrors.MissingNameIdentifier\n", indent)
+	out += fmt.Sprintf("%s\treturn ackerrors.NewTerminalError(fmt.Errorf(\"required field missing: %s\"))\n", indent, requiredField)
 	out += fmt.Sprintf("%s}\n", indent)
 	return out
 }

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -1802,7 +1802,7 @@ func TestSetResource_EKS_Cluster_PopulateResourceFromAnnotation(t *testing.T) {
 	expected := `
 	tmp, ok := fields["name"]
 	if !ok {
-		return ackerrors.MissingNameIdentifier
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
 	r.ko.Spec.Name = &tmp
 
@@ -1825,7 +1825,7 @@ func TestSetResource_SageMaker_ModelPackage_PopulateResourceFromAnnotation(t *te
 	expected := `
 	tmp, ok := identifier["arn"]
 	if !ok {
-		return ackerrors.MissingNameIdentifier
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
 
 	if r.ko.Status.ACKResourceMetadata == nil {
@@ -1852,7 +1852,7 @@ func TestSetResource_APIGWV2_ApiMapping_PopulateResourceFromAnnotation(t *testin
 	expected := `
 	tmp, ok := fields["apiMappingID"]
 	if !ok {
-		return ackerrors.MissingNameIdentifier
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: apiMappingID"))
 	}
 	r.ko.Status.APIMappingID = &tmp
 


### PR DESCRIPTION
Description of changes:
The error message returned from PopulateResourceFromAnnotation was 
not descriptive enough, as it did not include the name of the required field 
that was missing.

This change is including the field name in the error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
