### PR TITLE
Use ClusterIP as default Service type

### DIFF
--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -11,4 +11,4 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
Issue #, if available: [2506](https://github.com/aws-controllers-k8s/community/issues/2506)

Description of changes:
- Use ClusterIP as default Service type for metrics for non-Helm installations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
