### PR TITLE
Add BedRock Agent.MemoryConfiguration.StorageDays to BadDefaultsAssignment

### DIFF
--- a/pkg/apiv2/remove_defaults.go
+++ b/pkg/apiv2/remove_defaults.go
@@ -26,6 +26,9 @@ var BadDefaultsAssignment = map[string]map[string]bool{
 	"imagebuilder": {
 		"setDefaultVersion": true,
 	},
+	"AmazonBedrockAgentBuildTimeLambda": {
+		"StorageDays": true,
+	},
 }
 
 func hasBadDefualtAssignment(serviceName, shapeName string) bool {


### PR DESCRIPTION
Description of changes:
- Update BadDefaultsAssignment map to include AmazonBedrockAgentBuildTimeLambda.StorageDays to fix missing pointer operations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
