### PR TITLE
Upgrade default controller-gen version to v0.19.0

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CONTROLLER_TOOLS_VERSION="v0.16.2"
+export CONTROLLER_TOOLS_VERSION="v0.19.0"
 export HELM_VERSION="v3.7"
 
 # setting the -x option if debugging is true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Change CONTROLLER_TOOLS_VERSION environment variable default value to `v0.19.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
