### PR TITLE
fix: ensure maps of enums are generated properly

### DIFF
--- a/pkg/api/legacy_io_suffix.go
+++ b/pkg/api/legacy_io_suffix.go
@@ -187,6 +187,7 @@ var legacyIOSuffixed = IoSuffix{
 		"DatabaseInput":            struct{}{},
 		"PartitionInput":           struct{}{},
 		"ConnectionInput":          struct{}{},
+		"DQTransformOutput":          struct{}{},
 	},
 
 	"Glacier": {


### PR DESCRIPTION
Description of changes:
Currently, generating Maps of Enums was error prone. Instead of generating them.
With these changes, we ensure map[string]Enum are generated properly.

Sample:
```golang
f0valf28f0f0 := map[string]svcsdktypes.GlueRecordType{}
for f0valf28f0f0key, f0valf28f0f0valiter := range f0valiter.JDBCConnectorSource.AdditionalOptions.DataTypeMapping {
    var f0valf28f0f0val string
    f0valf28f0f0val = string(*f0valf28f0f0valiter)
    f0valf28f0f0[f0valf28f0f0key] = svcsdktypes.GlueRecordType(f0valf28f0f0val)
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
