### PR TITLE
Add Regex Pattern to documentation

### DIFF
--- a/pkg/api/shape.go
+++ b/pkg/api/shape.go
@@ -90,16 +90,17 @@ type Shape struct {
 	OriginalShapeName string `json:"-"`
 
 	// Map of exported member names to the ShapeReference.
-	MemberRefs       map[string]*ShapeRef `json:"members"`
-	MemberRef        ShapeRef             `json:"member"` // List ref
-	KeyRef           ShapeRef             `json:"key"`    // map key ref
-	ValueRef         ShapeRef             `json:"value"`  // map value ref
-	Required         []string
-	Payload          string
-	Type             string
+	MemberRefs map[string]*ShapeRef `json:"members"`
+	MemberRef  ShapeRef             `json:"member"` // List ref
+	KeyRef     ShapeRef             `json:"key"`    // map key ref
+	ValueRef   ShapeRef             `json:"value"`  // map value ref
+	Pattern    string               `json:"pattern"`
+	Required   []string
+	Payload    string
+	Type       string
 	// this is being added for type union specifically. We want to generate
 	//  api as struct and handle setSDK and setResource differently
-	RealType         string		
+	RealType         string
 	Exception        bool
 	Enum             []string
 	EnumConsts       []string

--- a/pkg/apiv2/converter.go
+++ b/pkg/apiv2/converter.go
@@ -231,6 +231,12 @@ func createApiShape(shape Shape) (*awssdkmodel.Shape, error) {
 	if ok {
 		apiShape.DefaultValue = fmt.Sprintf("%v", val)
 	}
+
+	pattern, ok := shape.Traits["smithy.api#pattern"]
+	if ok {
+		apiShape.Pattern = pattern.(string)
+	}
+
 	documentation, _ := shape.Traits["smithy.api#documentation"].(string)
 	apiShape.Documentation = awssdkmodel.AppendDocstring("", documentation)
 

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -111,7 +111,6 @@ func (f *Field) GetDocumentation() string {
 		}
 		out.WriteString("// ")
 		out.WriteString(fmt.Sprintf("Regex Pattern: `%s`", f.ShapeRef.Shape.Pattern))
-
 	}
 
 	if cfg == nil {

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -104,6 +104,16 @@ func (f *Field) GetDocumentation() string {
 			out.WriteString(f.ShapeRef.Documentation)
 		}
 	}
+
+	if f.ShapeRef != nil && f.ShapeRef.Shape != nil && f.ShapeRef.Shape.Pattern != "" {
+		if hasShapeDoc {
+			out.WriteString("\n//\n")
+		}
+		out.WriteString("// ")
+		out.WriteString(fmt.Sprintf("Regex Pattern: `%s`", f.ShapeRef.Shape.Pattern))
+
+	}
+
 	if cfg == nil {
 		return out.String()
 	}

--- a/pkg/model/field_test.go
+++ b/pkg/model/field_test.go
@@ -338,3 +338,34 @@ func TestFieldPathWithUnderscore(t *testing.T) {
 	field.Path = "subPathA.subPathB.MyField"
 	assert.Equal("subPathA_subPathB_MyField", field.FieldPathWithUnderscore())
 }
+
+func TestFieldWithPattern(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "eks",
+		&testutil.TestingModelOptions{
+			GeneratorConfigFile:     "generator.yaml",
+			DocumentationConfigFile: "documentation.yaml",
+		},
+	)
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("AddOn", crds)
+	require.NotNil(crd)
+
+	specFields := crd.SpecFields
+
+	// We have not altered the docstring for Version from the
+	// docstring that comes in the doc-2.json file...
+	ltdField := specFields["ClusterName"]
+	require.NotNil(ltdField)
+	require.NotNil(ltdField.ShapeRef)
+	require.NotEmpty(ltdField.ShapeRef.Shape.Pattern)
+
+	require.Equal(
+		"// The name of your cluster.\n//\n// Regex Pattern: `^[0-9A-Za-z][A-Za-z0-9\\-_]*$`",
+		ltdField.GetDocumentation(),
+	)
+}


### PR DESCRIPTION
Issue #, if available: [930](https://github.com/aws-controllers-k8s/community/issues/930)

Description of changes:
- Read smithy.api#pattern from aws-sdk-go-v2 JSON models
- Add Regex pattern to documentation string if exists
- Add test to verify pattern string is added when present

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
