### PR TITLE
fix: pass deployment.labels to deployment

### DIFF
--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ "{{ .Chart.AppVersion | quote }}" }}
     k8s-app: {{ IncludeTemplate "app.name" }}
     helm.sh/chart: {{ IncludeTemplate "chart.name-version" }}
+{{ "{{- range $key, $value := .Values.deployment.labels }}" }}
+    {{ "{{ $key }}: {{ $value | quote }}" }}
+{{ "{{- end }}" }}
 spec:
   replicas: {{ "{{ .Values.deployment.replicas }}" }}
   selector:


### PR DESCRIPTION
Description of changes:

This pull request enhances the Helm deployment template by allowing users to add custom labels to Kubernetes deployments through values in the Helm chart, similar to what has been done at the `spec.template.labels` level. This makes the deployment more flexible and customizable.

**Helm template improvements:**

* Added support for injecting user-defined deployment labels from `.Values.deployment.labels` into the `metadata` section of the `deployment.yaml.tpl` template.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
