### PR TITLE
fix(helm): indent of extra volumes

### DIFF
--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -205,7 +205,7 @@ spec:
             secretName: {{ "{{ .Values.aws.credentials.secretName }}" }}
       {{ "{{- end }}" }}
       {{ "{{- if .Values.deployment.extraVolumes }}" }}
-        {{ "{{ toYaml .Values.deployment.extraVolumes | indent 8 }}" }}
+        {{ "{{- toYaml .Values.deployment.extraVolumes | nindent 8 }}" }}
       {{ "{{- end }}" }}
       {{ "{{- end }}" }}
 {{ "  {{- with .Values.deployment.strategy }}" }}


### PR DESCRIPTION
Issue [#2583](https://github.com/aws-controllers-k8s/community/issues/2583) 

Description of changes:

This PR addresses an issue encountered when rendering a Helm chart that includes additional volumes, such as an emptyDir. The change ensures with `-` that leading whitespace is trimmed and using `nindent` instead of `indent` prevents unwanted blank lines. The issue originates from the following pull request https://github.com/aws-controllers-k8s/code-generator/pull/608.

To manually validate the fix of this PR in a chart based on the code-generator follow the steps below:
```
# Pull and extract the ACM chart, which is based on the code-generator: 
$ helm pull oci://public.ecr.aws/aws-controllers-k8s/acm-chart --version 1.0.14 && tar -xzf acm-chart-1.0.14.tgz

# Apply the fix from this PR to the chart
$ sed -i '208s|.*|        {{- toYaml .Values.deployment.extraVolumes \| nindent 8 }}|' ./acm-chart/templates/deployment.yaml

# Render the chart and verify the output:
$ helm template ./acm-chart --set deployment.extraVolumes[0].name=test --set deployment.extraVolumes[0].emptyDir.sizeLimit=1Mi

# Expected output snippet:
...
      hostPID: false
      hostNetwork: false
      dnsPolicy: ClusterFirst
      volumes:
        - emptyDir:
            sizeLimit: 1Mi
          name: test
```

To reproduce the issue with the current version, refer to the steps outlined in the mentioned issue at top.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.