### PR TITLE
chore: increase `git fetch` default timeout to 180s

### DIFF
--- a/pkg/sdk/repo.go
+++ b/pkg/sdk/repo.go
@@ -32,7 +32,7 @@ import (
 const (
 	sdkRepoURLV2           = "https://github.com/aws/aws-sdk-go-v2"
 	defaultGitCloneTimeout = 180 * time.Second
-	defaultGitFetchTimeout = 30 * time.Second
+	defaultGitFetchTimeout = 180 * time.Second
 )
 
 func ContextWithSigterm(ctx context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
Description of changes:
The timeout being 30 seconds was causing a timeout error. 
Moving forward we may want to make certain changes to make the fetch faster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
