### PR TITLE
Allow zero and negative values for generated float32 bounds check

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1615,7 +1615,13 @@ func setSDKForScalar(
 				actualType[1],
 			)
 		} else {
-			out += fmt.Sprintf("%sif %s > math.Max%s32 || %s < math.%s32 {\n", indent, dereferencedVal, actualType[0], dereferencedVal, actualType[1])
+			out += fmt.Sprintf(
+				"%[1]sif %[2]s > math.Max%[3]s32 || %[2]s < math.%[4]s32 {\n",
+				indent,
+				dereferencedVal,
+				actualType[0],
+				actualType[1],
+			)
 		}
 		out += fmt.Sprintf("%s\treturn nil, fmt.Errorf(\"error: field %s is of type %s32\")\n", indent, ogShapeName.Original, actualType[2])
 		out += fmt.Sprintf("%s}\n", indent)

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -369,7 +369,6 @@ func SetSDK(
 					indentLevel+1,
 				)
 				out += setSDKForScalar(
-					cfg, r,
 					memberName,
 					targetVarName,
 					inputShape.Type,
@@ -391,7 +390,6 @@ func SetSDK(
 				)
 			} else {
 				out += setSDKForScalar(
-					cfg, r,
 					memberName,
 					targetVarName,
 					inputShape.Type,
@@ -577,7 +575,6 @@ func SetSDKGetAttributes(
 			indent, sourceVarPath,
 		)
 		out += setSDKForScalar(
-			cfg, r,
 			memberName,
 			targetVarName,
 			inputShape.Type,
@@ -788,7 +785,6 @@ func SetSDKSetAttributes(
 			indent, sourceVarPath,
 		)
 		out += setSDKForScalar(
-			cfg, r,
 			memberName,
 			targetVarName,
 			inputShape.Type,
@@ -918,7 +914,6 @@ func setSDKReadMany(
 
 			// res.SetIds(f0)
 			out += setSDKForScalar(
-				cfg, r,
 				memberName,
 				targetVarName,
 				inputShape.Type,
@@ -932,7 +927,6 @@ func setSDKReadMany(
 			// For ReadMany that have a singular identifier field.
 			// ex: DescribeReplicationGroups
 			out += setSDKForScalar(
-				cfg, r,
 				memberName,
 				targetVarName,
 				inputShape.Type,
@@ -1041,7 +1035,6 @@ func setSDKForContainer(
 		}
 
 		return setSDKForScalar(
-			cfg, r,
 			targetFieldName,
 			targetVarName,
 			targetShapeRef.Shape.Type,
@@ -1215,7 +1208,6 @@ func SetSDKForStruct(
 					indentLevel+1,
 				)
 				out += setSDKForScalar(
-					cfg, r,
 					memberName,
 					targetVarName,
 					targetShape.Type,
@@ -1238,7 +1230,6 @@ func SetSDKForStruct(
 			} else {
 
 				out += setSDKForScalar(
-					cfg, r,
 					memberName,
 					targetVarName,
 					targetShape.Type,
@@ -1558,8 +1549,6 @@ func varEmptyConstructorK8sType(
 // the aws-sdk-go's common SetXXX() method. For everything else, we output
 // normal assignment operations.
 func setSDKForScalar(
-	cfg *ackgenconfig.Config,
-	r *model.CRD,
 	// The name of the Input SDK Shape member we're outputting for
 	targetFieldName string,
 	// The variable name that we want to set a value to

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1606,7 +1606,17 @@ func setSDKForScalar(
 		dereferencedVal := ogShapeName.CamelLower + "Copy0"
 		out += fmt.Sprintf("%s%s := %s\n", indent, dereferencedVal, setTo)
 
-		out += fmt.Sprintf("%sif %s > math.Max%s32 || %s < math.%s32 {\n", indent, dereferencedVal, actualType[0], dereferencedVal, actualType[1])
+		if shape.Type == "float" {
+			out += fmt.Sprintf(
+				"%[1]sif %[2]s > math.Max%[3]s32 || %[2]s < -math.Max%[3]s32 || (%[2]s < math.%[4]s32 && !(%[2]s <= 0)) || (%[2]s > -math.%[4]s32 && !(%[2]s >= 0)) {\n",
+				indent,
+				dereferencedVal,
+				actualType[0],
+				actualType[1],
+			)
+		} else {
+			out += fmt.Sprintf("%sif %s > math.Max%s32 || %s < math.%s32 {\n", indent, dereferencedVal, actualType[0], dereferencedVal, actualType[1])
+		}
 		out += fmt.Sprintf("%s\treturn nil, fmt.Errorf(\"error: field %s is of type %s32\")\n", indent, ogShapeName.Original, actualType[2])
 		out += fmt.Sprintf("%s}\n", indent)
 		tempVar := ogShapeName.CamelLower + "Copy"

--- a/pkg/generate/code/set_sdk_whitebox_test.go
+++ b/pkg/generate/code/set_sdk_whitebox_test.go
@@ -116,8 +116,6 @@ func TestSetSDKForScalar(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := setSDKForScalar(
-				nil,
-				nil,
 				tc.targetFieldName,
 				tc.targetVarName,
 				tc.targetVarType,

--- a/pkg/generate/code/set_sdk_whitebox_test.go
+++ b/pkg/generate/code/set_sdk_whitebox_test.go
@@ -47,6 +47,7 @@ func TestSetSDKForScalar(t *testing.T) {
 				Shape: &awssdkmodel.Shape{
 					Type: "string",
 				},
+				OriginalMemberName: "BucketName",
 			},
 			indentLevel: 1,
 			expected:    "\tres.BucketName = ko.Spec.Name\n",
@@ -63,6 +64,7 @@ func TestSetSDKForScalar(t *testing.T) {
 				Shape: &awssdkmodel.Shape{
 					Type: "boolean",
 				},
+				OriginalMemberName: "Enabled",
 			},
 			indentLevel: 1,
 			expected:    "\tres.Enabled = ko.Spec.Enabled\n",
@@ -79,14 +81,15 @@ func TestSetSDKForScalar(t *testing.T) {
 				Shape: &awssdkmodel.Shape{
 					Type: "integer",
 				},
+				OriginalMemberName: "MaxKeys",
 			},
 			indentLevel: 1,
-			expected: `	Copy0 := *ko.Spec.MaxKeys
-	if Copy0 > math.MaxInt32 || Copy0 < math.MinInt32 {
-		return nil, fmt.Errorf("error: field  is of type int32")
+			expected: `	maxKeysCopy0 := *ko.Spec.MaxKeys
+	if maxKeysCopy0 > math.MaxInt32 || maxKeysCopy0 < math.MinInt32 {
+		return nil, fmt.Errorf("error: field MaxKeys is of type int32")
 	}
-	Copy := int32(Copy0)
-	res.MaxKeys = &Copy
+	maxKeysCopy := int32(maxKeysCopy0)
+	res.MaxKeys = &maxKeysCopy
 `,
 		},
 		{
@@ -101,14 +104,15 @@ func TestSetSDKForScalar(t *testing.T) {
 				Shape: &awssdkmodel.Shape{
 					Type: "float",
 				},
+				OriginalMemberName: "Temperature",
 			},
 			indentLevel: 1,
-			expected: `	Copy0 := *ko.Spec.Temperature
-	if Copy0 > math.MaxFloat32 || Copy0 < -math.MaxFloat32 || (Copy0 < math.SmallestNonzeroFloat32 && !(Copy0 <= 0)) || (Copy0 > -math.SmallestNonzeroFloat32 && !(Copy0 >= 0)) {
-		return nil, fmt.Errorf("error: field  is of type float32")
+			expected: `	temperatureCopy0 := *ko.Spec.Temperature
+	if temperatureCopy0 > math.MaxFloat32 || temperatureCopy0 < -math.MaxFloat32 || (temperatureCopy0 < math.SmallestNonzeroFloat32 && !(temperatureCopy0 <= 0)) || (temperatureCopy0 > -math.SmallestNonzeroFloat32 && !(temperatureCopy0 >= 0)) {
+		return nil, fmt.Errorf("error: field Temperature is of type float32")
 	}
-	Copy := float32(Copy0)
-	res.Temperature = &Copy
+	temperatureCopy := float32(temperatureCopy0)
+	res.Temperature = &temperatureCopy
 `,
 		},
 	}

--- a/pkg/generate/code/set_sdk_whitebox_test.go
+++ b/pkg/generate/code/set_sdk_whitebox_test.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"testing"
+
+	awssdkmodel "github.com/aws-controllers-k8s/code-generator/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetSDKForScalar(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name            string
+		targetFieldName string
+		targetVarName   string
+		targetVarType   string
+		sourceFieldPath string
+		sourceVarName   string
+		isListMember    bool
+		shapeRef        *awssdkmodel.ShapeRef
+		indentLevel     int
+		expected        string
+	}{
+		{
+			name:            "string scalar",
+			targetFieldName: "BucketName",
+			targetVarName:   "res",
+			targetVarType:   "structure",
+			sourceFieldPath: "Name",
+			sourceVarName:   "ko.Spec.Name",
+			isListMember:    false,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type: "string",
+				},
+			},
+			indentLevel: 1,
+			expected:    "\tres.BucketName = ko.Spec.Name\n",
+		},
+		{
+			name:            "boolean scalar",
+			targetFieldName: "Enabled",
+			targetVarName:   "res",
+			targetVarType:   "structure",
+			sourceFieldPath: "Enabled",
+			sourceVarName:   "ko.Spec.Enabled",
+			isListMember:    false,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type: "boolean",
+				},
+			},
+			indentLevel: 1,
+			expected:    "\tres.Enabled = ko.Spec.Enabled\n",
+		},
+		{
+			name:            "integer scalar",
+			targetFieldName: "MaxKeys",
+			targetVarName:   "res",
+			targetVarType:   "structure",
+			sourceFieldPath: "MaxKeys",
+			sourceVarName:   "ko.Spec.MaxKeys",
+			isListMember:    false,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type: "integer",
+				},
+			},
+			indentLevel: 1,
+			expected: `	Copy0 := *ko.Spec.MaxKeys
+	if Copy0 > math.MaxInt32 || Copy0 < math.MinInt32 {
+		return nil, fmt.Errorf("error: field  is of type int32")
+	}
+	Copy := int32(Copy0)
+	res.MaxKeys = &Copy
+`,
+		},
+		{
+			name:            "float scalar",
+			targetFieldName: "Temperature",
+			targetVarName:   "res",
+			targetVarType:   "structure",
+			sourceFieldPath: "Temperature",
+			sourceVarName:   "ko.Spec.Temperature",
+			isListMember:    false,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type: "float",
+				},
+			},
+			indentLevel: 1,
+			expected: `	Copy0 := *ko.Spec.Temperature
+	if Copy0 > math.MaxFloat32 || Copy0 < -math.MaxFloat32 || (Copy0 < math.SmallestNonzeroFloat32 && !(Copy0 <= 0)) || (Copy0 > -math.SmallestNonzeroFloat32 && !(Copy0 >= 0)) {
+		return nil, fmt.Errorf("error: field  is of type float32")
+	}
+	Copy := float32(Copy0)
+	res.Temperature = &Copy
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := setSDKForScalar(
+				nil,
+				nil,
+				tc.targetFieldName,
+				tc.targetVarName,
+				tc.targetVarType,
+				tc.sourceFieldPath,
+				tc.sourceVarName,
+				tc.isListMember,
+				tc.shapeRef,
+				tc.indentLevel,
+			)
+
+			assert.Equal(tc.expected, result, "setSDKForScalar() did not return expected result for %s", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Update `set_sdk.go setSDKForScalar()` to allow zero and negative values for float32 in bounds check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
