### PR TITLE
Fix documentation loss for attribute fields

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -299,7 +299,14 @@ func (r *CRD) UnpackAttributes() {
 		fieldNames := names.New(fieldName)
 		fPath := fieldNames.Camel
 
-		f := NewField(r, fPath, fieldNames, nil, fieldConfig)
+		// Reuse existing ShapeRef if field was already processed from AWS SDK model
+		// This preserves documentation that would otherwise be lost with nil ShapeRef
+		var shapeRefToUse *awssdkmodel.ShapeRef = nil
+		if existingField, exists := r.Fields[fPath]; exists && existingField.ShapeRef != nil {
+			shapeRefToUse = existingField.ShapeRef
+		}
+
+		f := NewField(r, fPath, fieldNames, shapeRefToUse, fieldConfig)
 		if !fieldConfig.IsReadOnly {
 			r.SpecFields[fieldName] = f
 		} else {


### PR DESCRIPTION
Description of changes:

Fields marked with `is_attribute: true` were intermittently losing their documentation comments during code generation. These fields get processed twice:

1. From AWS SDK model (with documentation)
2. From attribute unpacking (with `nil` ShapeRef, losing documentation)

The issue was **non-deterministic** - sometimes documentation was preserved, sometimes it was lost, even with identical configuration.


**Cause**
The execution order depended on **Go's randomized map iteration** in `pkg/model/model.go`:

```go
for memberName, memberShapeRef := range inputShape.MemberRefs {
```

Since both field creation paths store to the same map location (`r.Fields[fPath]`), whichever runs **last wins**:

- **Lucky order**: Attribute unpacking → AWS SDK processing = Documentation preserved
- **Unlucky order**: AWS SDK processing → Attribute unpacking = Documentation lost

The `UnpackAttributes()` method called `NewField()` with `nil` ShapeRef:

```go
f := NewField(r, fPath, fieldNames, nil, fieldConfig)
```

This caused fallback to `simpleStringShapeRef` which has no documentation. 

This explains why the issue seemed random and why adding unrelated config changes could "trigger" the problem.

**Solution**
This makes documentation preservation **deterministic** regardless of execution order:

- **If attribute unpacking runs first**: No existing field found → uses `nil` ShapeRef -> SDK run adds the documentation
- **If AWS SDK processing runs first**: Existing documented field found → reuses documented ShapeRef 

In both cases, the final result preserves documentation when available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
