### PR TITLE
Add support for nested fields when using Set config

### DIFF
--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -14,7 +14,6 @@
 package code_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -5191,7 +5190,6 @@ func TestSetResource_MQ_OnlySetUnchangedFields_Update(t *testing.T) {
 	}
 `
 	actual := code.SetResource(crd.Config(), crd, op, "resp", "ko", 1)
-	fmt.Print(actual)
 
 	assert.Equal(
 		expected,

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1167,9 +1167,9 @@ func SetSDKForStruct(
 			}
 		}
 
-		fallBackName := r.GetMatchingInputShapeFieldName(op, targetFieldName)
-		if fallBackName == memberName {
-			// TODO: implement @AmineHilaly
+		fallBackName := r.GetMatchingInputShapeFieldName(op, memberName)
+		if fallBackName != "" {
+			sourceAdaptedVarName = sourceVarName + "." + fallBackName
 		}
 		if memberShape.RealType == "union" {
 			memberShapeRef.Shape.Type = "union"

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -14,7 +14,6 @@
 package code_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -4482,7 +4481,6 @@ func TestSetSDK_Lambda_Function_EnvironmentVariable_MapOfSecrets_Create(t *testi
 	}
 `
 	actual := code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1)
-	fmt.Print(actual)
 
 	assert.Equal(expected, actual)
 }
@@ -4648,6 +4646,227 @@ func TestSetSDK_Lambda_Function_EnvironmentVariable_MapOfSecrets_Update(t *testi
 	}
 `
 
+	actual := code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1)
+
+	assert.Equal(expected, actual)
+}
+
+func TestSetSDK_MQ_Broker_Configuration_Nested_Set_To(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	firehoseModel := testutil.NewModelForServiceWithOptions(t, "firehose", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-set-for-nested-field.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, firehoseModel, "DeliveryStream")
+	require.NotNil(crd)
+
+	expected := `
+	if r.ko.Spec.DeliveryStreamName != nil {
+		res.DeliveryStreamName = r.ko.Spec.DeliveryStreamName
+	}
+	if r.ko.Spec.HTTPEndpointDestinationConfiguration != nil {
+		f7 := &svcsdktypes.HttpEndpointDestinationUpdate{}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.BufferingHints != nil {
+			f7f0 := &svcsdktypes.HttpEndpointBufferingHints{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.BufferingHints.IntervalInSeconds != nil {
+				intervalInSecondsCopy0 := *r.ko.Spec.HTTPEndpointDestinationConfiguration.BufferingHints.IntervalInSeconds
+				if intervalInSecondsCopy0 > math.MaxInt32 || intervalInSecondsCopy0 < math.MinInt32 {
+					return nil, fmt.Errorf("error: field IntervalInSeconds is of type int32")
+				}
+				intervalInSecondsCopy := int32(intervalInSecondsCopy0)
+				f7f0.IntervalInSeconds = &intervalInSecondsCopy
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.BufferingHints.SizeInMBs != nil {
+				sizeInMBsCopy0 := *r.ko.Spec.HTTPEndpointDestinationConfiguration.BufferingHints.SizeInMBs
+				if sizeInMBsCopy0 > math.MaxInt32 || sizeInMBsCopy0 < math.MinInt32 {
+					return nil, fmt.Errorf("error: field SizeInMBs is of type int32")
+				}
+				sizeInMBsCopy := int32(sizeInMBsCopy0)
+				f7f0.SizeInMBs = &sizeInMBsCopy
+			}
+			f7.BufferingHints = f7f0
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions != nil {
+			f7f1 := &svcsdktypes.CloudWatchLoggingOptions{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.Enabled != nil {
+				f7f1.Enabled = r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.Enabled
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.LogGroupName != nil {
+				f7f1.LogGroupName = r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.LogGroupName
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.LogStreamName != nil {
+				f7f1.LogStreamName = r.ko.Spec.HTTPEndpointDestinationConfiguration.CloudWatchLoggingOptions.LogStreamName
+			}
+			f7.CloudWatchLoggingOptions = f7f1
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration != nil {
+			f7f2 := &svcsdktypes.HttpEndpointConfiguration{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.AccessKey != nil {
+				f7f2.AccessKey = r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.AccessKey
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.Name != nil {
+				f7f2.Name = r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.Name
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.URL != nil {
+				f7f2.Url = r.ko.Spec.HTTPEndpointDestinationConfiguration.EndpointConfiguration.URL
+			}
+			f7.EndpointConfiguration = f7f2
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.ProcessingConfiguration != nil {
+			f7f3 := &svcsdktypes.ProcessingConfiguration{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.ProcessingConfiguration.Enabled != nil {
+				f7f3.Enabled = r.ko.Spec.HTTPEndpointDestinationConfiguration.ProcessingConfiguration.Enabled
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.ProcessingConfiguration.Processors != nil {
+				f7f3f1 := []svcsdktypes.Processor{}
+				for _, f7f3f1iter := range r.ko.Spec.HTTPEndpointDestinationConfiguration.ProcessingConfiguration.Processors {
+					f7f3f1elem := &svcsdktypes.Processor{}
+					if f7f3f1iter.Parameters != nil {
+						f7f3f1elemf0 := []svcsdktypes.ProcessorParameter{}
+						for _, f7f3f1elemf0iter := range f7f3f1iter.Parameters {
+							f7f3f1elemf0elem := &svcsdktypes.ProcessorParameter{}
+							if f7f3f1elemf0iter.ParameterName != nil {
+								f7f3f1elemf0elem.ParameterName = svcsdktypes.ProcessorParameterName(*f7f3f1elemf0iter.ParameterName)
+							}
+							if f7f3f1elemf0iter.ParameterValue != nil {
+								f7f3f1elemf0elem.ParameterValue = f7f3f1elemf0iter.ParameterValue
+							}
+							f7f3f1elemf0 = append(f7f3f1elemf0, *f7f3f1elemf0elem)
+						}
+						f7f3f1elem.Parameters = f7f3f1elemf0
+					}
+					if f7f3f1iter.Type != nil {
+						f7f3f1elem.Type = svcsdktypes.ProcessorType(*f7f3f1iter.Type)
+					}
+					f7f3f1 = append(f7f3f1, *f7f3f1elem)
+				}
+				f7f3.Processors = f7f3f1
+			}
+			f7.ProcessingConfiguration = f7f3
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.RequestConfiguration != nil {
+			f7f4 := &svcsdktypes.HttpEndpointRequestConfiguration{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.RequestConfiguration.CommonAttributes != nil {
+				f7f4f0 := []svcsdktypes.HttpEndpointCommonAttribute{}
+				for _, f7f4f0iter := range r.ko.Spec.HTTPEndpointDestinationConfiguration.RequestConfiguration.CommonAttributes {
+					f7f4f0elem := &svcsdktypes.HttpEndpointCommonAttribute{}
+					if f7f4f0iter.AttributeName != nil {
+						f7f4f0elem.AttributeName = f7f4f0iter.AttributeName
+					}
+					if f7f4f0iter.AttributeValue != nil {
+						f7f4f0elem.AttributeValue = f7f4f0iter.AttributeValue
+					}
+					f7f4f0 = append(f7f4f0, *f7f4f0elem)
+				}
+				f7f4.CommonAttributes = f7f4f0
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.RequestConfiguration.ContentEncoding != nil {
+				f7f4.ContentEncoding = svcsdktypes.ContentEncoding(*r.ko.Spec.HTTPEndpointDestinationConfiguration.RequestConfiguration.ContentEncoding)
+			}
+			f7.RequestConfiguration = f7f4
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.RetryOptions != nil {
+			f7f5 := &svcsdktypes.HttpEndpointRetryOptions{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.RetryOptions.DurationInSeconds != nil {
+				durationInSecondsCopy0 := *r.ko.Spec.HTTPEndpointDestinationConfiguration.RetryOptions.DurationInSeconds
+				if durationInSecondsCopy0 > math.MaxInt32 || durationInSecondsCopy0 < math.MinInt32 {
+					return nil, fmt.Errorf("error: field DurationInSeconds is of type int32")
+				}
+				durationInSecondsCopy := int32(durationInSecondsCopy0)
+				f7f5.DurationInSeconds = &durationInSecondsCopy
+			}
+			f7.RetryOptions = f7f5
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.RoleARN != nil {
+			f7.RoleARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.RoleARN
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3BackupMode != nil {
+			f7.S3BackupMode = svcsdktypes.HttpEndpointS3BackupMode(*r.ko.Spec.HTTPEndpointDestinationConfiguration.S3BackupMode)
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration != nil {
+			f7f8 := &svcsdktypes.S3DestinationUpdate{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BucketARN != nil {
+				f7f8.BucketARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BucketARN
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BufferingHints != nil {
+				f7f8f1 := &svcsdktypes.BufferingHints{}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BufferingHints.IntervalInSeconds != nil {
+					intervalInSecondsCopy0 := *r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BufferingHints.IntervalInSeconds
+					if intervalInSecondsCopy0 > math.MaxInt32 || intervalInSecondsCopy0 < math.MinInt32 {
+						return nil, fmt.Errorf("error: field IntervalInSeconds is of type int32")
+					}
+					intervalInSecondsCopy := int32(intervalInSecondsCopy0)
+					f7f8f1.IntervalInSeconds = &intervalInSecondsCopy
+				}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BufferingHints.SizeInMBs != nil {
+					sizeInMBsCopy0 := *r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.BufferingHints.SizeInMBs
+					if sizeInMBsCopy0 > math.MaxInt32 || sizeInMBsCopy0 < math.MinInt32 {
+						return nil, fmt.Errorf("error: field SizeInMBs is of type int32")
+					}
+					sizeInMBsCopy := int32(sizeInMBsCopy0)
+					f7f8f1.SizeInMBs = &sizeInMBsCopy
+				}
+				f7f8.BufferingHints = f7f8f1
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions != nil {
+				f7f8f2 := &svcsdktypes.CloudWatchLoggingOptions{}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.Enabled != nil {
+					f7f8f2.Enabled = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.Enabled
+				}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.LogGroupName != nil {
+					f7f8f2.LogGroupName = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.LogGroupName
+				}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.LogStreamName != nil {
+					f7f8f2.LogStreamName = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CloudWatchLoggingOptions.LogStreamName
+				}
+				f7f8.CloudWatchLoggingOptions = f7f8f2
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CompressionFormat != nil {
+				f7f8.CompressionFormat = svcsdktypes.CompressionFormat(*r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.CompressionFormat)
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration != nil {
+				f7f8f4 := &svcsdktypes.EncryptionConfiguration{}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig != nil {
+					f7f8f4f0 := &svcsdktypes.KMSEncryptionConfig{}
+					if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN != nil {
+						f7f8f4f0.AWSKMSKeyARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN
+					}
+					f7f8f4.KMSEncryptionConfig = f7f8f4f0
+				}
+				if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig != nil {
+					f7f8f4.NoEncryptionConfig = svcsdktypes.NoEncryptionConfig(*r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig)
+				}
+				f7f8.EncryptionConfiguration = f7f8f4
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.ErrorOutputPrefix != nil {
+				f7f8.ErrorOutputPrefix = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.ErrorOutputPrefix
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.Prefix != nil {
+				f7f8.Prefix = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.Prefix
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.RoleARN != nil {
+				f7f8.RoleARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.S3Configuration.RoleARN
+			}
+			f7.S3Update = f7f8
+		}
+		if r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration != nil {
+			f7f9 := &svcsdktypes.SecretsManagerConfiguration{}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.Enabled != nil {
+				f7f9.Enabled = r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.Enabled
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.RoleARN != nil {
+				f7f9.RoleARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.RoleARN
+			}
+			if r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.SecretARN != nil {
+				f7f9.SecretARN = r.ko.Spec.HTTPEndpointDestinationConfiguration.SecretsManagerConfiguration.SecretARN
+			}
+			f7.SecretsManagerConfiguration = f7f9
+		}
+		res.HttpEndpointDestinationUpdate = f7
+	}
+`
 	actual := code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1)
 
 	assert.Equal(expected, actual)

--- a/pkg/testdata/codegen/sdk-codegen/aws-models/firehose.json
+++ b/pkg/testdata/codegen/sdk-codegen/aws-models/firehose.json
@@ -1,0 +1,8262 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.firehose#AWSKMSKeyARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:kms:[a-zA-Z0-9\\-]+:\\d{12}:(key|alias)/[a-zA-Z_0-9+=,.@\\-_/]+$"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingHints": {
+            "type": "structure",
+            "members": {
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering it\n         to the destination. The default value is 300 (5 minutes).</p>"
+                    }
+                },
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the\n         destination. The default value is 5. </p>\n         <p>We recommend setting this parameter to a value greater than the amount of data you\n         typically ingest into the Firehose stream in 10 seconds. For example, if you typically\n         ingest data at 1 MB/sec, the value should be 10 MB or higher.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the buffering to perform before delivering data to the Serverless offering for\n         Amazon OpenSearch Service destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessCollectionEndpoint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^https:"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Serverless offering for Amazon OpenSearch Service Configuration API and for\n         indexing documents.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CollectionEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessCollectionEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the collection in the Serverless offering\n         for Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Serverless offering for Amazon OpenSearch Service index name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for\n         AmazonopensearchserviceBufferingHints are used.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to the\n         Serverless offering for Amazon OpenSearch Service. The default value is 300 (5\n         minutes).</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines how documents should be delivered to Amazon S3. When it is set to\n         FailedDocumentsOnly, Firehose writes any documents that could not be indexed\n         to the configured Amazon S3 destination, with AmazonOpenSearchService-failed/ appended to\n         the key prefix. When set to AllDocuments, Firehose delivers all incoming\n         records to Amazon S3, and also writes failed documents with AmazonOpenSearchService-failed/\n         appended to the prefix.</p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "VpcConfiguration": {
+                    "target": "com.amazonaws.firehose#VpcConfiguration"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in the Serverless offering for Amazon\n         OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials.</p>"
+                    }
+                },
+                "CollectionEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessCollectionEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the collection in the Serverless offering\n         for Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Serverless offering for Amazon OpenSearch Service index name.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Serverless offering for Amazon OpenSearch Service retry options.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode.</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "VpcConfigurationDescription": {
+                    "target": "com.amazonaws.firehose#VpcConfigurationDescription"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The destination description in the Serverless offering for Amazon OpenSearch\n         Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Serverless offering for Amazon OpenSearch Service Configuration API and for\n         indexing documents.</p>"
+                    }
+                },
+                "CollectionEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessCollectionEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the collection in the Serverless offering\n         for Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Serverless offering for Amazon OpenSearch Service index name.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, AmazonopensearchBufferingHints object\n         default values are used.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to the\n         Serverless offering for Amazon OpenSearch Service. The default value is 300 (5\n         minutes).</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in the Serverless offering for Amazon OpenSearch\n         Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessIndexName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 80
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>After an initial failure to deliver to the Serverless offering for Amazon OpenSearch\n         Service, the total amount of time during which Firehose retries delivery\n         (including the first attempt). After this time has elapsed, the failed documents are\n         written to Amazon S3. Default value is 300 seconds (5 minutes). A value of 0 (zero) results\n         in no retries.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configures retry behavior in case Firehose is unable to deliver documents\n         to the Serverless offering for Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonOpenSearchServerlessS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDocumentsOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDocumentsOnly"
+                    }
+                },
+                "AllDocuments": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllDocuments"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceBufferingHints": {
+            "type": "structure",
+            "members": {
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering it\n         to the destination. The default value is 300 (5 minutes). </p>"
+                    }
+                },
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the\n         destination. The default value is 5.</p>\n         <p>We recommend setting this parameter to a value greater than the amount of data you\n         typically ingest into the Firehose stream in 10 seconds. For example, if you typically\n         ingest data at 1 MB/sec, the value should be 10 MB or higher. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the buffering to perform before delivering data to the Amazon OpenSearch\n         Service destination. </p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceClusterEndpoint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^https:"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Amazon OpenSearch Service Configuration API and for indexing\n         documents.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain. The IAM role must have permissions for\n         DescribeElasticsearchDomain, DescribeElasticsearchDomains, and\n         DescribeElasticsearchDomainConfig after assuming the role specified in RoleARN. </p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Specify either this\n         ClusterEndpoint or the DomainARN field. </p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ElasticsearAmazon OpenSearch Service index name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service type name. For Elasticsearch 6.x, there can be only one\n         type per index. If you try to specify a new type for an existing index that already has\n         another type, Firehose returns an error during run time. </p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service index rotation period. Index rotation appends a timestamp\n         to the IndexName to facilitate the expiration of old data.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for\n         AmazonopensearchserviceBufferingHints are used. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon OpenSearch Service. The default value is 300 (5 minutes). </p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines how documents should be delivered to Amazon S3. When it is set to\n         FailedDocumentsOnly, Firehose writes any documents that could not be indexed\n         to the configured Amazon S3 destination, with AmazonOpenSearchService-failed/ appended to\n         the key prefix. When set to AllDocuments, Firehose delivers all incoming\n         records to Amazon S3, and also writes failed documents with AmazonOpenSearchService-failed/\n         appended to the prefix. </p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "VpcConfiguration": {
+                    "target": "com.amazonaws.firehose#VpcConfiguration"
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Amazon OpenSearch Service</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. </p>"
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain.</p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Firehose uses\n         either this ClusterEndpoint or the DomainARN field to send data to Amazon OpenSearch\n         Service. </p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service index name.</p>"
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service type name. This applies to Elasticsearch 6.x and lower\n         versions. For Elasticsearch 7.x and OpenSearch Service 1.x, there's no value for TypeName. </p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service index rotation period</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service retry options.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode.</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "VpcConfigurationDescription": {
+                    "target": "com.amazonaws.firehose#VpcConfigurationDescription"
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The destination description in Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Amazon OpenSearch Service Configuration API and for indexing documents.\n      </p>"
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain. The IAM role must have permissions for\n         DescribeDomain, DescribeDomains, and DescribeDomainConfig after assuming the IAM role\n         specified in RoleARN.</p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Specify either this\n         ClusterEndpoint or the DomainARN field. </p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service index name.</p>"
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service type name. For Elasticsearch 6.x, there can be only one\n         type per index. If you try to specify a new type for an existing index that already has\n         another type, Firehose returns an error during runtime. </p>\n         <p>If you upgrade Elasticsearch from 6.x to 7.x and don’t update your Firehose stream,\n         Firehose still delivers data to Elasticsearch with the old index name and type\n         name. If you want to update your Firehose stream with a new index name, provide an empty\n         string for TypeName. </p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service index rotation period. Index rotation appends a timestamp\n         to IndexName to facilitate the expiration of old data.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, AmazonopensearchBufferingHints object\n         default values are used. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon OpenSearch Service. The default value is 300 (5 minutes). </p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceDomainARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:es:[a-zA-Z0-9\\-]+:\\d{12}:domain/[a-z][-0-9a-z]{2,27}$"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceIndexName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 80
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceIndexRotationPeriod": {
+            "type": "enum",
+            "members": {
+                "NoRotation": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NoRotation"
+                    }
+                },
+                "OneHour": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneHour"
+                    }
+                },
+                "OneDay": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneDay"
+                    }
+                },
+                "OneWeek": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneWeek"
+                    }
+                },
+                "OneMonth": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneMonth"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>After an initial failure to deliver to Amazon OpenSearch Service, the total amount of\n         time during which Firehose retries delivery (including the first attempt).\n         After this time has elapsed, the failed documents are written to Amazon S3. Default value\n         is 300 seconds (5 minutes). A value of 0 (zero) results in no retries. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configures retry behavior in case Firehose is unable to deliver documents\n         to Amazon OpenSearch Service. </p>"
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDocumentsOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDocumentsOnly"
+                    }
+                },
+                "AllDocuments": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllDocuments"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#AmazonopensearchserviceTypeName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 100
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#AuthenticationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the role used to access the Amazon MSK cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Connectivity": {
+                    "target": "com.amazonaws.firehose#Connectivity",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of connectivity used to access the Amazon MSK cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The authentication configuration of the Amazon MSK cluster.</p>"
+            }
+        },
+        "com.amazonaws.firehose#BlockSizeBytes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 67108864
+                }
+            }
+        },
+        "com.amazonaws.firehose#BooleanObject": {
+            "type": "boolean"
+        },
+        "com.amazonaws.firehose#BucketARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:.*:s3:::[\\w\\.\\-]{1,255}$"
+            }
+        },
+        "com.amazonaws.firehose#BufferingHints": {
+            "type": "structure",
+            "members": {
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#SizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MiBs, before delivering it to the\n         destination. The default value is 5. This parameter is optional but if you specify a value\n         for it, you must also specify a value for <code>IntervalInSeconds</code>, and vice\n         versa.</p>\n         <p>We recommend setting this parameter to a value greater than the amount of data you\n         typically ingest into the Firehose stream in 10 seconds. For example, if you typically\n         ingest data at 1 MiB/sec, the value should be 10 MiB or higher.</p>"
+                    }
+                },
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#IntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering\n         it to the destination. The default value is 300. This parameter is optional but if you\n         specify a value for it, you must also specify a value for <code>SizeInMBs</code>, and vice\n         versa.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes hints for the buffering to perform before delivering data to the\n         destination. These options are treated as hints, and therefore Firehose might\n         choose to use different values when it is optimal. The <code>SizeInMBs</code> and\n            <code>IntervalInSeconds</code> parameters are optional. However, if specify a value for\n         one of them, you must also provide a value for the other.</p>"
+            }
+        },
+        "com.amazonaws.firehose#CatalogConfiguration": {
+            "type": "structure",
+            "members": {
+                "CatalogARN": {
+                    "target": "com.amazonaws.firehose#GlueDataCatalogARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Specifies the Glue catalog ARN identifier of the destination Apache Iceberg Tables. You must specify the ARN in the format <code>arn:aws:glue:region:account-id:catalog</code>.\n      </p>"
+                    }
+                },
+                "WarehouseLocation": {
+                    "target": "com.amazonaws.firehose#WarehouseLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The warehouse location for Apache Iceberg tables. You must configure this when schema\n         evolution and table creation is enabled.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Describes the containers where the destination Apache Iceberg Tables are persisted.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#CloudWatchLoggingOptions": {
+            "type": "structure",
+            "members": {
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enables or disables CloudWatch logging.</p>"
+                    }
+                },
+                "LogGroupName": {
+                    "target": "com.amazonaws.firehose#LogGroupName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch group name for logging. This value is required if CloudWatch logging\n         is enabled.</p>"
+                    }
+                },
+                "LogStreamName": {
+                    "target": "com.amazonaws.firehose#LogStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch log stream name for logging. This value is required if CloudWatch\n         logging is enabled.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the Amazon CloudWatch logging options for your Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ClusterJDBCURL": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^jdbc:(redshift|postgresql)://((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+(redshift(-serverless)?)\\.([a-zA-Z0-9\\.\\-]+):\\d{1,5}/[a-zA-Z0-9_$-]+$"
+            }
+        },
+        "com.amazonaws.firehose#ColumnToJsonKeyMappings": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace"
+            },
+            "value": {
+                "target": "com.amazonaws.firehose#NonEmptyString"
+            }
+        },
+        "com.amazonaws.firehose#CompressionFormat": {
+            "type": "enum",
+            "members": {
+                "UNCOMPRESSED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNCOMPRESSED"
+                    }
+                },
+                "GZIP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GZIP"
+                    }
+                },
+                "ZIP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ZIP"
+                    }
+                },
+                "SNAPPY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Snappy"
+                    }
+                },
+                "HADOOP_SNAPPY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HADOOP_SNAPPY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ConcurrentModificationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Another modification has already happened. Fetch <code>VersionId</code> again and use\n         it to update the destination.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#Connectivity": {
+            "type": "enum",
+            "members": {
+                "PUBLIC": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PUBLIC"
+                    }
+                },
+                "PRIVATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PRIVATE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ContentEncoding": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "GZIP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GZIP"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#CopyCommand": {
+            "type": "structure",
+            "members": {
+                "DataTableName": {
+                    "target": "com.amazonaws.firehose#DataTableName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the target table. The table must already exist in the database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DataTableColumns": {
+                    "target": "com.amazonaws.firehose#DataTableColumns",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A comma-separated list of column names.</p>"
+                    }
+                },
+                "CopyOptions": {
+                    "target": "com.amazonaws.firehose#CopyOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional parameters to use with the Amazon Redshift <code>COPY</code> command. For\n         more information, see the \"Optional Parameters\" section of <a href=\"https://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html\">Amazon Redshift COPY command</a>. Some possible\n         examples that would apply to Firehose are as follows:</p>\n         <p>\n            <code>delimiter '\\t' lzop;</code> - fields are delimited with \"\\t\" (TAB character) and\n         compressed using lzop.</p>\n         <p>\n            <code>delimiter '|'</code> - fields are delimited with \"|\" (this is the default\n         delimiter).</p>\n         <p>\n            <code>delimiter '|' escape</code> - the delimiter should be escaped.</p>\n         <p>\n            <code>fixedwidth 'venueid:3,venuename:25,venuecity:12,venuestate:2,venueseats:6'</code> -\n         fields are fixed width in the source, with each width specified after every column in the\n         table.</p>\n         <p>\n            <code>JSON 's3://mybucket/jsonpaths.txt'</code> - data is in JSON format, and the path\n         specified is the format of the data.</p>\n         <p>For more examples, see <a href=\"https://docs.aws.amazon.com/redshift/latest/dg/r_COPY_command_examples.html\">Amazon Redshift COPY command\n            examples</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a <code>COPY</code> command for Amazon Redshift.</p>"
+            }
+        },
+        "com.amazonaws.firehose#CopyOptions": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 10240
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#CreateDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#CreateDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#CreateDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidKMSResourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a Firehose stream.</p>\n         <p>By default, you can create up to 5,000 Firehose streams per Amazon Web Services\n         Region.</p>\n         <p>This is an asynchronous operation that immediately returns. The initial status of the\n         Firehose stream is <code>CREATING</code>. After the Firehose stream is created, its status\n         is <code>ACTIVE</code> and it now accepts data. If the Firehose stream creation fails, the\n         status transitions to <code>CREATING_FAILED</code>. Attempts to send data to a delivery\n         stream that is not in the <code>ACTIVE</code> state cause an exception. To check the state\n         of a Firehose stream, use <a>DescribeDeliveryStream</a>.</p>\n         <p>If the status of a Firehose stream is <code>CREATING_FAILED</code>, this status\n         doesn't change, and you can't invoke <code>CreateDeliveryStream</code> again on it.\n         However, you can invoke the <a>DeleteDeliveryStream</a> operation to delete\n         it.</p>\n         <p>A Firehose stream can be configured to receive records directly\n         from providers using <a>PutRecord</a> or <a>PutRecordBatch</a>, or it\n         can be configured to use an existing Kinesis stream as its source. To specify a Kinesis\n         data stream as input, set the <code>DeliveryStreamType</code> parameter to\n            <code>KinesisStreamAsSource</code>, and provide the Kinesis stream Amazon Resource Name\n         (ARN) and role ARN in the <code>KinesisStreamSourceConfiguration</code>\n         parameter.</p>\n         <p>To create a Firehose stream with server-side encryption (SSE) enabled, include <a>DeliveryStreamEncryptionConfigurationInput</a> in your request. This is\n         optional. You can also invoke <a>StartDeliveryStreamEncryption</a> to turn on\n         SSE for an existing Firehose stream that doesn't have SSE enabled.</p>\n         <p>A Firehose stream is configured with a single destination, such as Amazon Simple\n         Storage Service (Amazon S3), Amazon Redshift, Amazon OpenSearch Service, Amazon OpenSearch\n         Serverless, Splunk, and any custom HTTP endpoint or HTTP endpoints owned by or supported by\n         third-party service providers, including Datadog, Dynatrace, LogicMonitor, MongoDB, New\n         Relic, and Sumo Logic. You must specify only one of the following destination configuration\n         parameters: <code>ExtendedS3DestinationConfiguration</code>,\n            <code>S3DestinationConfiguration</code>,\n            <code>ElasticsearchDestinationConfiguration</code>,\n            <code>RedshiftDestinationConfiguration</code>, or\n            <code>SplunkDestinationConfiguration</code>.</p>\n         <p>When you specify <code>S3DestinationConfiguration</code>, you can also provide the\n         following optional values: BufferingHints, <code>EncryptionConfiguration</code>, and\n            <code>CompressionFormat</code>. By default, if no <code>BufferingHints</code> value is\n         provided, Firehose buffers data up to 5 MB or for 5 minutes, whichever\n         condition is satisfied first. <code>BufferingHints</code> is a hint, so there are some\n         cases where the service cannot adhere to these conditions strictly. For example, record\n         boundaries might be such that the size is a little over or under the configured buffering\n         size. By default, no encryption is performed. We strongly recommend that you enable\n         encryption to ensure secure data storage in Amazon S3.</p>\n         <p>A few notes about Amazon Redshift as a destination:</p>\n         <ul>\n            <li>\n               <p>An Amazon Redshift destination requires an S3 bucket as intermediate location.\n               Firehose first delivers data to Amazon S3 and then uses\n                  <code>COPY</code> syntax to load data into an Amazon Redshift table. This is\n               specified in the <code>RedshiftDestinationConfiguration.S3Configuration</code>\n               parameter.</p>\n            </li>\n            <li>\n               <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be\n               specified in <code>RedshiftDestinationConfiguration.S3Configuration</code> because\n               the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't\n               support these compression formats.</p>\n            </li>\n            <li>\n               <p>We strongly recommend that you use the user name and password you provide\n               exclusively with Firehose, and that the permissions for the account are\n               restricted for Amazon Redshift <code>INSERT</code> permissions.</p>\n            </li>\n         </ul>\n         <p>Firehose assumes the IAM role that is configured as part of the\n         destination. The role should allow the Firehose principal to assume the role,\n         and the role should have permissions that allow the service to deliver the data. For more\n         information, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Firehose Access to an Amazon S3 Destination</a> in the <i>Amazon Firehose Developer Guide</i>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#CreateDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream. This name must be unique per Amazon Web Services\n         account in the same Amazon Web Services Region. If the Firehose streams are in different\n         accounts or different Regions, you can have multiple Firehose streams with the same\n         name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DeliveryStreamType": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Firehose stream type. This parameter can be one of the following\n         values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DirectPut</code>: Provider applications access the Firehose stream\n               directly.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KinesisStreamAsSource</code>: The Firehose stream uses a Kinesis data\n               stream as a source.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "DirectPutSourceConfiguration": {
+                    "target": "com.amazonaws.firehose#DirectPutSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The structure that configures parameters such as <code>ThroughputHintInMBs</code> for a\n         stream configured with Direct PUT as a source. </p>"
+                    }
+                },
+                "KinesisStreamSourceConfiguration": {
+                    "target": "com.amazonaws.firehose#KinesisStreamSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When a Kinesis data stream is used as the source for the Firehose stream, a <a>KinesisStreamSourceConfiguration</a> containing the Kinesis data stream Amazon\n         Resource Name (ARN) and the role ARN for the source stream.</p>"
+                    }
+                },
+                "DeliveryStreamEncryptionConfigurationInput": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamEncryptionConfigurationInput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Used to specify the type and Amazon Resource Name (ARN) of the KMS key needed for\n         Server-Side Encryption (SSE).</p>"
+                    }
+                },
+                "S3DestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#deprecated": {},
+                        "smithy.api#documentation": "<p>[Deprecated]\n         The destination in Amazon S3. You can specify only one destination.</p>"
+                    }
+                },
+                "ExtendedS3DestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#ExtendedS3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon S3. You can specify only one destination.</p>"
+                    }
+                },
+                "RedshiftDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#RedshiftDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon Redshift. You can specify only one destination.</p>"
+                    }
+                },
+                "ElasticsearchDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon OpenSearch Service. You can specify only one destination.</p>"
+                    }
+                },
+                "AmazonopensearchserviceDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon OpenSearch Service. You can specify only one\n         destination.</p>"
+                    }
+                },
+                "SplunkDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#SplunkDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Splunk. You can specify only one destination.</p>"
+                    }
+                },
+                "HttpEndpointDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enables configuring Kinesis Firehose to deliver data to any HTTP endpoint destination.\n         You can specify only one destination.</p>"
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.firehose#TagDeliveryStreamInputTagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of tags to assign to the Firehose stream. A tag is a key-value pair that you can\n         define and assign to Amazon Web Services resources. Tags are metadata. For example, you can\n         add friendly names and descriptions or other types of information that can help you\n         distinguish the Firehose stream. For more information about tags, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using\n            Cost Allocation Tags</a> in the Amazon Web Services Billing and Cost Management User\n         Guide.</p>\n         <p>You can specify up to 50 tags when creating a Firehose stream.</p>\n         <p>If you specify tags in the <code>CreateDeliveryStream</code> action, Amazon Data\n         Firehose performs an additional authorization on the\n            <code>firehose:TagDeliveryStream</code> action to verify if users have permissions to\n         create tags. If you do not provide this permission, requests to create new Firehose streams\n         with IAM resource tags will fail with an <code>AccessDeniedException</code> such as\n         following.</p>\n         <p>\n            <b>AccessDeniedException</b>\n         </p>\n         <p>User: arn:aws:sts::x:assumed-role/x/x is not authorized to perform: firehose:TagDeliveryStream on resource: arn:aws:firehose:us-east-1:x:deliverystream/x with an explicit deny in an identity-based policy.</p>\n         <p>For an example IAM policy, see <a href=\"https://docs.aws.amazon.com/firehose/latest/APIReference/API_CreateDeliveryStream.html#API_CreateDeliveryStream_Examples\">Tag example.</a>\n         </p>"
+                    }
+                },
+                "AmazonOpenSearchServerlessDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in the Serverless offering for Amazon OpenSearch Service. You can\n         specify only one destination.</p>"
+                    }
+                },
+                "MSKSourceConfiguration": {
+                    "target": "com.amazonaws.firehose#MSKSourceConfiguration"
+                },
+                "SnowflakeDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configure Snowflake destination</p>"
+                    }
+                },
+                "IcebergDestinationConfiguration": {
+                    "target": "com.amazonaws.firehose#IcebergDestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Configure Apache Iceberg Tables destination.\n      </p>"
+                    }
+                },
+                "DatabaseSourceConfiguration": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The top level object for configuring streams with database as a source. \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#CreateDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamARN": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#CustomTimeZone": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 50
+                },
+                "smithy.api#pattern": "^$|[a-zA-Z/_]+$"
+            }
+        },
+        "com.amazonaws.firehose#Data": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024000
+                }
+            }
+        },
+        "com.amazonaws.firehose#DataFormatConversionConfiguration": {
+            "type": "structure",
+            "members": {
+                "SchemaConfiguration": {
+                    "target": "com.amazonaws.firehose#SchemaConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the Amazon Web Services Glue Data Catalog table that contains the column\n         information. This parameter is required if <code>Enabled</code> is set to true.</p>"
+                    }
+                },
+                "InputFormatConfiguration": {
+                    "target": "com.amazonaws.firehose#InputFormatConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the deserializer that you want Firehose to use to convert the\n         format of your data from JSON. This parameter is required if <code>Enabled</code> is set to\n         true.</p>"
+                    }
+                },
+                "OutputFormatConfiguration": {
+                    "target": "com.amazonaws.firehose#OutputFormatConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the serializer that you want Firehose to use to convert the\n         format of your data to the Parquet or ORC format. This parameter is required if\n            <code>Enabled</code> is set to true.</p>"
+                    }
+                },
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defaults to <code>true</code>. Set it to <code>false</code> if you want to disable\n         format conversion while preserving the configuration details.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies that you want Firehose to convert data from the JSON format to\n         the Parquet or ORC format before writing it to Amazon S3. Firehose uses the\n         serializer and deserializer that you specify, in addition to the column information from\n         the Amazon Web Services Glue table, to deserialize your input data from JSON and then\n         serialize it to the Parquet or ORC format. For more information, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/record-format-conversion.html\">Firehose Record Format Conversion</a>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DataTableColumns": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 10240
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#DataTableName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseColumnIncludeOrExcludeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DatabaseColumnName"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseColumnList": {
+            "type": "structure",
+            "members": {
+                "Include": {
+                    "target": "com.amazonaws.firehose#DatabaseColumnIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of column patterns in source database to be included for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Exclude": {
+                    "target": "com.amazonaws.firehose#DatabaseColumnIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of column patterns in source database to be excluded for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure used to configure the list of column patterns in source database\n         endpoint for Firehose to read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseColumnName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 194
+                },
+                "smithy.api#pattern": "^[\\u0001-\\uFFFF]*$"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseEndpoint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^(?!\\s*$).+$"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseIncludeOrExcludeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DatabaseName"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseList": {
+            "type": "structure",
+            "members": {
+                "Include": {
+                    "target": "com.amazonaws.firehose#DatabaseIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of database patterns in source database endpoint to be included for Firehose\n         to read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Exclude": {
+                    "target": "com.amazonaws.firehose#DatabaseIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of database patterns in source database endpoint to be excluded for Firehose\n         to read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure used to configure the list of database patterns in source database\n         endpoint for Firehose to read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[\\u0001-\\uFFFF]*$"
+            }
+        },
+        "com.amazonaws.firehose#DatabasePort": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 65535
+                }
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSnapshotInfo": {
+            "type": "structure",
+            "members": {
+                "Id": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The identifier of the current snapshot of the table in source database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Table": {
+                    "target": "com.amazonaws.firehose#DatabaseTableName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The fully qualified name of the table in source database endpoint that Firehose reads.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RequestTimestamp": {
+                    "target": "com.amazonaws.firehose#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The timestamp when the current snapshot is taken on the table.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RequestedBy": {
+                    "target": "com.amazonaws.firehose#SnapshotRequestedBy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The principal that sent the request to take the current snapshot on the table.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.firehose#SnapshotStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The status of the current snapshot of the table.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "FailureDescription": {
+                    "target": "com.amazonaws.firehose#FailureDescription"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            The structure that describes the snapshot information of a table in source database endpoint that Firehose reads.  \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSnapshotInfoList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DatabaseSnapshotInfo"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSourceAuthenticationConfiguration": {
+            "type": "structure",
+            "members": {
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            The structure to configure the authentication methods for Firehose to connect to source database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSourceConfiguration": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.firehose#DatabaseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of database engine. This can be one of the following values. </p>\n         <ul>\n            <li>\n               <p>MySQL</p>\n            </li>\n            <li>\n               <p>PostgreSQL</p>\n            </li>\n         </ul>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Endpoint": {
+                    "target": "com.amazonaws.firehose#DatabaseEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The endpoint of the database server.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Port": {
+                    "target": "com.amazonaws.firehose#DatabasePort",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port of the database. This can be one of the following values.</p>\n         <ul>\n            <li>\n               <p>3306 for MySQL database type</p>\n            </li>\n            <li>\n               <p>5432 for PostgreSQL database type</p>\n            </li>\n         </ul>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SSLMode": {
+                    "target": "com.amazonaws.firehose#SSLMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The mode to enable or disable SSL when Firehose connects to the database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Databases": {
+                    "target": "com.amazonaws.firehose#DatabaseList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of database patterns in source database endpoint for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tables": {
+                    "target": "com.amazonaws.firehose#DatabaseTableList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of table patterns in source database endpoint for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Columns": {
+                    "target": "com.amazonaws.firehose#DatabaseColumnList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of column patterns in source database endpoint for Firehose to read from.  \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SurrogateKeys": {
+                    "target": "com.amazonaws.firehose#DatabaseSurrogateKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The optional list of table and column names used as unique key columns when taking snapshot if the tables don’t have primary keys configured.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SnapshotWatermarkTable": {
+                    "target": "com.amazonaws.firehose#DatabaseTableName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The fully qualified name of the table in source database endpoint that Firehose uses to track snapshot progress.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DatabaseSourceAuthenticationConfiguration": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceAuthenticationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The structure to configure the authentication methods for Firehose to connect to source database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DatabaseSourceVPCConfiguration": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceVPCConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The details of the VPC Endpoint Service which Firehose uses to create a PrivateLink to the database.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            The top level object for configuring streams with database as a source. \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSourceDescription": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.firehose#DatabaseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of database engine. This can be one of the following values. </p>\n         <ul>\n            <li>\n               <p>MySQL</p>\n            </li>\n            <li>\n               <p>PostgreSQL</p>\n            </li>\n         </ul>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Endpoint": {
+                    "target": "com.amazonaws.firehose#DatabaseEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The endpoint of the database server.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Port": {
+                    "target": "com.amazonaws.firehose#DatabasePort",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port of the database. This can be one of the following values.</p>\n         <ul>\n            <li>\n               <p>3306 for MySQL database type</p>\n            </li>\n            <li>\n               <p>5432 for PostgreSQL database type</p>\n            </li>\n         </ul>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SSLMode": {
+                    "target": "com.amazonaws.firehose#SSLMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The mode to enable or disable SSL when Firehose connects to the database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Databases": {
+                    "target": "com.amazonaws.firehose#DatabaseList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of database patterns in source database endpoint for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Tables": {
+                    "target": "com.amazonaws.firehose#DatabaseTableList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of table patterns in source database endpoint for Firehose to read from.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Columns": {
+                    "target": "com.amazonaws.firehose#DatabaseColumnList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The list of column patterns in source database endpoint for Firehose to read from.  \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SurrogateKeys": {
+                    "target": "com.amazonaws.firehose#DatabaseColumnIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The optional list of table and column names used as unique key columns when taking snapshot if the tables don’t have primary keys configured.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SnapshotWatermarkTable": {
+                    "target": "com.amazonaws.firehose#DatabaseTableName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The fully qualified name of the table in source database endpoint that Firehose uses to track snapshot progress.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "SnapshotInfo": {
+                    "target": "com.amazonaws.firehose#DatabaseSnapshotInfoList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The structure that describes the snapshot information of a table in source database endpoint that Firehose reads.  \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "DatabaseSourceAuthenticationConfiguration": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceAuthenticationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The structure to configure the authentication methods for Firehose to connect to source database endpoint.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "DatabaseSourceVPCConfiguration": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceVPCConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The details of the VPC Endpoint Service which Firehose uses to create a PrivateLink to the database.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            The top level object for database source description.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSourceVPCConfiguration": {
+            "type": "structure",
+            "members": {
+                "VpcEndpointServiceName": {
+                    "target": "com.amazonaws.firehose#VpcEndpointServiceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n            The VPC endpoint service name which Firehose uses to create a PrivateLink to the database. The endpoint service must have the Firehose service principle <code>firehose.amazonaws.com</code> as an allowed principal on the VPC endpoint service. The VPC endpoint service name is a string that looks like <code>com.amazonaws.vpce.<region>.<vpc-endpoint-service-id></code>. \n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            The structure for details of the VPC Endpoint Service which Firehose uses to create a PrivateLink to the database.\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseSurrogateKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseTableIncludeOrExcludeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DatabaseTableName"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseTableList": {
+            "type": "structure",
+            "members": {
+                "Include": {
+                    "target": "com.amazonaws.firehose#DatabaseTableIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of table patterns in source database endpoint to be included for Firehose to\n         read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "Exclude": {
+                    "target": "com.amazonaws.firehose#DatabaseTableIncludeOrExcludeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of table patterns in source database endpoint to be excluded for Firehose to\n         read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure used to configure the list of table patterns in source database endpoint\n         for Firehose to read from. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseTableName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 129
+                },
+                "smithy.api#pattern": "^[\\u0001-\\uFFFF]*$"
+            }
+        },
+        "com.amazonaws.firehose#DatabaseType": {
+            "type": "enum",
+            "members": {
+                "MySQL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MySQL"
+                    }
+                },
+                "PostgreSQL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PostgreSQL"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DefaultDocumentIdFormat": {
+            "type": "enum",
+            "members": {
+                "FIREHOSE_DEFAULT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FIREHOSE_DEFAULT"
+                    }
+                },
+                "NO_DOCUMENT_ID": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NO_DOCUMENT_ID"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DeleteDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#DeleteDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#DeleteDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a Firehose stream and its data.</p>\n         <p>You can delete a Firehose stream only if it is in one of the following states:\n            <code>ACTIVE</code>, <code>DELETING</code>, <code>CREATING_FAILED</code>, or\n            <code>DELETING_FAILED</code>. You can't delete a Firehose stream that is in the\n         <code>CREATING</code> state. To check the state of a Firehose stream, use <a>DescribeDeliveryStream</a>. </p>\n         <p>DeleteDeliveryStream is an asynchronous API. When an API request to DeleteDeliveryStream succeeds, the Firehose stream is marked for deletion, and it goes into the \n         <code>DELETING</code> state.While the Firehose stream is in the <code>DELETING</code> state, the service might\n         continue to accept records, but it doesn't make any guarantees with respect to delivering\n         the data. Therefore, as a best practice, first stop any applications that are sending\n         records before you delete a Firehose stream.</p>\n         <p>Removal of a Firehose stream that is in the <code>DELETING</code> state is a low priority operation for the service. A stream may remain in the \n         <code>DELETING</code> state for several minutes. Therefore, as a best practice, applications should not wait for streams in the <code>DELETING</code> state \n         to be removed. </p>"
+            }
+        },
+        "com.amazonaws.firehose#DeleteDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "AllowForceDelete": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Set this to true if you want to delete the Firehose stream even if Firehose\n         is unable to retire the grant for the CMK. Firehose might be unable to retire\n         the grant due to a customer error, such as when the CMK or the grant are in an invalid\n         state. If you force deletion, you can then use the <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_RevokeGrant.html\">RevokeGrant</a> operation to\n         revoke the grant you gave to Firehose. If a failure to retire the grant\n         happens due to an Amazon Web Services KMS issue, Firehose keeps retrying the\n         delete operation.</p>\n         <p>The default value is false.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#DeleteDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStartTimestamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.firehose#DeliveryStreamARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:firehose:[a-zA-Z0-9\\-]+:\\d{12}:deliverystream/[a-zA-Z0-9._-]+$"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamDescription": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DeliveryStreamARN": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Firehose stream. For more information, see\n            <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon\n            Resource Names (ARNs) and Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DeliveryStreamStatus": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Firehose stream. If the status of a Firehose stream is\n            <code>CREATING_FAILED</code>, this status doesn't change, and you can't invoke\n            <code>CreateDeliveryStream</code> again on it. However, you can invoke the <a>DeleteDeliveryStream</a> operation to delete it.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "FailureDescription": {
+                    "target": "com.amazonaws.firehose#FailureDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides details in case one of the following operations fails due to an error related\n         to KMS: <a>CreateDeliveryStream</a>, <a>DeleteDeliveryStream</a>,\n            <a>StartDeliveryStreamEncryption</a>, <a>StopDeliveryStreamEncryption</a>.</p>"
+                    }
+                },
+                "DeliveryStreamEncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamEncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the server-side encryption (SSE) status for the Firehose stream.</p>"
+                    }
+                },
+                "DeliveryStreamType": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Firehose stream type. This can be one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DirectPut</code>: Provider applications access the Firehose stream\n               directly.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KinesisStreamAsSource</code>: The Firehose stream uses a Kinesis data\n               stream as a source.</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Each time the destination is updated for a Firehose stream, the version ID is\n         changed, and the current version ID is required when updating the destination. This is so\n         that the service knows it is applying the changes to the correct version of the delivery\n         stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CreateTimestamp": {
+                    "target": "com.amazonaws.firehose#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time that the Firehose stream was created.</p>"
+                    }
+                },
+                "LastUpdateTimestamp": {
+                    "target": "com.amazonaws.firehose#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time that the Firehose stream was last updated.</p>"
+                    }
+                },
+                "Source": {
+                    "target": "com.amazonaws.firehose#SourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the <code>DeliveryStreamType</code> parameter is\n            <code>KinesisStreamAsSource</code>, a <a>SourceDescription</a> object\n         describing the source Kinesis data stream.</p>"
+                    }
+                },
+                "Destinations": {
+                    "target": "com.amazonaws.firehose#DestinationDescriptionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destinations.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HasMoreDestinations": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether there are more destinations available to list.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains information about a Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamEncryptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "KeyARN": {
+                    "target": "com.amazonaws.firehose#AWSKMSKeyARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If <code>KeyType</code> is <code>CUSTOMER_MANAGED_CMK</code>, this field contains the\n         ARN of the customer managed CMK. If <code>KeyType</code> is <code>Amazon Web Services_OWNED_CMK</code>, <code>DeliveryStreamEncryptionConfiguration</code> doesn't contain\n         a value for <code>KeyARN</code>.</p>"
+                    }
+                },
+                "KeyType": {
+                    "target": "com.amazonaws.firehose#KeyType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the type of customer master key (CMK) that is used for encryption. The default\n         setting is <code>Amazon Web Services_OWNED_CMK</code>. For more information about CMKs, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys\">Customer Master Keys (CMKs)</a>.</p>"
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamEncryptionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This is the server-side encryption (SSE) status for the Firehose stream. For a full\n         description of the different values of this status, see <a>StartDeliveryStreamEncryption</a> and <a>StopDeliveryStreamEncryption</a>. If this status is <code>ENABLING_FAILED</code>\n         or <code>DISABLING_FAILED</code>, it is the status of the most recent attempt to enable or\n         disable SSE, respectively.</p>"
+                    }
+                },
+                "FailureDescription": {
+                    "target": "com.amazonaws.firehose#FailureDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides details in case one of the following operations fails due to an error related\n         to KMS: <a>CreateDeliveryStream</a>, <a>DeleteDeliveryStream</a>,\n            <a>StartDeliveryStreamEncryption</a>, <a>StopDeliveryStreamEncryption</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains information about the server-side encryption (SSE) status for the delivery\n         stream, the type customer master key (CMK) in use, if any, and the ARN of the CMK. You can\n         get <code>DeliveryStreamEncryptionConfiguration</code> by invoking the <a>DescribeDeliveryStream</a> operation. </p>"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamEncryptionConfigurationInput": {
+            "type": "structure",
+            "members": {
+                "KeyARN": {
+                    "target": "com.amazonaws.firehose#AWSKMSKeyARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you set <code>KeyType</code> to <code>CUSTOMER_MANAGED_CMK</code>, you must specify\n         the Amazon Resource Name (ARN) of the CMK. If you set <code>KeyType</code> to <code>Amazon Web Services_OWNED_CMK</code>, Firehose uses a service-account CMK.</p>"
+                    }
+                },
+                "KeyType": {
+                    "target": "com.amazonaws.firehose#KeyType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the type of customer master key (CMK) to use for encryption. The default\n         setting is <code>Amazon Web Services_OWNED_CMK</code>. For more information about CMKs, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys\">Customer Master Keys (CMKs)</a>. When you invoke <a>CreateDeliveryStream</a> or <a>StartDeliveryStreamEncryption</a> with\n            <code>KeyType</code> set to CUSTOMER_MANAGED_CMK, Firehose invokes the\n         Amazon KMS operation <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateGrant.html\">CreateGrant</a> to create a grant\n         that allows the Firehose service to use the customer managed CMK to perform\n         encryption and decryption. Firehose manages that grant. </p>\n         <p>When you invoke <a>StartDeliveryStreamEncryption</a> to change the CMK for a\n         Firehose stream that is encrypted with a customer managed CMK, Firehose\n         schedules the grant it had on the old CMK for retirement.</p>\n         <p>You can use a CMK of type CUSTOMER_MANAGED_CMK to encrypt up to 500 Firehose streams. If\n         a <a>CreateDeliveryStream</a> or <a>StartDeliveryStreamEncryption</a>\n         operation exceeds this limit, Firehose throws a\n            <code>LimitExceededException</code>. </p>\n         <important>\n            <p>To encrypt your Firehose stream, use symmetric CMKs. Firehose doesn't\n            support asymmetric CMKs. For information about symmetric and asymmetric CMKs, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html\">About\n               Symmetric and Asymmetric CMKs</a> in the Amazon Web Services Key Management\n            Service developer guide.</p>\n         </important>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the type and Amazon Resource Name (ARN) of the CMK to use for Server-Side\n         Encryption (SSE). </p>"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamEncryptionStatus": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "ENABLING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLING"
+                    }
+                },
+                "ENABLING_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLING_FAILED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                },
+                "DISABLING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLING"
+                    }
+                },
+                "DISABLING_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLING_FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamFailureType": {
+            "type": "enum",
+            "members": {
+                "VPC_ENDPOINT_SERVICE_NAME_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VPC_ENDPOINT_SERVICE_NAME_NOT_FOUND"
+                    }
+                },
+                "VPC_INTERFACE_ENDPOINT_SERVICE_ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VPC_INTERFACE_ENDPOINT_SERVICE_ACCESS_DENIED"
+                    }
+                },
+                "RETIRE_KMS_GRANT_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RETIRE_KMS_GRANT_FAILED"
+                    }
+                },
+                "CREATE_KMS_GRANT_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_KMS_GRANT_FAILED"
+                    }
+                },
+                "KMS_ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "KMS_ACCESS_DENIED"
+                    }
+                },
+                "DISABLED_KMS_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED_KMS_KEY"
+                    }
+                },
+                "INVALID_KMS_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INVALID_KMS_KEY"
+                    }
+                },
+                "KMS_KEY_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "KMS_KEY_NOT_FOUND"
+                    }
+                },
+                "KMS_OPT_IN_REQUIRED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "KMS_OPT_IN_REQUIRED"
+                    }
+                },
+                "CREATE_ENI_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_ENI_FAILED"
+                    }
+                },
+                "DELETE_ENI_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_ENI_FAILED"
+                    }
+                },
+                "SUBNET_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUBNET_NOT_FOUND"
+                    }
+                },
+                "SECURITY_GROUP_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SECURITY_GROUP_NOT_FOUND"
+                    }
+                },
+                "ENI_ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENI_ACCESS_DENIED"
+                    }
+                },
+                "SUBNET_ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUBNET_ACCESS_DENIED"
+                    }
+                },
+                "SECURITY_GROUP_ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SECURITY_GROUP_ACCESS_DENIED"
+                    }
+                },
+                "UNKNOWN_ERROR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNKNOWN_ERROR"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_.-]+$"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamNameList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DeliveryStreamName"
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamStatus": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "CREATING_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING_FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETING_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING_FAILED"
+                    }
+                },
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamType": {
+            "type": "enum",
+            "members": {
+                "DirectPut": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DirectPut"
+                    }
+                },
+                "KinesisStreamAsSource": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "KinesisStreamAsSource"
+                    }
+                },
+                "MSKAsSource": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MSKAsSource"
+                    }
+                },
+                "DatabaseAsSource": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DatabaseAsSource"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#DeliveryStreamVersionId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 50
+                },
+                "smithy.api#pattern": "^[0-9]+$"
+            }
+        },
+        "com.amazonaws.firehose#DescribeDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#DescribeDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#DescribeDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the specified Firehose stream and its status. For example, after your\n         Firehose stream is created, call <code>DescribeDeliveryStream</code> to see whether the\n         Firehose stream is <code>ACTIVE</code> and therefore ready for data to be sent to it. </p>\n         <p>If the status of a Firehose stream is <code>CREATING_FAILED</code>, this status\n         doesn't change, and you can't invoke <a>CreateDeliveryStream</a> again on it.\n         However, you can invoke the <a>DeleteDeliveryStream</a> operation to delete it.\n         If the status is <code>DELETING_FAILED</code>, you can force deletion by invoking <a>DeleteDeliveryStream</a> again but with <a>DeleteDeliveryStreamInput$AllowForceDelete</a> set to true.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DescribeDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Limit": {
+                    "target": "com.amazonaws.firehose#DescribeDeliveryStreamInputLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The limit on the number of destinations to return. You can have one destination per\n         Firehose stream.</p>"
+                    }
+                },
+                "ExclusiveStartDestinationId": {
+                    "target": "com.amazonaws.firehose#DestinationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the destination to start returning the destination information. Firehose supports one destination per Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#DescribeDeliveryStreamInputLimit": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10000
+                }
+            }
+        },
+        "com.amazonaws.firehose#DescribeDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamDescription": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#Deserializer": {
+            "type": "structure",
+            "members": {
+                "OpenXJsonSerDe": {
+                    "target": "com.amazonaws.firehose#OpenXJsonSerDe",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The OpenX SerDe. Used by Firehose for deserializing data, which means\n         converting it from the JSON format in preparation for serializing it to the Parquet or ORC\n         format. This is one of two deserializers you can choose, depending on which one offers the\n         functionality you need. The other option is the native Hive / HCatalog JsonSerDe.</p>"
+                    }
+                },
+                "HiveJsonSerDe": {
+                    "target": "com.amazonaws.firehose#HiveJsonSerDe",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The native Hive / HCatalog JsonSerDe. Used by Firehose for deserializing\n         data, which means converting it from the JSON format in preparation for serializing it to\n         the Parquet or ORC format. This is one of two deserializers you can choose, depending on\n         which one offers the functionality you need. The other option is the OpenX SerDe.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The deserializer you want Firehose to use for converting the input data\n         from JSON. Firehose then serializes the data to its final format using the\n            <a>Serializer</a>. Firehose supports two types of deserializers:\n         the <a href=\"https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-JSON\">Apache Hive JSON SerDe</a> and the <a href=\"https://github.com/rcongiu/Hive-JSON-Serde\">OpenX JSON SerDe</a>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DestinationDescription": {
+            "type": "structure",
+            "members": {
+                "DestinationId": {
+                    "target": "com.amazonaws.firehose#DestinationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the destination.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>[Deprecated] The destination in Amazon S3.</p>"
+                    }
+                },
+                "ExtendedS3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#ExtendedS3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon S3.</p>"
+                    }
+                },
+                "RedshiftDestinationDescription": {
+                    "target": "com.amazonaws.firehose#RedshiftDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon Redshift.</p>"
+                    }
+                },
+                "ElasticsearchDestinationDescription": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "AmazonopensearchserviceDestinationDescription": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "SplunkDestinationDescription": {
+                    "target": "com.amazonaws.firehose#SplunkDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in Splunk.</p>"
+                    }
+                },
+                "HttpEndpointDestinationDescription": {
+                    "target": "com.amazonaws.firehose#HttpEndpointDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "SnowflakeDestinationDescription": {
+                    "target": "com.amazonaws.firehose#SnowflakeDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional description for the destination</p>"
+                    }
+                },
+                "AmazonOpenSearchServerlessDestinationDescription": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination in the Serverless offering for Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "IcebergDestinationDescription": {
+                    "target": "com.amazonaws.firehose#IcebergDestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes a destination in Apache Iceberg Tables.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the destination for a Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#DestinationDescriptionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DestinationDescription"
+            }
+        },
+        "com.amazonaws.firehose#DestinationId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9-]+$"
+            }
+        },
+        "com.amazonaws.firehose#DestinationTableConfiguration": {
+            "type": "structure",
+            "members": {
+                "DestinationTableName": {
+                    "target": "com.amazonaws.firehose#StringWithLettersDigitsUnderscoresDots",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n        Specifies the name of the Apache Iceberg Table.\n      </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DestinationDatabaseName": {
+                    "target": "com.amazonaws.firehose#StringWithLettersDigitsUnderscoresDots",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The name of the Apache Iceberg database.\n      </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "UniqueKeys": {
+                    "target": "com.amazonaws.firehose#ListOfNonEmptyStringsWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         A list of unique keys for a given Apache Iceberg table. Firehose will use these for running Create, Update, or Delete operations on the given Iceberg table. \n         \n      </p>"
+                    }
+                },
+                "PartitionSpec": {
+                    "target": "com.amazonaws.firehose#PartitionSpec",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The partition spec configuration for a table that is used by automatic table\n         creation.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "S3ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n        The table specific S3 error output prefix. All the errors that occurred while delivering to this table will be prefixed with this value in S3 destination. \n       </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Describes the configuration of a destination in Apache Iceberg Tables.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#DestinationTableConfigurationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#DestinationTableConfiguration"
+            }
+        },
+        "com.amazonaws.firehose#DirectPutSourceConfiguration": {
+            "type": "structure",
+            "members": {
+                "ThroughputHintInMBs": {
+                    "target": "com.amazonaws.firehose#ThroughputHintInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The value that you configure for this parameter is for information purpose only and\n         does not affect Firehose delivery throughput limit. You can use the <a href=\"https://support.console.aws.amazon.com/support/home#/case/create%3FissueType=service-limit-increase%26limitType=kinesis-firehose-limits\">Firehose Limits form</a> to request a throughput limit increase. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure that configures parameters such as <code>ThroughputHintInMBs</code> for a stream configured with\n         Direct PUT as a source. </p>"
+            }
+        },
+        "com.amazonaws.firehose#DirectPutSourceDescription": {
+            "type": "structure",
+            "members": {
+                "ThroughputHintInMBs": {
+                    "target": "com.amazonaws.firehose#ThroughputHintInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The value that you configure for this parameter is for information purpose only and\n         does not affect Firehose delivery throughput limit. You can use the <a href=\"https://support.console.aws.amazon.com/support/home#/case/create%3FissueType=service-limit-increase%26limitType=kinesis-firehose-limits\">Firehose Limits form</a> to request a throughput limit increase. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure that configures parameters such as <code>ThroughputHintInMBs</code> for a stream configured with\n         Direct PUT as a source. </p>"
+            }
+        },
+        "com.amazonaws.firehose#DocumentIdOptions": {
+            "type": "structure",
+            "members": {
+                "DefaultDocumentIdFormat": {
+                    "target": "com.amazonaws.firehose#DefaultDocumentIdFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When the <code>FIREHOSE_DEFAULT</code> option is chosen, Firehose generates\n         a unique document ID for each record based on a unique internal identifier. The generated\n         document ID is stable across multiple delivery attempts, which helps prevent the same\n         record from being indexed multiple times with different document IDs.</p>\n         <p>When the <code>NO_DOCUMENT_ID</code> option is chosen, Firehose does not\n         include any document IDs in the requests it sends to the Amazon OpenSearch Service. This\n         causes the Amazon OpenSearch Service domain to generate document IDs. In case of multiple\n         delivery attempts, this may cause the same record to be indexed more than once with\n         different document IDs. This option enables write-heavy operations, such as the ingestion\n         of logs and observability data, to consume less resources in the Amazon OpenSearch Service\n         domain, resulting in improved performance.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>\n         <p></p>"
+            }
+        },
+        "com.amazonaws.firehose#DynamicPartitioningConfiguration": {
+            "type": "structure",
+            "members": {
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver data to an Amazon\n         S3 prefix.</p>"
+                    }
+                },
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies that the dynamic partitioning is enabled for this Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration of the dynamic partitioning mechanism that creates smaller data sets\n         from the streaming data by partitioning it based on partition keys. Currently, dynamic\n         partitioning is only supported for Amazon S3 destinations.\n         </p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchBufferingHints": {
+            "type": "structure",
+            "members": {
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#ElasticsearchBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering\n         it to the destination. The default value is 300 (5 minutes).</p>"
+                    }
+                },
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#ElasticsearchBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the\n         destination. The default value is 5.</p>\n         <p>We recommend setting this parameter to a value greater than the amount of data you\n         typically ingest into the Firehose stream in 10 seconds. For example, if you typically\n         ingest data at 1 MB/sec, the value should be 10 MB or higher.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the buffering to perform before delivering data to the Amazon OpenSearch Service\n         destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchClusterEndpoint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^https:"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Amazon OpenSearch Service Configuration API and for indexing documents. For more\n         information, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Firehose Access to an Amazon S3 Destination</a> and <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain. The IAM role must have permissions\n            for <code>DescribeDomain</code>, <code>DescribeDomains</code>, and\n            <code>DescribeDomainConfig</code> after assuming the role specified in <b>RoleARN</b>. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>\n         <p>Specify either <code>ClusterEndpoint</code> or <code>DomainARN</code>.</p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#ElasticsearchClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Specify either this\n            <code>ClusterEndpoint</code> or the <code>DomainARN</code> field.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch type name. For Elasticsearch 6.x, there can be only one type per\n         index. If you try to specify a new type for an existing index that already has another\n         type, Firehose returns an error during run time.</p>\n         <p>For Elasticsearch 7.x, don't specify a <code>TypeName</code>.</p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index rotation period. Index rotation appends a timestamp to the\n            <code>IndexName</code> to facilitate the expiration of old data. For more information,\n         see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for the\n            Amazon OpenSearch Service Destination</a>. The default value is <code>OneDay</code>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#ElasticsearchBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for\n            <code>ElasticsearchBufferingHints</code> are used.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#ElasticsearchRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon OpenSearch Service. The default value is 300 (5 minutes).</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#ElasticsearchS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines how documents should be delivered to Amazon S3. When it is set to\n            <code>FailedDocumentsOnly</code>, Firehose writes any documents that could\n         not be indexed to the configured Amazon S3 destination, with\n            <code>AmazonOpenSearchService-failed/</code> appended to the key prefix. When set to\n            <code>AllDocuments</code>, Firehose delivers all incoming records to Amazon\n         S3, and also writes failed documents with <code>AmazonOpenSearchService-failed/</code>\n         appended to the prefix. For more information, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-s3-backup\">Amazon S3 Backup for the\n            Amazon OpenSearch Service Destination</a>. Default value is\n         <code>FailedDocumentsOnly</code>.</p>\n         <p>You can't change this backup mode after you create the Firehose stream. </p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for the backup Amazon S3 location.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "VpcConfiguration": {
+                    "target": "com.amazonaws.firehose#VpcConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The details of the VPC of the Amazon destination.</p>"
+                    }
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon\n            Resource Names (ARNs) and Amazon Web Services Service Namespaces</a>.</p>\n         <p>Firehose uses either <code>ClusterEndpoint</code> or <code>DomainARN</code>\n         to send data to Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#ElasticsearchClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Firehose uses\n         either this <code>ClusterEndpoint</code> or the <code>DomainARN</code> field to send data\n         to Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index name.</p>"
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch type name. This applies to Elasticsearch 6.x and lower versions.\n         For Elasticsearch 7.x and OpenSearch Service 1.x, there's no value for\n            <code>TypeName</code>.</p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index rotation period</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#ElasticsearchBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#ElasticsearchRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon OpenSearch Service retry options.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#ElasticsearchS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode.</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options.</p>"
+                    }
+                },
+                "VpcConfigurationDescription": {
+                    "target": "com.amazonaws.firehose#VpcConfigurationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The details of the VPC of the Amazon OpenSearch or the Amazon OpenSearch Serverless\n         destination.</p>"
+                    }
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The destination description in Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose\n         for calling the Amazon OpenSearch Service Configuration API and for indexing documents. For more\n         information, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Firehose Access to an Amazon S3 Destination</a> and <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "DomainARN": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDomainARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon OpenSearch Service domain. The IAM role must have permissions\n            for <code>DescribeDomain</code>, <code>DescribeDomains</code>, and\n            <code>DescribeDomainConfig</code> after assuming the IAM role specified in\n            <code>RoleARN</code>. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>\n         <p>Specify either <code>ClusterEndpoint</code> or <code>DomainARN</code>.</p>"
+                    }
+                },
+                "ClusterEndpoint": {
+                    "target": "com.amazonaws.firehose#ElasticsearchClusterEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint to use when communicating with the cluster. Specify either this\n            <code>ClusterEndpoint</code> or the <code>DomainARN</code> field.</p>"
+                    }
+                },
+                "IndexName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index name.</p>"
+                    }
+                },
+                "TypeName": {
+                    "target": "com.amazonaws.firehose#ElasticsearchTypeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch type name. For Elasticsearch 6.x, there can be only one type per\n         index. If you try to specify a new type for an existing index that already has another\n         type, Firehose returns an error during runtime.</p>\n         <p>If you upgrade Elasticsearch from 6.x to 7.x and don’t update your Firehose stream,\n         Firehose still delivers data to Elasticsearch with the old index name and type\n         name. If you want to update your Firehose stream with a new index name, provide an empty\n         string for <code>TypeName</code>. </p>"
+                    }
+                },
+                "IndexRotationPeriod": {
+                    "target": "com.amazonaws.firehose#ElasticsearchIndexRotationPeriod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Elasticsearch index rotation period. Index rotation appends a timestamp to\n            <code>IndexName</code> to facilitate the expiration of old data. For more information,\n         see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for the\n            Amazon OpenSearch Service Destination</a>. Default value is <code>OneDay</code>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#ElasticsearchBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified,\n            <code>ElasticsearchBufferingHints</code> object default values are used. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#ElasticsearchRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon OpenSearch Service. The default value is 300 (5 minutes).</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "DocumentIdOptions": {
+                    "target": "com.amazonaws.firehose#DocumentIdOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the method for setting up document ID. The supported methods are Firehose generated document ID and OpenSearch Service generated document ID.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchDomainARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:es:[a-zA-Z0-9\\-]+:\\d{12}:domain/[a-z][-0-9a-z]{2,27}$"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchIndexName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 80
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchIndexRotationPeriod": {
+            "type": "enum",
+            "members": {
+                "NoRotation": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NoRotation"
+                    }
+                },
+                "OneHour": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneHour"
+                    }
+                },
+                "OneDay": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneDay"
+                    }
+                },
+                "OneWeek": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneWeek"
+                    }
+                },
+                "OneMonth": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OneMonth"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#ElasticsearchRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>After an initial failure to deliver to Amazon OpenSearch Service, the total amount of time during\n         which Firehose retries delivery (including the first attempt). After this time\n         has elapsed, the failed documents are written to Amazon S3. Default value is 300 seconds (5\n         minutes). A value of 0 (zero) results in no retries.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configures retry behavior in case Firehose is unable to deliver\n         documents to Amazon OpenSearch Service.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDocumentsOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDocumentsOnly"
+                    }
+                },
+                "AllDocuments": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllDocuments"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ElasticsearchTypeName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 100
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#EncryptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "NoEncryptionConfig": {
+                    "target": "com.amazonaws.firehose#NoEncryptionConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifically override existing encryption information to ensure that no encryption is\n         used.</p>"
+                    }
+                },
+                "KMSEncryptionConfig": {
+                    "target": "com.amazonaws.firehose#KMSEncryptionConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption key.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the encryption for a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ErrorCode": {
+            "type": "string"
+        },
+        "com.amazonaws.firehose#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.firehose#ErrorOutputPrefix": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#ExtendedS3DestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option.</p>"
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n         UNCOMPRESSED.</p>"
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#S3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode. After you create a Firehose stream, you can update it to\n         enable Amazon S3 backup if it is disabled. If backup is enabled, you can't update the\n         Firehose stream to disable it. </p>"
+                    }
+                },
+                "S3BackupConfiguration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for backup in Amazon S3.</p>"
+                    }
+                },
+                "DataFormatConversionConfiguration": {
+                    "target": "com.amazonaws.firehose#DataFormatConversionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The serializer, deserializer, and schema for converting data from the JSON format to\n         the Parquet or ORC format before writing it to Amazon S3.</p>"
+                    }
+                },
+                "DynamicPartitioningConfiguration": {
+                    "target": "com.amazonaws.firehose#DynamicPartitioningConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the dynamic partitioning mechanism that creates smaller data sets\n         from the streaming data by partitioning it based on partition keys. Currently, dynamic\n         partitioning is only supported for Amazon S3 destinations.\n         </p>"
+                    }
+                },
+                "FileExtension": {
+                    "target": "com.amazonaws.firehose#FileExtension",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify a file extension. It will override the default file extension</p>"
+                    }
+                },
+                "CustomTimeZone": {
+                    "target": "com.amazonaws.firehose#CustomTimeZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time zone you prefer. UTC is the default.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ExtendedS3DestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n            <code>UNCOMPRESSED</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#S3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode.</p>"
+                    }
+                },
+                "S3BackupDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for backup in Amazon S3.</p>"
+                    }
+                },
+                "DataFormatConversionConfiguration": {
+                    "target": "com.amazonaws.firehose#DataFormatConversionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The serializer, deserializer, and schema for converting data from the JSON format to\n         the Parquet or ORC format before writing it to Amazon S3.</p>"
+                    }
+                },
+                "DynamicPartitioningConfiguration": {
+                    "target": "com.amazonaws.firehose#DynamicPartitioningConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the dynamic partitioning mechanism that creates smaller data sets\n         from the streaming data by partitioning it based on partition keys. Currently, dynamic\n         partitioning is only supported for Amazon S3 destinations.\n         </p>"
+                    }
+                },
+                "FileExtension": {
+                    "target": "com.amazonaws.firehose#FileExtension",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify a file extension. It will override the default file extension</p>"
+                    }
+                },
+                "CustomTimeZone": {
+                    "target": "com.amazonaws.firehose#CustomTimeZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time zone you prefer. UTC is the default.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ExtendedS3DestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option.</p>"
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n            <code>UNCOMPRESSED</code>. </p>"
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#S3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>You can update a Firehose stream to enable Amazon S3 backup if it is disabled. If\n         backup is enabled, you can't update the Firehose stream to disable it. </p>"
+                    }
+                },
+                "S3BackupUpdate": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination for backup.</p>"
+                    }
+                },
+                "DataFormatConversionConfiguration": {
+                    "target": "com.amazonaws.firehose#DataFormatConversionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The serializer, deserializer, and schema for converting data from the JSON format to\n         the Parquet or ORC format before writing it to Amazon S3.</p>"
+                    }
+                },
+                "DynamicPartitioningConfiguration": {
+                    "target": "com.amazonaws.firehose#DynamicPartitioningConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the dynamic partitioning mechanism that creates smaller data sets\n         from the streaming data by partitioning it based on partition keys. Currently, dynamic\n         partitioning is only supported for Amazon S3 destinations.\n         </p>"
+                    }
+                },
+                "FileExtension": {
+                    "target": "com.amazonaws.firehose#FileExtension",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify a file extension. It will override the default file extension</p>"
+                    }
+                },
+                "CustomTimeZone": {
+                    "target": "com.amazonaws.firehose#CustomTimeZone",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time zone you prefer. UTC is the default.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#FailureDescription": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamFailureType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of error that caused the failure.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Details": {
+                    "target": "com.amazonaws.firehose#NonEmptyString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message providing details about the error that caused the failure.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides details in case one of the following operations fails due to an error related\n         to KMS: <a>CreateDeliveryStream</a>, <a>DeleteDeliveryStream</a>,\n            <a>StartDeliveryStreamEncryption</a>, <a>StopDeliveryStreamEncryption</a>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#FileExtension": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^$|\\.[0-9a-z!\\-_.*'()]+$"
+            }
+        },
+        "com.amazonaws.firehose#Firehose_20150804": {
+            "type": "service",
+            "version": "2015-08-04",
+            "operations": [
+                {
+                    "target": "com.amazonaws.firehose#CreateDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#DeleteDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#DescribeDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ListDeliveryStreams"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ListTagsForDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#PutRecord"
+                },
+                {
+                    "target": "com.amazonaws.firehose#PutRecordBatch"
+                },
+                {
+                    "target": "com.amazonaws.firehose#StartDeliveryStreamEncryption"
+                },
+                {
+                    "target": "com.amazonaws.firehose#StopDeliveryStreamEncryption"
+                },
+                {
+                    "target": "com.amazonaws.firehose#TagDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#UntagDeliveryStream"
+                },
+                {
+                    "target": "com.amazonaws.firehose#UpdateDestination"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Firehose",
+                    "arnNamespace": "firehose",
+                    "cloudFormationName": "KinesisFirehose",
+                    "cloudTrailEventSource": "firehose.amazonaws.com",
+                    "endpointPrefix": "firehose"
+                },
+                "aws.auth#sigv4": {
+                    "name": "firehose"
+                },
+                "aws.protocols#awsJson1_1": {},
+                "smithy.api#documentation": "<fullname>Amazon Data Firehose</fullname>\n         <note>\n            <p>Amazon Data Firehose was previously known as Amazon Kinesis Data Firehose.</p>\n         </note>\n         <p>Amazon Data Firehose is a fully managed service that delivers real-time streaming\n         data to destinations such as Amazon Simple Storage Service (Amazon S3), Amazon OpenSearch\n         Service, Amazon Redshift, Splunk, and various other supported destinations.</p>",
+                "smithy.api#title": "Amazon Kinesis Firehose",
+                "smithy.api#xmlNamespace": {
+                    "uri": "http://firehose.amazonaws.com/doc/2015-08-04"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseDualStack"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": {
+                                            "ref": "Endpoint"
+                                        },
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "aws.partition",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ],
+                                            "assign": "PartitionResult"
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://firehose-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://firehose-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://firehose.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://firehose.{Region}.{PartitionResult#dnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.af-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "af-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-northeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-northeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-northeast-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-southeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ap-southeast-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://firehose.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.firehose#GlueDataCatalogARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:glue:.*:\\d{12}:catalog(?:(/[a-z0-9_-]+){1,2})?$"
+            }
+        },
+        "com.amazonaws.firehose#HECAcknowledgmentTimeoutInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 180,
+                    "max": 600
+                }
+            }
+        },
+        "com.amazonaws.firehose#HECEndpoint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 2048
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#HECEndpointType": {
+            "type": "enum",
+            "members": {
+                "Raw": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Raw"
+                    }
+                },
+                "Event": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Event"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#HECToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 2048
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#HiveJsonSerDe": {
+            "type": "structure",
+            "members": {
+                "TimestampFormats": {
+                    "target": "com.amazonaws.firehose#ListOfNonEmptyStrings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates how you want Firehose to parse the date and timestamps that\n         may be present in your input data JSON. To specify these format strings, follow the pattern\n         syntax of JodaTime's DateTimeFormat format strings. For more information, see <a href=\"https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html\">Class DateTimeFormat</a>. You can also use the special value <code>millis</code> to\n         parse timestamps in epoch milliseconds. If you don't specify a format, Firehose uses <code>java.sql.Timestamp::valueOf</code> by default.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The native Hive / HCatalog JsonSerDe. Used by Firehose for deserializing\n         data, which means converting it from the JSON format in preparation for serializing it to\n         the Parquet or ORC format. This is one of two deserializers you can choose, depending on\n         which one offers the functionality you need. The other option is the OpenX SerDe.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointAccessKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4096
+                },
+                "smithy.api#pattern": ".*",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointAttributeName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^(?!\\s*$).+$",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointAttributeValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                },
+                "smithy.api#pattern": ".*",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointBufferingHints": {
+            "type": "structure",
+            "members": {
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#HttpEndpointBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the\n         destination. The default value is 5. </p>\n         <p>We recommend setting this parameter to a value greater than the amount of data you\n         typically ingest into the Firehose stream in 10 seconds. For example, if you typically\n         ingest data at 1 MB/sec, the value should be 10 MB or higher. </p>"
+                    }
+                },
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#HttpEndpointBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering it\n         to the destination. The default value is 300 (5 minutes). </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the buffering options that can be applied before data is delivered to the HTTP\n         endpoint destination. Firehose treats these options as hints, and it might\n         choose to use more optimal values. The <code>SizeInMBs</code> and\n            <code>IntervalInSeconds</code> parameters are optional. However, if specify a value for\n         one of them, you must also provide a value for the other. </p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointCommonAttribute": {
+            "type": "structure",
+            "members": {
+                "AttributeName": {
+                    "target": "com.amazonaws.firehose#HttpEndpointAttributeName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the HTTP endpoint common attribute.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "AttributeValue": {
+                    "target": "com.amazonaws.firehose#HttpEndpointAttributeValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the HTTP endpoint common attribute.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the metadata that's delivered to the specified HTTP endpoint\n         destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointCommonAttributesList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#HttpEndpointCommonAttribute"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointConfiguration": {
+            "type": "structure",
+            "members": {
+                "Url": {
+                    "target": "com.amazonaws.firehose#HttpEndpointUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL of the HTTP endpoint selected as the destination.</p>\n         <important>\n            <p>If you choose an HTTP endpoint as your destination, review and follow the\n            instructions in the <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html\">Appendix - HTTP Endpoint\n               Delivery Request and Response Specifications</a>.</p>\n         </important>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.firehose#HttpEndpointName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the HTTP endpoint selected as the destination.</p>"
+                    }
+                },
+                "AccessKey": {
+                    "target": "com.amazonaws.firehose#HttpEndpointAccessKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The access key required for Kinesis Firehose to authenticate with the HTTP endpoint\n         selected as the destination.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of the HTTP endpoint to which Kinesis Firehose delivers\n         data.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointDescription": {
+            "type": "structure",
+            "members": {
+                "Url": {
+                    "target": "com.amazonaws.firehose#HttpEndpointUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL of the HTTP endpoint selected as the destination.</p>"
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.firehose#HttpEndpointName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the HTTP endpoint selected as the destination.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the HTTP endpoint selected as the destination. </p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "EndpointConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the HTTP endpoint selected as the destination.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#HttpEndpointBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options that can be used before data is delivered to the specified\n         destination. Firehose treats these options as hints, and it might choose to\n         use more optimal values. The <code>SizeInMBs</code> and <code>IntervalInSeconds</code>\n         parameters are optional. However, if you specify a value for one of them, you must also\n         provide a value for the other. </p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "RequestConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRequestConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the request sent to the HTTP endpoint that is specified as the\n         destination.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose uses this IAM role for all the permissions that the delivery\n         stream needs.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the retry behavior in case Firehose is unable to deliver data to\n         the specified HTTP endpoint destination, or if it doesn't receive a valid acknowledgment of\n         receipt from the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#HttpEndpointS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the S3 bucket backup options for the data that Firehose delivers\n         to the HTTP endpoint destination. You can back up all documents (<code>AllData</code>) or\n         only the documents that Firehose could not deliver to the specified HTTP\n         endpoint destination (<code>FailedDataOnly</code>).</p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n       The configuration that defines how you access secrets for HTTP Endpoint destination.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of the HTTP endpoint destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "EndpointConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#HttpEndpointBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes buffering options that can be applied to the data before it is delivered to\n         the HTTPS endpoint destination. Firehose teats these options as hints, and it\n         might choose to use more optimal values. The <code>SizeInMBs</code> and\n            <code>IntervalInSeconds</code> parameters are optional. However, if specify a value for\n         one of them, you must also provide a value for the other. </p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "RequestConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRequestConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of request sent to the HTTP endpoint specified as the\n         destination.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose uses this IAM role for all the permissions that the delivery\n         stream needs.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the retry behavior in case Firehose is unable to deliver data to\n         the specified HTTP endpoint destination, or if it doesn't receive a valid acknowledgment of\n         receipt from the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#HttpEndpointS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the S3 bucket backup options for the data that Kinesis Firehose delivers to\n         the HTTP endpoint destination. You can back up all documents (<code>AllData</code>) or only\n         the documents that Firehose could not deliver to the specified HTTP endpoint\n         destination (<code>FailedDataOnly</code>).</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription"
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for HTTP Endpoint destination.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the HTTP endpoint destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "EndpointConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the configuration of the HTTP endpoint destination.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#HttpEndpointBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes buffering options that can be applied to the data before it is delivered to\n         the HTTPS endpoint destination. Firehose teats these options as hints, and it\n         might choose to use more optimal values. The <code>SizeInMBs</code> and\n            <code>IntervalInSeconds</code> parameters are optional. However, if specify a value for\n         one of them, you must also provide a value for the other. </p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "RequestConfiguration": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRequestConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration of the request sent to the HTTP endpoint specified as the\n         destination.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose uses this IAM role for all the permissions that the delivery\n         stream needs.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the retry behavior in case Firehose is unable to deliver data to\n         the specified HTTP endpoint destination, or if it doesn't receive a valid acknowledgment of\n         receipt from the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#HttpEndpointS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the S3 bucket backup options for the data that Kinesis Firehose delivers to\n         the HTTP endpoint destination. You can back up all documents (<code>AllData</code>) or only\n         the documents that Firehose could not deliver to the specified HTTP endpoint\n         destination (<code>FailedDataOnly</code>).</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate"
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for HTTP Endpoint destination.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the specified HTTP endpoint destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^(?!\\s*$).+$"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointRequestConfiguration": {
+            "type": "structure",
+            "members": {
+                "ContentEncoding": {
+                    "target": "com.amazonaws.firehose#ContentEncoding",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose uses the content encoding to compress the body of a request before\n         sending the request to the destination. For more information, see <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding\">Content-Encoding</a> in MDN Web Docs, the official Mozilla documentation.</p>"
+                    }
+                },
+                "CommonAttributes": {
+                    "target": "com.amazonaws.firehose#HttpEndpointCommonAttributesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes the metadata sent to the HTTP endpoint destination.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration of the HTTP endpoint request.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#HttpEndpointRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total amount of time that Firehose spends on retries. This duration\n         starts after the initial attempt to send data to the custom destination via HTTPS endpoint\n         fails. It doesn't include the periods during which Firehose waits for\n         acknowledgment from the specified destination after each attempt. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the retry behavior in case Firehose is unable to deliver data to\n         the specified HTTP endpoint destination, or if it doesn't receive a valid acknowledgment of\n         receipt from the specified HTTP endpoint destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDataOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDataOnly"
+                    }
+                },
+                "AllData": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllData"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#HttpEndpointUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                },
+                "smithy.api#pattern": "^https://",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#IcebergDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "DestinationTableConfigurationList": {
+                    "target": "com.amazonaws.firehose#DestinationTableConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Provides a list of <code>DestinationTableConfigurations</code> which Firehose uses\n         to deliver data to Apache Iceberg Tables. Firehose will write data with insert if table specific configuration is not provided here.</p>"
+                    }
+                },
+                "SchemaEvolutionConfiguration": {
+                    "target": "com.amazonaws.firehose#SchemaEvolutionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration to enable automatic schema evolution.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "TableCreationConfiguration": {
+                    "target": "com.amazonaws.firehose#TableCreationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration to enable automatic table creation.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#IcebergS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes how Firehose will backup records. Currently,S3 backup only supports\n            <code>FailedDataOnly</code>. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RetryOptions"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.\n      </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "AppendOnly": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes whether all incoming data for this delivery stream will be append only\n         (inserts only and not for updates and deletes) for Iceberg delivery. This feature is only\n         applicable for Apache Iceberg Tables.</p>\n         <p>The default value is false. If you set this value to true, Firehose automatically\n         increases the throughput limit of a stream based on the throttling levels of the stream. If\n         you set this parameter to true for a stream with updates and deletes, you will see out of\n         order delivery. </p>"
+                    }
+                },
+                "CatalogConfiguration": {
+                    "target": "com.amazonaws.firehose#CatalogConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Configuration describing where the destination Apache Iceberg Tables are persisted.\n      </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Specifies the destination configure settings for  Apache Iceberg Table.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#IcebergDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "DestinationTableConfigurationList": {
+                    "target": "com.amazonaws.firehose#DestinationTableConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Provides a list of <code>DestinationTableConfigurations</code> which Firehose uses\n         to deliver data to Apache Iceberg Tables. Firehose will write data with insert if table specific configuration is not provided here.</p>"
+                    }
+                },
+                "SchemaEvolutionConfiguration": {
+                    "target": "com.amazonaws.firehose#SchemaEvolutionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of automatic schema evolution configuration.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "TableCreationConfiguration": {
+                    "target": "com.amazonaws.firehose#TableCreationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The description of table creation configuration.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#IcebergS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes how Firehose will backup records. Currently,Firehose only supports\n         <code>FailedDataOnly</code>. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RetryOptions"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.\n      </p>"
+                    }
+                },
+                "AppendOnly": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes whether all incoming data for this delivery stream will be append only\n         (inserts only and not for updates and deletes) for Iceberg delivery. This feature is only\n         applicable for Apache Iceberg Tables.</p>\n         <p>The default value is false. If you set this value to true, Firehose automatically\n         increases the throughput limit of a stream based on the throttling levels of the stream. If\n         you set this parameter to true for a stream with updates and deletes, you will see out of\n         order delivery.</p>\n         <p> </p>"
+                    }
+                },
+                "CatalogConfiguration": {
+                    "target": "com.amazonaws.firehose#CatalogConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Configuration describing where the destination Iceberg tables are persisted.\n      </p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Describes a destination in Apache Iceberg Tables.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#IcebergDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "DestinationTableConfigurationList": {
+                    "target": "com.amazonaws.firehose#DestinationTableConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Provides a list of <code>DestinationTableConfigurations</code> which Firehose uses\n         to deliver data to Apache Iceberg Tables. Firehose will write data with insert if table specific configuration is not provided here.</p>"
+                    }
+                },
+                "SchemaEvolutionConfiguration": {
+                    "target": "com.amazonaws.firehose#SchemaEvolutionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration to enable automatic schema evolution.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "TableCreationConfiguration": {
+                    "target": "com.amazonaws.firehose#TableCreationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration to enable automatic table creation.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#IcebergS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes how Firehose will backup records. Currently,Firehose only supports\n         <code>FailedDataOnly</code>. </p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RetryOptions"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The Amazon Resource Name (ARN) of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.\n      </p>"
+                    }
+                },
+                "AppendOnly": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Describes whether all incoming data for this delivery stream will be append only\n         (inserts only and not for updates and deletes) for Iceberg delivery. This feature is only\n         applicable for Apache Iceberg Tables. </p>\n         <p>The default value is false. If you set this value to true, Firehose automatically\n         increases the throughput limit of a stream based on the throttling levels of the stream. If\n         you set this parameter to true for a stream with updates and deletes, you will see out of\n         order delivery. </p>"
+                    }
+                },
+                "CatalogConfiguration": {
+                    "target": "com.amazonaws.firehose#CatalogConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Configuration describing where the destination Iceberg tables are persisted.\n      </p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Describes an update for a destination in Apache Iceberg Tables.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#IcebergS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDataOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDataOnly"
+                    }
+                },
+                "AllData": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllData"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#InputFormatConfiguration": {
+            "type": "structure",
+            "members": {
+                "Deserializer": {
+                    "target": "com.amazonaws.firehose#Deserializer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies which deserializer to use. You can choose either the Apache Hive JSON SerDe\n         or the OpenX JSON SerDe. If both are non-null, the server rejects the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the deserializer you want to use to convert the format of the input data.\n         This parameter is required if <code>Enabled</code> is set to true.</p>"
+            }
+        },
+        "com.amazonaws.firehose#IntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#InvalidArgumentException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified input parameter has a value that is not valid.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#InvalidKMSResourceException": {
+            "type": "structure",
+            "members": {
+                "code": {
+                    "target": "com.amazonaws.firehose#ErrorCode"
+                },
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Firehose throws this exception when an attempt to put records or to start\n         or stop Firehose stream encryption fails. This happens when the KMS service throws one of\n         the following exception types: <code>AccessDeniedException</code>,\n            <code>InvalidStateException</code>, <code>DisabledException</code>, or\n            <code>NotFoundException</code>.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#InvalidSourceException": {
+            "type": "structure",
+            "members": {
+                "code": {
+                    "target": "com.amazonaws.firehose#ErrorCode"
+                },
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Only requests from CloudWatch Logs are supported when CloudWatch Logs decompression is enabled.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#KMSEncryptionConfig": {
+            "type": "structure",
+            "members": {
+                "AWSKMSKeyARN": {
+                    "target": "com.amazonaws.firehose#AWSKMSKeyARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the encryption key. Must belong to the same Amazon Web Services Region as the destination Amazon S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon\n            Resource Names (ARNs) and Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an encryption key for a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#KeyType": {
+            "type": "enum",
+            "members": {
+                "AWS_OWNED_CMK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_OWNED_CMK"
+                    }
+                },
+                "CUSTOMER_MANAGED_CMK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CUSTOMER_MANAGED_CMK"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#KinesisStreamARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:kinesis:[a-zA-Z0-9\\-]+:\\d{12}:stream/[a-zA-Z0-9_.-]+$"
+            }
+        },
+        "com.amazonaws.firehose#KinesisStreamSourceConfiguration": {
+            "type": "structure",
+            "members": {
+                "KinesisStreamARN": {
+                    "target": "com.amazonaws.firehose#KinesisStreamARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the source Kinesis data stream. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kinesis-streams\">Amazon\n            Kinesis Data Streams ARN Format</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the role that provides access to the source Kinesis data stream. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam\">Amazon Web Services\n            Identity and Access Management (IAM) ARN Format</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The stream and role Amazon Resource Names (ARNs) for a Kinesis data stream used as\n         the source for a Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#KinesisStreamSourceDescription": {
+            "type": "structure",
+            "members": {
+                "KinesisStreamARN": {
+                    "target": "com.amazonaws.firehose#KinesisStreamARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the source Kinesis data stream. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kinesis-streams\">Amazon\n            Kinesis Data Streams ARN Format</a>.</p>"
+                    }
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the role used by the source Kinesis data stream. For more information, see\n            <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam\">Amazon Web Services\n            Identity and Access Management (IAM) ARN Format</a>.</p>"
+                    }
+                },
+                "DeliveryStartTimestamp": {
+                    "target": "com.amazonaws.firehose#DeliveryStartTimestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose starts retrieving records from the Kinesis data stream starting\n         with this timestamp.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about a Kinesis data stream used as the source for a Firehose\n         stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#LimitExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You have already reached the limit for a requested resource.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#ListDeliveryStreams": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#ListDeliveryStreamsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#ListDeliveryStreamsOutput"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Lists your Firehose streams in alphabetical order of their names.</p>\n         <p>The number of Firehose streams might be too large to return using a single call to\n            <code>ListDeliveryStreams</code>. You can limit the number of Firehose streams returned,\n         using the <code>Limit</code> parameter. To determine whether there are more delivery\n         streams to list, check the value of <code>HasMoreDeliveryStreams</code> in the output. If\n         there are more Firehose streams to list, you can request them by calling this operation\n         again and setting the <code>ExclusiveStartDeliveryStreamName</code> parameter to the name\n         of the last Firehose stream returned in the last call.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ListDeliveryStreamsInput": {
+            "type": "structure",
+            "members": {
+                "Limit": {
+                    "target": "com.amazonaws.firehose#ListDeliveryStreamsInputLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of Firehose streams to list. The default value is 10.</p>"
+                    }
+                },
+                "DeliveryStreamType": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Firehose stream type. This can be one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DirectPut</code>: Provider applications access the Firehose stream\n               directly.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KinesisStreamAsSource</code>: The Firehose stream uses a Kinesis data\n               stream as a source.</p>\n            </li>\n         </ul>\n         <p>This parameter is optional. If this parameter is omitted, Firehose streams of all\n         types are returned.</p>"
+                    }
+                },
+                "ExclusiveStartDeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of Firehose streams returned by this call to\n            <code>ListDeliveryStreams</code> will start with the Firehose stream whose name comes\n         alphabetically immediately after the name you specify in\n            <code>ExclusiveStartDeliveryStreamName</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#ListDeliveryStreamsInputLimit": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 10000
+                }
+            }
+        },
+        "com.amazonaws.firehose#ListDeliveryStreamsOutput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamNames": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The names of the Firehose streams.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HasMoreDeliveryStreams": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether there are more Firehose streams available to list.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#ListOfNonEmptyStrings": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#NonEmptyString"
+            }
+        },
+        "com.amazonaws.firehose#ListOfNonEmptyStringsWithoutWhitespace": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace"
+            }
+        },
+        "com.amazonaws.firehose#ListTagsForDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#ListTagsForDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#ListTagsForDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the tags for the specified Firehose stream. This operation has a limit of five\n         transactions per second per account. </p>"
+            }
+        },
+        "com.amazonaws.firehose#ListTagsForDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream whose tags you want to list.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ExclusiveStartTagKey": {
+                    "target": "com.amazonaws.firehose#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key to use as the starting point for the list of tags. If you set this parameter,\n            <code>ListTagsForDeliveryStream</code> gets all tags that occur after\n            <code>ExclusiveStartTagKey</code>.</p>"
+                    }
+                },
+                "Limit": {
+                    "target": "com.amazonaws.firehose#ListTagsForDeliveryStreamInputLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of tags to return. If this number is less than the total number of tags\n         associated with the Firehose stream, <code>HasMoreTags</code> is set to <code>true</code>\n         in the response. To list additional tags, set <code>ExclusiveStartTagKey</code> to the last\n         key in the response. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#ListTagsForDeliveryStreamInputLimit": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.firehose#ListTagsForDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {
+                "Tags": {
+                    "target": "com.amazonaws.firehose#ListTagsForDeliveryStreamOutputTagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tags associated with <code>DeliveryStreamName</code>, starting with the\n         first tag after <code>ExclusiveStartTagKey</code> and up to the specified\n            <code>Limit</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HasMoreTags": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If this is <code>true</code> in the response, more tags are available. To list the\n         remaining tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned\n         and call <code>ListTagsForDeliveryStream</code> again.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#ListTagsForDeliveryStreamOutputTagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.firehose#LogGroupName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^[\\.\\-_/#A-Za-z0-9]*$"
+            }
+        },
+        "com.amazonaws.firehose#LogStreamName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^[^:*]*$"
+            }
+        },
+        "com.amazonaws.firehose#MSKClusterARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:"
+            }
+        },
+        "com.amazonaws.firehose#MSKSourceConfiguration": {
+            "type": "structure",
+            "members": {
+                "MSKClusterARN": {
+                    "target": "com.amazonaws.firehose#MSKClusterARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon MSK cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TopicName": {
+                    "target": "com.amazonaws.firehose#TopicName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topic name within the Amazon MSK cluster. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "AuthenticationConfiguration": {
+                    "target": "com.amazonaws.firehose#AuthenticationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration of the Amazon MSK cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ReadFromTimestamp": {
+                    "target": "com.amazonaws.firehose#ReadFromTimestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The start date and time in UTC for the offset position within your MSK topic from where\n         Firehose begins to read. By default, this is set to timestamp when Firehose becomes Active. </p>\n         <p>If you want to create a Firehose stream with Earliest start position from SDK or CLI,\n         you need to set the <code>ReadFromTimestamp</code> parameter to Epoch\n         (1970-01-01T00:00:00Z). </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration for the Amazon MSK cluster to be used as the source for a delivery\n         stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#MSKSourceDescription": {
+            "type": "structure",
+            "members": {
+                "MSKClusterARN": {
+                    "target": "com.amazonaws.firehose#MSKClusterARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Amazon MSK cluster.</p>"
+                    }
+                },
+                "TopicName": {
+                    "target": "com.amazonaws.firehose#TopicName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The topic name within the Amazon MSK cluster.</p>"
+                    }
+                },
+                "AuthenticationConfiguration": {
+                    "target": "com.amazonaws.firehose#AuthenticationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authentication configuration of the Amazon MSK cluster.</p>"
+                    }
+                },
+                "DeliveryStartTimestamp": {
+                    "target": "com.amazonaws.firehose#DeliveryStartTimestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Firehose starts retrieving records from the topic within the Amazon MSK\n         cluster starting with this timestamp.</p>"
+                    }
+                },
+                "ReadFromTimestamp": {
+                    "target": "com.amazonaws.firehose#ReadFromTimestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The start date and time in UTC for the offset position within your MSK topic from where\n         Firehose begins to read. By default, this is set to timestamp when Firehose becomes Active. </p>\n         <p>If you want to create a Firehose stream with Earliest start position from SDK or CLI,\n         you need to set the <code>ReadFromTimestampUTC</code> parameter to Epoch\n         (1970-01-01T00:00:00Z). </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about the Amazon MSK cluster used as the source for a Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#NoEncryptionConfig": {
+            "type": "enum",
+            "members": {
+                "NoEncryption": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NoEncryption"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#NonEmptyString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^(?!\\s*$).+$"
+            }
+        },
+        "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^\\S+$"
+            }
+        },
+        "com.amazonaws.firehose#NonNegativeIntegerObject": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0
+                }
+            }
+        },
+        "com.amazonaws.firehose#OpenXJsonSerDe": {
+            "type": "structure",
+            "members": {
+                "ConvertDotsInJsonKeysToUnderscores": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When set to <code>true</code>, specifies that the names of the keys include dots and\n         that you want Firehose to replace them with underscores. This is useful\n         because Apache Hive does not allow dots in column names. For example, if the JSON contains\n         a key whose name is \"a.b\", you can define the column name to be \"a_b\" when using this\n         option.</p>\n         <p>The default is <code>false</code>.</p>"
+                    }
+                },
+                "CaseInsensitive": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>When set to <code>true</code>, which is the default, Firehose converts\n         JSON keys to lowercase before deserializing them.</p>"
+                    }
+                },
+                "ColumnToJsonKeyMappings": {
+                    "target": "com.amazonaws.firehose#ColumnToJsonKeyMappings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Maps column names to JSON keys that aren't identical to the column names. This is\n         useful when the JSON contains keys that are Hive keywords. For example,\n            <code>timestamp</code> is a Hive keyword. If you have a JSON key named\n            <code>timestamp</code>, set this parameter to <code>{\"ts\": \"timestamp\"}</code> to map\n         this key to a column named <code>ts</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The OpenX SerDe. Used by Firehose for deserializing data, which means\n         converting it from the JSON format in preparation for serializing it to the Parquet or ORC\n         format. This is one of two deserializers you can choose, depending on which one offers the\n         functionality you need. The other option is the native Hive / HCatalog JsonSerDe.</p>"
+            }
+        },
+        "com.amazonaws.firehose#OrcCompression": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "ZLIB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ZLIB"
+                    }
+                },
+                "SNAPPY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SNAPPY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#OrcFormatVersion": {
+            "type": "enum",
+            "members": {
+                "V0_11": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "V0_11"
+                    }
+                },
+                "V0_12": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "V0_12"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#OrcRowIndexStride": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1000
+                }
+            }
+        },
+        "com.amazonaws.firehose#OrcSerDe": {
+            "type": "structure",
+            "members": {
+                "StripeSizeBytes": {
+                    "target": "com.amazonaws.firehose#OrcStripeSizeBytes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of bytes in each stripe. The default is 64 MiB and the minimum is 8\n         MiB.</p>"
+                    }
+                },
+                "BlockSizeBytes": {
+                    "target": "com.amazonaws.firehose#BlockSizeBytes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to\n         copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the\n         minimum is 64 MiB. Firehose uses this value for padding calculations.</p>"
+                    }
+                },
+                "RowIndexStride": {
+                    "target": "com.amazonaws.firehose#OrcRowIndexStride",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of rows between index entries. The default is 10,000 and the minimum is\n         1,000.</p>"
+                    }
+                },
+                "EnablePadding": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Set this to <code>true</code> to indicate that you want stripes to be padded to the HDFS\n         block boundaries. This is useful if you intend to copy the data from Amazon S3 to HDFS\n         before querying. The default is <code>false</code>.</p>"
+                    }
+                },
+                "PaddingTolerance": {
+                    "target": "com.amazonaws.firehose#Proportion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A number between 0 and 1 that defines the tolerance for block padding as a decimal\n         fraction of stripe size. The default value is 0.05, which means 5 percent of stripe\n         size.</p>\n         <p>For the default values of 64 MiB ORC stripes and 256 MiB HDFS blocks, the default block\n         padding tolerance of 5 percent reserves a maximum of 3.2 MiB for padding within the 256 MiB\n         block. In such a case, if the available size within the block is more than 3.2 MiB, a new,\n         smaller stripe is inserted to fit within that space. This ensures that no stripe crosses\n         block boundaries and causes remote reads within a node-local task.</p>\n         <p>Firehose ignores this parameter when <a>OrcSerDe$EnablePadding</a> is <code>false</code>.</p>"
+                    }
+                },
+                "Compression": {
+                    "target": "com.amazonaws.firehose#OrcCompression",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression code to use over data blocks. The default is <code>SNAPPY</code>.</p>"
+                    }
+                },
+                "BloomFilterColumns": {
+                    "target": "com.amazonaws.firehose#ListOfNonEmptyStringsWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The column names for which you want Firehose to create bloom filters. The\n         default is <code>null</code>.</p>"
+                    }
+                },
+                "BloomFilterFalsePositiveProbability": {
+                    "target": "com.amazonaws.firehose#Proportion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Bloom filter false positive probability (FPP). The lower the FPP, the bigger the\n         Bloom filter. The default value is 0.05, the minimum is 0, and the maximum is 1.</p>"
+                    }
+                },
+                "DictionaryKeyThreshold": {
+                    "target": "com.amazonaws.firehose#Proportion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents the fraction of the total number of non-null rows. To turn off dictionary\n         encoding, set this fraction to a number that is less than the number of distinct keys in a\n         dictionary. To always use dictionary encoding, set this threshold to 1.</p>"
+                    }
+                },
+                "FormatVersion": {
+                    "target": "com.amazonaws.firehose#OrcFormatVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the file to write. The possible values are <code>V0_11</code> and\n            <code>V0_12</code>. The default is <code>V0_12</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A serializer to use for converting data to the ORC format before storing it in Amazon\n         S3. For more information, see <a href=\"https://orc.apache.org/docs/\">Apache\n         ORC</a>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#OrcStripeSizeBytes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 8388608
+                }
+            }
+        },
+        "com.amazonaws.firehose#OutputFormatConfiguration": {
+            "type": "structure",
+            "members": {
+                "Serializer": {
+                    "target": "com.amazonaws.firehose#Serializer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies which serializer to use. You can choose either the ORC SerDe or the Parquet\n         SerDe. If both are non-null, the server rejects the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the serializer that you want Firehose to use to convert the\n         format of your data before it writes it to Amazon S3. This parameter is required if\n            <code>Enabled</code> is set to true.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ParquetCompression": {
+            "type": "enum",
+            "members": {
+                "UNCOMPRESSED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNCOMPRESSED"
+                    }
+                },
+                "GZIP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GZIP"
+                    }
+                },
+                "SNAPPY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SNAPPY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ParquetPageSizeBytes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 65536
+                }
+            }
+        },
+        "com.amazonaws.firehose#ParquetSerDe": {
+            "type": "structure",
+            "members": {
+                "BlockSizeBytes": {
+                    "target": "com.amazonaws.firehose#BlockSizeBytes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to\n         copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the\n         minimum is 64 MiB. Firehose uses this value for padding calculations.</p>"
+                    }
+                },
+                "PageSizeBytes": {
+                    "target": "com.amazonaws.firehose#ParquetPageSizeBytes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Parquet page size. Column chunks are divided into pages. A page is conceptually an\n         indivisible unit (in terms of compression and encoding). The minimum value is 64 KiB and\n         the default is 1 MiB.</p>"
+                    }
+                },
+                "Compression": {
+                    "target": "com.amazonaws.firehose#ParquetCompression",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression code to use over data blocks. The possible values are\n            <code>UNCOMPRESSED</code>, <code>SNAPPY</code>, and <code>GZIP</code>, with the default\n         being <code>SNAPPY</code>. Use <code>SNAPPY</code> for higher decompression speed. Use\n            <code>GZIP</code> if the compression ratio is more important than speed.</p>"
+                    }
+                },
+                "EnableDictionaryCompression": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether to enable dictionary compression.</p>"
+                    }
+                },
+                "MaxPaddingBytes": {
+                    "target": "com.amazonaws.firehose#NonNegativeIntegerObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum amount of padding to apply. This is useful if you intend to copy the data\n         from Amazon S3 to HDFS before querying. The default is 0.</p>"
+                    }
+                },
+                "WriterVersion": {
+                    "target": "com.amazonaws.firehose#ParquetWriterVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the version of row format to output. The possible values are <code>V1</code>\n         and <code>V2</code>. The default is <code>V1</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A serializer to use for converting data to the Parquet format before storing it in\n         Amazon S3. For more information, see <a href=\"https://parquet.apache.org/docs/\">Apache Parquet</a>.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ParquetWriterVersion": {
+            "type": "enum",
+            "members": {
+                "V1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "V1"
+                    }
+                },
+                "V2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "V2"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#PartitionField": {
+            "type": "structure",
+            "members": {
+                "SourceName": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The column name to be configured in partition spec.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a single field in a <code>PartitionSpec</code>. </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#PartitionFields": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#PartitionField"
+            }
+        },
+        "com.amazonaws.firehose#PartitionSpec": {
+            "type": "structure",
+            "members": {
+                "Identity": {
+                    "target": "com.amazonaws.firehose#PartitionFields",
+                    "traits": {
+                        "smithy.api#documentation": "<p> List of identity <a href=\"https://iceberg.apache.org/spec/#partition-transforms\">transforms</a> that performs an identity transformation. The transform takes the\n         source value, and does not modify it. Result type is the source type.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents how to produce partition data for a table. Partition data is produced by\n         transforming columns in a table. Each column transform is represented by a named\n            <code>PartitionField</code>. </p>\n         <p>Here is an example of the schema in JSON. </p>\n         <p>\n            <code>\"partitionSpec\": { \"identity\": [ {\"sourceName\": \"column1\"}, {\"sourceName\":\n            \"column2\"}, {\"sourceName\": \"column3\"} ] }</code>\n         </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#Password": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 6,
+                    "max": 512
+                },
+                "smithy.api#pattern": ".*",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#Prefix": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1024
+                },
+                "smithy.api#pattern": ".*"
+            }
+        },
+        "com.amazonaws.firehose#ProcessingConfiguration": {
+            "type": "structure",
+            "members": {
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enables or disables data processing.</p>"
+                    }
+                },
+                "Processors": {
+                    "target": "com.amazonaws.firehose#ProcessorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processors.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a data processing configuration.</p>"
+            }
+        },
+        "com.amazonaws.firehose#Processor": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "com.amazonaws.firehose#ProcessorType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of processor.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Parameters": {
+                    "target": "com.amazonaws.firehose#ProcessorParameterList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The processor parameters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a data processor.</p>\n         <note>\n            <p>If you want to add a new line delimiter between records in objects that are delivered to Amazon S3, choose <code>AppendDelimiterToRecord</code> as a processor type. You don’t have to put a processor parameter when you select <code>AppendDelimiterToRecord</code>. </p>\n         </note>"
+            }
+        },
+        "com.amazonaws.firehose#ProcessorList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#Processor"
+            }
+        },
+        "com.amazonaws.firehose#ProcessorParameter": {
+            "type": "structure",
+            "members": {
+                "ParameterName": {
+                    "target": "com.amazonaws.firehose#ProcessorParameterName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the parameter. Currently the following default values are supported: 3\n         for <code>NumberOfRetries</code> and 60 for the <code>BufferIntervalInSeconds</code>. The\n            <code>BufferSizeInMBs</code> ranges between 0.2 MB and up to 3MB. The default buffering\n         hint is 1MB for all destinations, except Splunk. For Splunk, the default buffering hint is\n         256 KB. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ParameterValue": {
+                    "target": "com.amazonaws.firehose#ProcessorParameterValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The parameter value.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the processor parameter. </p>"
+            }
+        },
+        "com.amazonaws.firehose#ProcessorParameterList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#ProcessorParameter"
+            }
+        },
+        "com.amazonaws.firehose#ProcessorParameterName": {
+            "type": "enum",
+            "members": {
+                "LAMBDA_ARN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LambdaArn"
+                    }
+                },
+                "LAMBDA_NUMBER_OF_RETRIES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NumberOfRetries"
+                    }
+                },
+                "METADATA_EXTRACTION_QUERY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MetadataExtractionQuery"
+                    }
+                },
+                "JSON_PARSING_ENGINE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JsonParsingEngine"
+                    }
+                },
+                "ROLE_ARN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RoleArn"
+                    }
+                },
+                "BUFFER_SIZE_IN_MB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BufferSizeInMBs"
+                    }
+                },
+                "BUFFER_INTERVAL_IN_SECONDS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BufferIntervalInSeconds"
+                    }
+                },
+                "SUB_RECORD_TYPE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SubRecordType"
+                    }
+                },
+                "Delimiter": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Delimiter"
+                    }
+                },
+                "COMPRESSION_FORMAT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CompressionFormat"
+                    }
+                },
+                "DATA_MESSAGE_EXTRACTION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DataMessageExtraction"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ProcessorParameterValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 5120
+                },
+                "smithy.api#pattern": "^(?!\\s*$).+$"
+            }
+        },
+        "com.amazonaws.firehose#ProcessorType": {
+            "type": "enum",
+            "members": {
+                "RecordDeAggregation": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RecordDeAggregation"
+                    }
+                },
+                "Decompression": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Decompression"
+                    }
+                },
+                "CloudWatchLogProcessing": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CloudWatchLogProcessing"
+                    }
+                },
+                "Lambda": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lambda"
+                    }
+                },
+                "MetadataExtraction": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MetadataExtraction"
+                    }
+                },
+                "AppendDelimiterToRecord": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AppendDelimiterToRecord"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#Proportion": {
+            "type": "double",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.firehose#PutRecord": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#PutRecordInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#PutRecordOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidKMSResourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidSourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ServiceUnavailableException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Writes a single data record into an Firehose stream. To\n         write multiple data records into a Firehose stream, use <a>PutRecordBatch</a>.\n         Applications using these operations are referred to as producers.</p>\n         <p>By default, each Firehose stream can take in up to 2,000 transactions per second,\n         5,000 records per second, or 5 MB per second. If you use <a>PutRecord</a> and\n            <a>PutRecordBatch</a>, the limits are an aggregate across these two\n         operations for each Firehose stream. For more information about limits and how to request\n         an increase, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon\n            Firehose Limits</a>. </p>\n         <p>Firehose accumulates and publishes a particular metric for a customer account in one minute intervals. It is possible that the bursts of incoming bytes/records ingested to a Firehose stream last only for a few seconds. Due to this, the actual spikes in the traffic might not be fully visible in the customer's 1 minute CloudWatch metrics.</p>\n         <p>You must specify the name of the Firehose stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000\n         KiB in size, and any kind of data. For example, it can be a segment from a log file,\n         geographic location data, website clickstream data, and so on.</p>\n         <p>For multi record de-aggregation, you can not put more than 500 records even if the\n         data blob length is less than 1000 KiB. If you include more than 500 records, the request\n         succeeds but the record de-aggregation doesn't work as expected and transformation lambda\n         is invoked with the complete base64 encoded data blob instead of de-aggregated base64\n         decoded records.</p>\n         <p>Firehose buffers records before delivering them to the destination. To\n         disambiguate the data blobs at the destination, a common solution is to use delimiters in\n         the data, such as a newline (<code>\\n</code>) or some other character unique within the\n         data. This allows the consumer application to parse individual data items when reading the\n         data from the destination.</p>\n         <p>The <code>PutRecord</code> operation returns a <code>RecordId</code>, which is a\n         unique string assigned to each record. Producer applications can use this ID for purposes\n         such as auditability and investigation.</p>\n         <p>If the <code>PutRecord</code> operation throws a\n            <code>ServiceUnavailableException</code>, the API is automatically reinvoked (retried) 3\n         times. If the exception persists, it is possible that the throughput limits have been\n         exceeded for the Firehose stream. </p>\n         <p>Re-invoking the Put API operations (for example, PutRecord and PutRecordBatch) can\n         result in data duplicates. For larger data assets, allow for a longer time out before\n         retrying Put API operations.</p>\n         <p>Data records sent to Firehose are stored for 24 hours from the time they\n         are added to a Firehose stream as it tries to send the records to the destination. If the\n         destination is unreachable for more than 24 hours, the data is no longer\n         available.</p>\n         <important>\n            <p>Don't concatenate two or more base64 strings to form the data fields of your records.\n            Instead, concatenate the raw data, then perform base64 encoding.</p>\n         </important>"
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatch": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#PutRecordBatchInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#PutRecordBatchOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidKMSResourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidSourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ServiceUnavailableException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Writes multiple data records into a Firehose stream in a single call, which can\n         achieve higher throughput per producer than when writing single records. To write single\n         data records into a Firehose stream, use <a>PutRecord</a>. Applications using\n         these operations are referred to as producers.</p>\n         <p>Firehose accumulates and publishes a particular metric for a customer account in one minute intervals. It is possible that the bursts of incoming bytes/records ingested to a Firehose stream last only for a few seconds. Due to this, the actual spikes in the traffic might not be fully visible in the customer's 1 minute CloudWatch metrics.</p>\n         <p>For information about service quota, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Firehose\n         Quota</a>.</p>\n         <p>Each <a>PutRecordBatch</a> request supports up to 500 records. Each record\n         in the request can be as large as 1,000 KB (before base64 encoding), up to a limit of 4 MB\n         for the entire request. These limits cannot be changed.</p>\n         <p>You must specify the name of the Firehose stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000\n         KB in size, and any kind of data. For example, it could be a segment from a log file,\n         geographic location data, website clickstream data, and so on.</p>\n         <p>For multi record de-aggregation, you can not put more than 500 records even if the\n         data blob length is less than 1000 KiB. If you include more than 500 records, the request\n         succeeds but the record de-aggregation doesn't work as expected and transformation lambda\n         is invoked with the complete base64 encoded data blob instead of de-aggregated base64\n         decoded records.</p>\n         <p>Firehose buffers records before delivering them to the destination. To\n         disambiguate the data blobs at the destination, a common solution is to use delimiters in\n         the data, such as a newline (<code>\\n</code>) or some other character unique within the\n         data. This allows the consumer application to parse individual data items when reading the\n         data from the destination.</p>\n         <p>The <a>PutRecordBatch</a> response includes a count of failed records,\n            <code>FailedPutCount</code>, and an array of responses, <code>RequestResponses</code>.\n         Even if the <a>PutRecordBatch</a> call succeeds, the value of\n            <code>FailedPutCount</code> may be greater than 0, indicating that there are records for\n         which the operation didn't succeed. Each entry in the <code>RequestResponses</code> array\n         provides additional information about the processed record. It directly correlates with a\n         record in the request array using the same ordering, from the top to the bottom. The\n         response array always includes the same number of records as the request array.\n            <code>RequestResponses</code> includes both successfully and unsuccessfully processed\n         records. Firehose tries to process all records in each <a>PutRecordBatch</a> request. A single record failure does not stop the processing\n         of subsequent records. </p>\n         <p>A successfully processed record includes a <code>RecordId</code> value, which is\n         unique for the record. An unsuccessfully processed record includes <code>ErrorCode</code>\n         and <code>ErrorMessage</code> values. <code>ErrorCode</code> reflects the type of error,\n         and is one of the following values: <code>ServiceUnavailableException</code> or\n            <code>InternalFailure</code>. <code>ErrorMessage</code> provides more detailed\n         information about the error.</p>\n         <p>If there is an internal server error or a timeout, the write might have completed or\n         it might have failed. If <code>FailedPutCount</code> is greater than 0, retry the request,\n         resending only those records that might have failed processing. This minimizes the possible\n         duplicate records and also reduces the total bytes sent (and corresponding charges). We\n         recommend that you handle any duplicates at the destination.</p>\n         <p>If <a>PutRecordBatch</a> throws <code>ServiceUnavailableException</code>,\n         the API is automatically reinvoked (retried) 3 times. If the exception persists, it is\n         possible that the throughput limits have been exceeded for the Firehose stream.</p>\n         <p>Re-invoking the Put API operations (for example, PutRecord and PutRecordBatch) can\n         result in data duplicates. For larger data assets, allow for a longer time out before\n         retrying Put API operations.</p>\n         <p>Data records sent to Firehose are stored for 24 hours from the time they\n         are added to a Firehose stream as it attempts to send the records to the destination. If\n         the destination is unreachable for more than 24 hours, the data is no longer\n         available.</p>\n         <important>\n            <p>Don't concatenate two or more base64 strings to form the data fields of your records.\n            Instead, concatenate the raw data, then perform base64 encoding.</p>\n         </important>"
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatchInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Records": {
+                    "target": "com.amazonaws.firehose#PutRecordBatchRequestEntryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>One or more records.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatchOutput": {
+            "type": "structure",
+            "members": {
+                "FailedPutCount": {
+                    "target": "com.amazonaws.firehose#NonNegativeIntegerObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of records that might have failed processing. This number might be greater\n         than 0 even if the <a>PutRecordBatch</a> call succeeds. Check\n            <code>FailedPutCount</code> to determine whether there are records that you need to\n         resend.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Encrypted": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether server-side encryption (SSE) was enabled during this operation.</p>"
+                    }
+                },
+                "RequestResponses": {
+                    "target": "com.amazonaws.firehose#PutRecordBatchResponseEntryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The results array. For each record, the index of the response element is the same as\n         the index used in the request array.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatchRequestEntryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#Record"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 500
+                }
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatchResponseEntry": {
+            "type": "structure",
+            "members": {
+                "RecordId": {
+                    "target": "com.amazonaws.firehose#PutResponseRecordId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the record.</p>"
+                    }
+                },
+                "ErrorCode": {
+                    "target": "com.amazonaws.firehose#ErrorCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error code for an individual record result.</p>"
+                    }
+                },
+                "ErrorMessage": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error message for an individual record result.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the result for an individual record from a <a>PutRecordBatch</a>\n         request. If the record is successfully added to your Firehose stream, it receives a record\n         ID. If the record fails to be added to your Firehose stream, the result includes an error\n         code and an error message.</p>"
+            }
+        },
+        "com.amazonaws.firehose#PutRecordBatchResponseEntryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#PutRecordBatchResponseEntry"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 500
+                }
+            }
+        },
+        "com.amazonaws.firehose#PutRecordInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Record": {
+                    "target": "com.amazonaws.firehose#Record",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The record.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#PutRecordOutput": {
+            "type": "structure",
+            "members": {
+                "RecordId": {
+                    "target": "com.amazonaws.firehose#PutResponseRecordId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the record.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Encrypted": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether server-side encryption (SSE) was enabled during this operation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#PutResponseRecordId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.firehose#ReadFromTimestamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.firehose#Record": {
+            "type": "structure",
+            "members": {
+                "Data": {
+                    "target": "com.amazonaws.firehose#Data",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data blob, which is base64-encoded when the blob is serialized. The maximum size\n         of the data blob, before base64-encoding, is 1,000 KiB.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The unit of data in a Firehose stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RedshiftDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ClusterJDBCURL": {
+                    "target": "com.amazonaws.firehose#ClusterJDBCURL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The database connection string.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CopyCommand": {
+                    "target": "com.amazonaws.firehose#CopyCommand",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>COPY</code> command.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Username": {
+                    "target": "com.amazonaws.firehose#Username",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the user.</p>"
+                    }
+                },
+                "Password": {
+                    "target": "com.amazonaws.firehose#Password",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user password.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RedshiftRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon Redshift. Default value is 3600 (60 minutes).</p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for the intermediate Amazon S3 location from which Amazon Redshift\n         obtains data. Restrictions are described in the topic for <a>CreateDeliveryStream</a>.</p>\n         <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified\n         in <code>RedshiftDestinationConfiguration.S3Configuration</code> because the Amazon\n         Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these\n         compression formats.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#RedshiftS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode. After you create a Firehose stream, you can update it to\n         enable Amazon S3 backup if it is disabled. If backup is enabled, you can't update the\n         Firehose stream to disable it. </p>"
+                    }
+                },
+                "S3BackupConfiguration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for backup in Amazon S3.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Amazon Redshift.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Amazon Redshift.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RedshiftDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ClusterJDBCURL": {
+                    "target": "com.amazonaws.firehose#ClusterJDBCURL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The database connection string.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CopyCommand": {
+                    "target": "com.amazonaws.firehose#CopyCommand",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>COPY</code> command.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Username": {
+                    "target": "com.amazonaws.firehose#Username",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the user.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RedshiftRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon Redshift. Default value is 3600 (60 minutes).</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#RedshiftS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 backup mode.</p>"
+                    }
+                },
+                "S3BackupDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for backup in Amazon S3.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Amazon Redshift.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a destination in Amazon Redshift.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RedshiftDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "ClusterJDBCURL": {
+                    "target": "com.amazonaws.firehose#ClusterJDBCURL",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The database connection string.</p>"
+                    }
+                },
+                "CopyCommand": {
+                    "target": "com.amazonaws.firehose#CopyCommand",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>COPY</code> command.</p>"
+                    }
+                },
+                "Username": {
+                    "target": "com.amazonaws.firehose#Username",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the user.</p>"
+                    }
+                },
+                "Password": {
+                    "target": "com.amazonaws.firehose#Password",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user password.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#RedshiftRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver documents to\n         Amazon Redshift. Default value is 3600 (60 minutes).</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination.</p>\n         <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified\n         in <code>RedshiftDestinationUpdate.S3Update</code> because the Amazon Redshift\n            <code>COPY</code> operation that reads from the S3 bucket doesn't support these\n         compression formats.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#RedshiftS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>You can update a Firehose stream to enable Amazon S3 backup if it is disabled. If\n         backup is enabled, you can't update the Firehose stream to disable it. </p>"
+                    }
+                },
+                "S3BackupUpdate": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination for backup.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Amazon Redshift.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Amazon Redshift.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RedshiftRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#RedshiftRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#RedshiftRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The length of time during which Firehose retries delivery after a\n         failure, starting from the initial request and including the first attempt. The default\n         value is 3600 seconds (60 minutes). Firehose does not retry if the value of\n            <code>DurationInSeconds</code> is 0 (zero) or if the first delivery attempt takes longer\n         than the current value.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configures retry behavior in case Firehose is unable to deliver\n         documents to Amazon Redshift.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RedshiftS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                },
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#ResourceInUseException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The resource is already in use and not available for this operation.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified resource could not be found.</p>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.firehose#RetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#RetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#RetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The period of time during which Firehose retries to deliver data to the\n         specified destination.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The retry behavior in case Firehose is unable to deliver data to a destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#RoleARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": "^arn:.*:iam::\\d{12}:role/[a-zA-Z_0-9+=,.@\\-_/]+$"
+            }
+        },
+        "com.amazonaws.firehose#S3BackupMode": {
+            "type": "enum",
+            "members": {
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                },
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#S3DestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object\n         default values are used.</p>"
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n            <code>UNCOMPRESSED</code>.</p>\n         <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified\n         for Amazon Redshift destinations because they are not supported by the Amazon Redshift\n            <code>COPY</code> operation that reads from the S3 bucket.</p>"
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#S3DestinationDescription": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object\n         default values are used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n            <code>UNCOMPRESSED</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#S3DestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services credentials. For more\n         information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "BucketARN": {
+                    "target": "com.amazonaws.firehose#BucketARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the S3 bucket. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and\n               Amazon Web Services Service Namespaces</a>.</p>"
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.firehose#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3\n         files. You can also specify a custom prefix, as described in <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "ErrorOutputPrefix": {
+                    "target": "com.amazonaws.firehose#ErrorOutputPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A prefix that Firehose evaluates and adds to failed records before writing\n         them to S3. This prefix appears immediately following the bucket name. For information\n         about how to specify this prefix, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html\">Custom Prefixes for Amazon S3\n         Objects</a>.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#BufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object\n         default values are used.</p>"
+                    }
+                },
+                "CompressionFormat": {
+                    "target": "com.amazonaws.firehose#CompressionFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The compression format. If no value is specified, the default is\n            <code>UNCOMPRESSED</code>.</p>\n         <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified\n         for Amazon Redshift destinations because they are not supported by the Amazon Redshift\n            <code>COPY</code> operation that reads from the S3 bucket.</p>"
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.firehose#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption configuration. If no value is specified, the default is no\n         encryption.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Amazon S3.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SSLMode": {
+            "type": "enum",
+            "members": {
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                },
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#SchemaConfiguration": {
+            "type": "structure",
+            "members": {
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The role that Firehose can use to access Amazon Web Services Glue. This\n         role must be in the same account you use for Firehose. Cross-account roles\n         aren't allowed.</p>\n         <important>\n            <p>If the <code>SchemaConfiguration</code> request parameter is used as part of invoking\n            the <code>CreateDeliveryStream</code> API, then the <code>RoleARN</code> property is\n            required and its value must be specified.</p>\n         </important>"
+                    }
+                },
+                "CatalogId": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the Amazon Web Services Glue Data Catalog. If you don't supply this, the\n            Amazon Web Services account ID is used by default.</p>"
+                    }
+                },
+                "DatabaseName": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the name of the Amazon Web Services Glue database that contains the schema for\n         the output data.</p>\n         <important>\n            <p>If the <code>SchemaConfiguration</code> request parameter is used as part of invoking\n            the <code>CreateDeliveryStream</code> API, then the <code>DatabaseName</code> property\n            is required and its value must be specified.</p>\n         </important>"
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the Amazon Web Services Glue table that contains the column information that\n         constitutes your data schema.</p>\n         <important>\n            <p>If the <code>SchemaConfiguration</code> request parameter is used as part of invoking\n            the <code>CreateDeliveryStream</code> API, then the <code>TableName</code> property is\n            required and its value must be specified.</p>\n         </important>"
+                    }
+                },
+                "Region": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If you don't specify an Amazon Web Services Region, the default is the current\n         Region.</p>"
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the table version for the output data schema. If you don't specify this\n         version ID, or if you set it to <code>LATEST</code>, Firehose uses the most\n         recent version. This means that any updates to the table are automatically picked\n         up.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the schema to which you want Firehose to configure your data\n         before it writes it to Amazon S3. This parameter is required if <code>Enabled</code> is set\n         to true.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SchemaEvolutionConfiguration": {
+            "type": "structure",
+            "members": {
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Specify whether you want to enable schema evolution.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration to enable schema evolution.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SecretARN": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:.*:secretsmanager:[a-zA-Z0-9\\-]+:\\d{12}:secret:[a-zA-Z0-9\\-/_+=.@!]+$"
+            }
+        },
+        "com.amazonaws.firehose#SecretsManagerConfiguration": {
+            "type": "structure",
+            "members": {
+                "SecretARN": {
+                    "target": "com.amazonaws.firehose#SecretARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the secret that stores your credentials. It must be in the same region as the\n         Firehose stream and the role. The secret ARN can reside in a different account than the Firehose stream and role as Firehose supports cross-account secret access. This parameter is required when <b>Enabled</b> is set to <code>True</code>.</p>"
+                    }
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Specifies the role that Firehose assumes when calling the Secrets Manager API operation. When you provide the role, it overrides any destination specific role defined in the destination configuration. If you do not provide the then we use the destination specific role. This parameter is required for Splunk.\n      </p>"
+                    }
+                },
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether you want to use the secrets manager feature. When set as\n            <code>True</code> the secrets manager configuration overwrites the existing secrets in\n         the destination configuration. When it's set to <code>False</code> Firehose falls back to\n         the credentials in the destination configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The structure that defines how Firehose accesses the secret.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SecurityGroupIdList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.firehose#Serializer": {
+            "type": "structure",
+            "members": {
+                "ParquetSerDe": {
+                    "target": "com.amazonaws.firehose#ParquetSerDe",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A serializer to use for converting data to the Parquet format before storing it in\n         Amazon S3. For more information, see <a href=\"https://parquet.apache.org/docs/contribution-guidelines/\">Apache Parquet</a>.</p>"
+                    }
+                },
+                "OrcSerDe": {
+                    "target": "com.amazonaws.firehose#OrcSerDe",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A serializer to use for converting data to the ORC format before storing it in Amazon\n         S3. For more information, see <a href=\"https://orc.apache.org/docs/\">Apache\n         ORC</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The serializer that you want Firehose to use to convert data to the target\n         format before writing it to Amazon S3. Firehose supports two types of\n         serializers: the ORC SerDe and the Parquet SerDe.</p>"
+            }
+        },
+        "com.amazonaws.firehose#ServiceUnavailableException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.firehose#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message that provides information about the error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The service is unavailable. Back off and retry the operation. If you continue to see\n         the exception, throughput limits for the Firehose stream may have been exceeded. For more\n         information about limits and how to request an increase, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Firehose\n         Limits</a>.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 503
+            }
+        },
+        "com.amazonaws.firehose#SizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnapshotRequestedBy": {
+            "type": "enum",
+            "members": {
+                "USER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USER"
+                    }
+                },
+                "FIREHOSE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FIREHOSE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnapshotStatus": {
+            "type": "enum",
+            "members": {
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "COMPLETE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "COMPLETE"
+                    }
+                },
+                "SUSPENDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUSPENDED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeAccountUrl": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 24,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^.+?\\.snowflakecomputing\\.com$",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeBufferingHints": {
+            "type": "structure",
+            "members": {
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#SnowflakeBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the\n         destination. The default value is 128. </p>"
+                    }
+                },
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#SnowflakeBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 0.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Describes the buffering to perform before delivering data to the Snowflake destination. If you do not specify any value, Firehose uses the default values.\n      </p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 900
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeContentColumnName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeDataLoadingOption": {
+            "type": "enum",
+            "members": {
+                "JSON_MAPPING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "JSON_MAPPING"
+                    }
+                },
+                "VARIANT_CONTENT_MAPPING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VARIANT_CONTENT_MAPPING"
+                    }
+                },
+                "VARIANT_CONTENT_AND_METADATA_MAPPING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VARIANT_CONTENT_AND_METADATA_MAPPING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeDatabase": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "AccountUrl": {
+                    "target": "com.amazonaws.firehose#SnowflakeAccountUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>URL for accessing your Snowflake account. This URL must include your <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier\">account identifier</a>. \n         Note that the protocol (https://) and port number are optional.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "PrivateKey": {
+                    "target": "com.amazonaws.firehose#SnowflakePrivateKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The private key used to encrypt your Snowflake client. For information, see <a href=\"https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-configuration#using-key-pair-authentication-key-rotation\">Using Key Pair Authentication & Key Rotation</a>.</p>"
+                    }
+                },
+                "KeyPassphrase": {
+                    "target": "com.amazonaws.firehose#SnowflakeKeyPassphrase",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Passphrase to decrypt the private key when the key is encrypted. For information, see <a href=\"https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-configuration#using-key-pair-authentication-key-rotation\">Using Key Pair Authentication & Key Rotation</a>.</p>"
+                    }
+                },
+                "User": {
+                    "target": "com.amazonaws.firehose#SnowflakeUser",
+                    "traits": {
+                        "smithy.api#documentation": "<p>User login name for the Snowflake account.</p>"
+                    }
+                },
+                "Database": {
+                    "target": "com.amazonaws.firehose#SnowflakeDatabase",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is maintained in databases.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Schema": {
+                    "target": "com.amazonaws.firehose#SnowflakeSchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Each database consists of one or more schemas, which are logical groupings of database objects, such as tables and views</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Table": {
+                    "target": "com.amazonaws.firehose#SnowflakeTable",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is stored in database tables, logically structured as collections of columns and rows.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SnowflakeRoleConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeRoleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optionally configure a Snowflake role. Otherwise the default user role will be used.</p>"
+                    }
+                },
+                "DataLoadingOption": {
+                    "target": "com.amazonaws.firehose#SnowflakeDataLoadingOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Choose to load JSON keys mapped to table column names or choose to split the JSON payload where content is mapped to a record content column and source metadata is mapped to a record metadata column.</p>"
+                    }
+                },
+                "MetaDataColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeMetaDataColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify a column name in the table, where the metadata information has to be loaded.\n         When you enable this field, you will see the following column in the snowflake table, which\n         differs based on the source type.</p>\n         <p>For Direct PUT as source </p>\n         <p>\n            <code>{ \"firehoseDeliveryStreamName\" : \"streamname\", \"IngestionTime\" : \"timestamp\"\n            }</code>\n         </p>\n         <p>For Kinesis Data Stream as source </p>\n         <p>\n            <code> \"kinesisStreamName\" : \"streamname\", \"kinesisShardId\" : \"Id\",\n            \"kinesisPartitionKey\" : \"key\", \"kinesisSequenceNumber\" : \"1234\", \"subsequenceNumber\" :\n            \"2334\", \"IngestionTime\" : \"timestamp\" }</code>\n         </p>"
+                    }
+                },
+                "ContentColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeContentColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the record content column.</p>"
+                    }
+                },
+                "SnowflakeVpcConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeVpcConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The VPCE ID for Firehose to privately connect with Snowflake. The ID format is\n         com.amazonaws.vpce.[region].vpce-svc-<[id]>. For more information, see <a href=\"https://docs.snowflake.com/en/user-guide/admin-security-privatelink\">Amazon PrivateLink & Snowflake</a>\n         </p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Snowflake role</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SnowflakeRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time period where Firehose will retry sending data to the chosen HTTP endpoint.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SnowflakeS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Choose an S3 backup mode</p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Snowflake.\n      </p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SnowflakeBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes the buffering to perform before delivering data to the Snowflake destination. If you do not specify any value, Firehose uses the default values.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configure Snowflake destination</p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "AccountUrl": {
+                    "target": "com.amazonaws.firehose#SnowflakeAccountUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>URL for accessing your Snowflake account. This URL must include your <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier\">account identifier</a>. \n         Note that the protocol (https://) and port number are optional.</p>"
+                    }
+                },
+                "User": {
+                    "target": "com.amazonaws.firehose#SnowflakeUser",
+                    "traits": {
+                        "smithy.api#documentation": "<p>User login name for the Snowflake account.</p>"
+                    }
+                },
+                "Database": {
+                    "target": "com.amazonaws.firehose#SnowflakeDatabase",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is maintained in databases.</p>"
+                    }
+                },
+                "Schema": {
+                    "target": "com.amazonaws.firehose#SnowflakeSchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Each database consists of one or more schemas, which are logical groupings of database objects, such as tables and views</p>"
+                    }
+                },
+                "Table": {
+                    "target": "com.amazonaws.firehose#SnowflakeTable",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is stored in database tables, logically structured as collections of columns and rows.</p>"
+                    }
+                },
+                "SnowflakeRoleConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeRoleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optionally configure a Snowflake role. Otherwise the default user role will be used.</p>"
+                    }
+                },
+                "DataLoadingOption": {
+                    "target": "com.amazonaws.firehose#SnowflakeDataLoadingOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Choose to load JSON keys mapped to table column names or choose to split the JSON payload where content is mapped to a record content column and source metadata is mapped to a record metadata column.</p>"
+                    }
+                },
+                "MetaDataColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeMetaDataColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the record metadata column</p>"
+                    }
+                },
+                "ContentColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeContentColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the record content column</p>"
+                    }
+                },
+                "SnowflakeVpcConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeVpcConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The VPCE ID for Firehose to privately connect with Snowflake. The ID format is\n         com.amazonaws.vpce.[region].vpce-svc-<[id]>. For more information, see <a href=\"https://docs.snowflake.com/en/user-guide/admin-security-privatelink\">Amazon PrivateLink & Snowflake</a>\n         </p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Snowflake role</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SnowflakeRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time period where Firehose will retry sending data to the chosen HTTP endpoint.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SnowflakeS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Choose an S3 backup mode</p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription"
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Snowflake.\n      </p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SnowflakeBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes the buffering to perform before delivering data to the Snowflake destination. If you do not specify any value, Firehose uses the default values.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Optional Snowflake destination description</p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "AccountUrl": {
+                    "target": "com.amazonaws.firehose#SnowflakeAccountUrl",
+                    "traits": {
+                        "smithy.api#documentation": "<p>URL for accessing your Snowflake account. This URL must include your <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier\">account identifier</a>. \n         Note that the protocol (https://) and port number are optional.</p>"
+                    }
+                },
+                "PrivateKey": {
+                    "target": "com.amazonaws.firehose#SnowflakePrivateKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The private key used to encrypt your Snowflake client. For information, see <a href=\"https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-configuration#using-key-pair-authentication-key-rotation\">Using Key Pair Authentication & Key Rotation</a>.</p>"
+                    }
+                },
+                "KeyPassphrase": {
+                    "target": "com.amazonaws.firehose#SnowflakeKeyPassphrase",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Passphrase to decrypt the private key when the key is encrypted. For information, see <a href=\"https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-configuration#using-key-pair-authentication-key-rotation\">Using Key Pair Authentication & Key Rotation</a>.</p>"
+                    }
+                },
+                "User": {
+                    "target": "com.amazonaws.firehose#SnowflakeUser",
+                    "traits": {
+                        "smithy.api#documentation": "<p>User login name for the Snowflake account.</p>"
+                    }
+                },
+                "Database": {
+                    "target": "com.amazonaws.firehose#SnowflakeDatabase",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is maintained in databases.</p>"
+                    }
+                },
+                "Schema": {
+                    "target": "com.amazonaws.firehose#SnowflakeSchema",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Each database consists of one or more schemas, which are logical groupings of database objects, such as tables and views</p>"
+                    }
+                },
+                "Table": {
+                    "target": "com.amazonaws.firehose#SnowflakeTable",
+                    "traits": {
+                        "smithy.api#documentation": "<p>All data in Snowflake is stored in database tables, logically structured as collections of columns and rows.</p>"
+                    }
+                },
+                "SnowflakeRoleConfiguration": {
+                    "target": "com.amazonaws.firehose#SnowflakeRoleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optionally configure a Snowflake role. Otherwise the default user role will be used.</p>"
+                    }
+                },
+                "DataLoadingOption": {
+                    "target": "com.amazonaws.firehose#SnowflakeDataLoadingOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p> JSON keys mapped to table column names or choose to split the JSON payload where content is mapped to a record content column and source metadata is mapped to a record metadata column.</p>"
+                    }
+                },
+                "MetaDataColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeMetaDataColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the record metadata column</p>"
+                    }
+                },
+                "ContentColumnName": {
+                    "target": "com.amazonaws.firehose#SnowflakeContentColumnName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the content metadata column</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions"
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Snowflake role</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SnowflakeRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify how long Firehose retries sending data to the New Relic HTTP endpoint.\n         \n         After sending data, Firehose first waits for an acknowledgment from the HTTP endpoint. If an error occurs or the acknowledgment doesn’t arrive within the acknowledgment timeout period, Firehose starts the retry duration counter. It keeps retrying until the retry duration expires. After that, Firehose considers it a data delivery failure and backs up the data to your Amazon S3 bucket.\n         \n         Every time that Firehose sends data to the HTTP endpoint (either the initial attempt or a retry), it restarts the acknowledgement timeout counter and waits for an acknowledgement from the HTTP endpoint.\n         \n         Even if the retry duration expires, Firehose still waits for the acknowledgment until it receives it or the acknowledgement timeout period is reached. If the acknowledgment times out, Firehose determines whether there's time left in the retry counter. If there is time left, it retries again and repeats the logic until it receives an acknowledgment or determines that the retry time has expired.\n         \n         If you don't want Firehose to retry sending data, set this value to 0.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SnowflakeS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Choose an S3 backup mode. Once you set the mode as <code>AllData</code>, you can not\n         change it to <code>FailedDataOnly</code>.</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate"
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes the Secrets Manager configuration in Snowflake.\n      </p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SnowflakeBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes the buffering to perform before delivering data to the Snowflake destination. \n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Update to configuration settings</p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeKeyPassphrase": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 7,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeMetaDataColumnName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakePrivateKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 256,
+                    "max": 4096
+                },
+                "smithy.api#pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=)?$",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakePrivateLinkVpceId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 47,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^([a-zA-Z0-9\\-\\_]+\\.){2,3}vpce\\.[a-zA-Z0-9\\-]*\\.vpce-svc\\-[a-zA-Z0-9\\-]{17}$",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#SnowflakeRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>the time period where Firehose will retry sending data to the chosen HTTP endpoint.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specify how long Firehose retries sending data to the New Relic HTTP endpoint.\n         \n         After sending data, Firehose first waits for an acknowledgment from the HTTP endpoint. If an error occurs or the acknowledgment doesn’t arrive within the acknowledgment timeout period, Firehose starts the retry duration counter. It keeps retrying until the retry duration expires. After that, Firehose considers it a data delivery failure and backs up the data to your Amazon S3 bucket.\n         \n         Every time that Firehose sends data to the HTTP endpoint (either the initial attempt or a retry), it restarts the acknowledgement timeout counter and waits for an acknowledgement from the HTTP endpoint.\n         \n         Even if the retry duration expires, Firehose still waits for the acknowledgment until it receives it or the acknowledgement timeout period is reached. If the acknowledgment times out, Firehose determines whether there's time left in the retry counter. If there is time left, it retries again and repeats the logic until it receives an acknowledgment or determines that the retry time has expired.\n         \n         If you don't want Firehose to retry sending data, set this value to 0.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeRole": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeRoleConfiguration": {
+            "type": "structure",
+            "members": {
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enable Snowflake role</p>"
+                    }
+                },
+                "SnowflakeRole": {
+                    "target": "com.amazonaws.firehose#SnowflakeRole",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Snowflake role you wish to configure</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Optionally configure a Snowflake role. Otherwise the default user role will be used.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedDataOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedDataOnly"
+                    }
+                },
+                "AllData": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllData"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeSchema": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeTable": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeUser": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#SnowflakeVpcConfiguration": {
+            "type": "structure",
+            "members": {
+                "PrivateLinkVpceId": {
+                    "target": "com.amazonaws.firehose#SnowflakePrivateLinkVpceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The VPCE ID for Firehose to privately connect with Snowflake. The ID format is\n         com.amazonaws.vpce.[region].vpce-svc-<[id]>. For more information, see <a href=\"https://docs.snowflake.com/en/user-guide/admin-security-privatelink\">Amazon PrivateLink & Snowflake</a>\n         </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configure a Snowflake VPC</p>"
+            }
+        },
+        "com.amazonaws.firehose#SourceDescription": {
+            "type": "structure",
+            "members": {
+                "DirectPutSourceDescription": {
+                    "target": "com.amazonaws.firehose#DirectPutSourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details about Direct PUT used as the source for a Firehose stream.\n         </p>"
+                    }
+                },
+                "KinesisStreamSourceDescription": {
+                    "target": "com.amazonaws.firehose#KinesisStreamSourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis\n         data stream.</p>"
+                    }
+                },
+                "MSKSourceDescription": {
+                    "target": "com.amazonaws.firehose#MSKSourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration description for the Amazon MSK cluster to be used as the source for a delivery\n         stream.</p>"
+                    }
+                },
+                "DatabaseSourceDescription": {
+                    "target": "com.amazonaws.firehose#DatabaseSourceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details about a database used as the source for a Firehose stream.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about a Kinesis data stream used as the source for a Firehose\n         stream.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkBufferingHints": {
+            "type": "structure",
+            "members": {
+                "IntervalInSeconds": {
+                    "target": "com.amazonaws.firehose#SplunkBufferingIntervalInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 60 (1 minute).</p>"
+                    }
+                },
+                "SizeInMBs": {
+                    "target": "com.amazonaws.firehose#SplunkBufferingSizeInMBs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.\n         \n         </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for Splunk are used.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkBufferingIntervalInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 60
+                }
+            }
+        },
+        "com.amazonaws.firehose#SplunkBufferingSizeInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.firehose#SplunkDestinationConfiguration": {
+            "type": "structure",
+            "members": {
+                "HECEndpoint": {
+                    "target": "com.amazonaws.firehose#HECEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP Event Collector (HEC) endpoint to which Firehose sends your\n         data.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HECEndpointType": {
+                    "target": "com.amazonaws.firehose#HECEndpointType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This type can be either \"Raw\" or \"Event.\"</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "HECToken": {
+                    "target": "com.amazonaws.firehose#HECToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This is a GUID that you obtain from your Splunk cluster when you create a new HEC\n         endpoint.</p>"
+                    }
+                },
+                "HECAcknowledgmentTimeoutInSeconds": {
+                    "target": "com.amazonaws.firehose#HECAcknowledgmentTimeoutInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The amount of time that Firehose waits to receive an acknowledgment from\n         Splunk after it sends it data. At the end of the timeout period, Firehose\n         either tries to send the data again or considers it an error, based on your retry\n         settings.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SplunkRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver data to Splunk,\n         or if it doesn't receive an acknowledgment of receipt from Splunk.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SplunkS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines how documents should be delivered to Amazon S3. When set to\n            <code>FailedEventsOnly</code>, Firehose writes any data that could not be\n         indexed to the configured Amazon S3 destination. When set to <code>AllEvents</code>,\n         Firehose delivers all incoming records to Amazon S3, and also writes failed\n         documents to Amazon S3. The default value is <code>FailedEventsOnly</code>.</p>\n         <p>You can update this backup mode from <code>FailedEventsOnly</code> to\n            <code>AllEvents</code>. You can't update it from <code>AllEvents</code> to\n            <code>FailedEventsOnly</code>.</p>"
+                    }
+                },
+                "S3Configuration": {
+                    "target": "com.amazonaws.firehose#S3DestinationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The configuration for the backup Amazon S3 location.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SplunkBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for Splunk are used.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Splunk.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the configuration of a destination in Splunk.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkDestinationDescription": {
+            "type": "structure",
+            "members": {
+                "HECEndpoint": {
+                    "target": "com.amazonaws.firehose#HECEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP Event Collector (HEC) endpoint to which Firehose sends your\n         data.</p>"
+                    }
+                },
+                "HECEndpointType": {
+                    "target": "com.amazonaws.firehose#HECEndpointType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This type can be either \"Raw\" or \"Event.\"</p>"
+                    }
+                },
+                "HECToken": {
+                    "target": "com.amazonaws.firehose#HECToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A GUID you obtain from your Splunk cluster when you create a new HEC\n         endpoint.</p>"
+                    }
+                },
+                "HECAcknowledgmentTimeoutInSeconds": {
+                    "target": "com.amazonaws.firehose#HECAcknowledgmentTimeoutInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The amount of time that Firehose waits to receive an acknowledgment from\n         Splunk after it sends it data. At the end of the timeout period, Firehose\n         either tries to send the data again or considers it an error, based on your retry\n         settings.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SplunkRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver data to Splunk\n         or if it doesn't receive an acknowledgment of receipt from Splunk.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SplunkS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines how documents should be delivered to Amazon S3. When set to\n            <code>FailedDocumentsOnly</code>, Firehose writes any data that could not\n         be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>,\n         Firehose delivers all incoming records to Amazon S3, and also writes failed\n         documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>"
+                    }
+                },
+                "S3DestinationDescription": {
+                    "target": "com.amazonaws.firehose#S3DestinationDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 destination.></p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SplunkBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for Splunk are used.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Splunk.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a destination in Splunk.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkDestinationUpdate": {
+            "type": "structure",
+            "members": {
+                "HECEndpoint": {
+                    "target": "com.amazonaws.firehose#HECEndpoint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP Event Collector (HEC) endpoint to which Firehose sends your\n         data.</p>"
+                    }
+                },
+                "HECEndpointType": {
+                    "target": "com.amazonaws.firehose#HECEndpointType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This type can be either \"Raw\" or \"Event.\"</p>"
+                    }
+                },
+                "HECToken": {
+                    "target": "com.amazonaws.firehose#HECToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A GUID that you obtain from your Splunk cluster when you create a new HEC\n         endpoint.</p>"
+                    }
+                },
+                "HECAcknowledgmentTimeoutInSeconds": {
+                    "target": "com.amazonaws.firehose#HECAcknowledgmentTimeoutInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The amount of time that Firehose waits to receive an acknowledgment from\n         Splunk after it sends data. At the end of the timeout period, Firehose either\n         tries to send the data again or considers it an error, based on your retry\n         settings.</p>"
+                    }
+                },
+                "RetryOptions": {
+                    "target": "com.amazonaws.firehose#SplunkRetryOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retry behavior in case Firehose is unable to deliver data to Splunk\n         or if it doesn't receive an acknowledgment of receipt from Splunk.</p>"
+                    }
+                },
+                "S3BackupMode": {
+                    "target": "com.amazonaws.firehose#SplunkS3BackupMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how you want Firehose to back up documents to Amazon S3. When\n         set to <code>FailedDocumentsOnly</code>, Firehose writes any data that could\n         not be indexed to the configured Amazon S3 destination. When set to <code>AllEvents</code>,\n         Firehose delivers all incoming records to Amazon S3, and also writes failed\n         documents to Amazon S3. The default value is <code>FailedEventsOnly</code>.</p>\n         <p>You can update this backup mode from <code>FailedEventsOnly</code> to\n            <code>AllEvents</code>. You can't update it from <code>AllEvents</code> to\n            <code>FailedEventsOnly</code>.</p>"
+                    }
+                },
+                "S3Update": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Your update to the configuration of the backup Amazon S3 location.</p>"
+                    }
+                },
+                "ProcessingConfiguration": {
+                    "target": "com.amazonaws.firehose#ProcessingConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data processing configuration.</p>"
+                    }
+                },
+                "CloudWatchLoggingOptions": {
+                    "target": "com.amazonaws.firehose#CloudWatchLoggingOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon CloudWatch logging options for your Firehose stream.</p>"
+                    }
+                },
+                "BufferingHints": {
+                    "target": "com.amazonaws.firehose#SplunkBufferingHints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The buffering options. If no value is specified, the default values for Splunk are used.</p>"
+                    }
+                },
+                "SecretsManagerConfiguration": {
+                    "target": "com.amazonaws.firehose#SecretsManagerConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         The configuration that defines how you access secrets for Splunk.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an update for a destination in Splunk.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkRetryDurationInSeconds": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 7200
+                }
+            }
+        },
+        "com.amazonaws.firehose#SplunkRetryOptions": {
+            "type": "structure",
+            "members": {
+                "DurationInSeconds": {
+                    "target": "com.amazonaws.firehose#SplunkRetryDurationInSeconds",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total amount of time that Firehose spends on retries. This duration\n         starts after the initial attempt to send data to Splunk fails. It doesn't include the\n         periods during which Firehose waits for acknowledgment from Splunk after each\n         attempt.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configures retry behavior in case Firehose is unable to deliver\n         documents to Splunk, or if it doesn't receive an acknowledgment from Splunk.</p>"
+            }
+        },
+        "com.amazonaws.firehose#SplunkS3BackupMode": {
+            "type": "enum",
+            "members": {
+                "FailedEventsOnly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FailedEventsOnly"
+                    }
+                },
+                "AllEvents": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AllEvents"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.firehose#StartDeliveryStreamEncryption": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#StartDeliveryStreamEncryptionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#StartDeliveryStreamEncryptionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidKMSResourceException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Enables server-side encryption (SSE) for the Firehose stream. </p>\n         <p>This operation is asynchronous. It returns immediately. When you invoke it, Firehose first sets the encryption status of the stream to <code>ENABLING</code>, and then\n         to <code>ENABLED</code>. The encryption status of a Firehose stream is the\n            <code>Status</code> property in <a>DeliveryStreamEncryptionConfiguration</a>.\n         If the operation fails, the encryption status changes to <code>ENABLING_FAILED</code>. You\n         can continue to read and write data to your Firehose stream while the encryption status is\n            <code>ENABLING</code>, but the data is not encrypted. It can take up to 5 seconds after\n         the encryption status changes to <code>ENABLED</code> before all records written to the\n         Firehose stream are encrypted. To find out whether a record or a batch of records was\n         encrypted, check the response elements <a>PutRecordOutput$Encrypted</a> and\n            <a>PutRecordBatchOutput$Encrypted</a>, respectively.</p>\n         <p>To check the encryption status of a Firehose stream, use <a>DescribeDeliveryStream</a>.</p>\n         <p>Even if encryption is currently enabled for a Firehose stream, you can still invoke this\n         operation on it to change the ARN of the CMK or both its type and ARN. If you invoke this\n         method to change the CMK, and the old CMK is of type <code>CUSTOMER_MANAGED_CMK</code>,\n         Firehose schedules the grant it had on the old CMK for retirement. If the new\n         CMK is of type <code>CUSTOMER_MANAGED_CMK</code>, Firehose creates a grant\n         that enables it to use the new CMK to encrypt and decrypt data and to manage the\n         grant.</p>\n         <p>For the KMS grant creation to be successful, the Firehose API operations\n            <code>StartDeliveryStreamEncryption</code> and <code>CreateDeliveryStream</code> should\n         not be called with session credentials that are more than 6 hours old.</p>\n         <p>If a Firehose stream already has encryption enabled and then you invoke this operation\n         to change the ARN of the CMK or both its type and ARN and you get\n            <code>ENABLING_FAILED</code>, this only means that the attempt to change the CMK failed.\n         In this case, encryption remains enabled with the old CMK.</p>\n         <p>If the encryption status of your Firehose stream is <code>ENABLING_FAILED</code>, you\n         can invoke this operation again with a valid CMK. The CMK must be enabled and the key\n         policy mustn't explicitly deny the permission for Firehose to invoke KMS\n         encrypt and decrypt operations.</p>\n         <p>You can enable SSE for a Firehose stream only if it's a Firehose stream that uses\n            <code>DirectPut</code> as its source. </p>\n         <p>The <code>StartDeliveryStreamEncryption</code> and\n            <code>StopDeliveryStreamEncryption</code> operations have a combined limit of 25 calls\n         per Firehose stream per 24 hours. For example, you reach the limit if you call\n            <code>StartDeliveryStreamEncryption</code> 13 times and\n            <code>StopDeliveryStreamEncryption</code> 12 times for the same Firehose stream in a\n         24-hour period.</p>"
+            }
+        },
+        "com.amazonaws.firehose#StartDeliveryStreamEncryptionInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream for which you want to enable server-side encryption\n         (SSE).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DeliveryStreamEncryptionConfigurationInput": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamEncryptionConfigurationInput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Used to specify the type and Amazon Resource Name (ARN) of the KMS key needed for\n         Server-Side Encryption (SSE).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#StartDeliveryStreamEncryptionOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#StopDeliveryStreamEncryption": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#StopDeliveryStreamEncryptionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#StopDeliveryStreamEncryptionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Disables server-side encryption (SSE) for the Firehose stream. </p>\n         <p>This operation is asynchronous. It returns immediately. When you invoke it, Firehose first sets the encryption status of the stream to <code>DISABLING</code>, and then\n         to <code>DISABLED</code>. You can continue to read and write data to your stream while its\n         status is <code>DISABLING</code>. It can take up to 5 seconds after the encryption status\n         changes to <code>DISABLED</code> before all records written to the Firehose stream are no\n         longer subject to encryption. To find out whether a record or a batch of records was\n         encrypted, check the response elements <a>PutRecordOutput$Encrypted</a> and\n            <a>PutRecordBatchOutput$Encrypted</a>, respectively.</p>\n         <p>To check the encryption state of a Firehose stream, use <a>DescribeDeliveryStream</a>. </p>\n         <p>If SSE is enabled using a customer managed CMK and then you invoke\n            <code>StopDeliveryStreamEncryption</code>, Firehose schedules the related\n         KMS grant for retirement and then retires it after it ensures that it is finished\n         delivering records to the destination.</p>\n         <p>The <code>StartDeliveryStreamEncryption</code> and\n            <code>StopDeliveryStreamEncryption</code> operations have a combined limit of 25 calls\n         per Firehose stream per 24 hours. For example, you reach the limit if you call\n            <code>StartDeliveryStreamEncryption</code> 13 times and\n            <code>StopDeliveryStreamEncryption</code> 12 times for the same Firehose stream in a\n         24-hour period.</p>"
+            }
+        },
+        "com.amazonaws.firehose#StopDeliveryStreamEncryptionInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream for which you want to disable server-side encryption\n         (SSE).</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#StopDeliveryStreamEncryptionOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#StringWithLettersDigitsUnderscoresDots": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9\\.\\_]+$"
+            }
+        },
+        "com.amazonaws.firehose#SubnetIdList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 16
+                }
+            }
+        },
+        "com.amazonaws.firehose#TableCreationConfiguration": {
+            "type": "structure",
+            "members": {
+                "Enabled": {
+                    "target": "com.amazonaws.firehose#BooleanObject",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Specify whether you want to enable automatic table creation.\n      </p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration to enable automatic table creation.</p>\n         <p>Amazon Data Firehose is in preview release and is subject to change.</p>"
+            }
+        },
+        "com.amazonaws.firehose#Tag": {
+            "type": "structure",
+            "members": {
+                "Key": {
+                    "target": "com.amazonaws.firehose#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique identifier for the tag. Maximum length: 128 characters. Valid characters:\n         Unicode letters, digits, white space, _ . / = + - % @</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.firehose#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An optional string, which you can use to describe or define the tag. Maximum length:\n         256 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - %\n         @</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Metadata that you can assign to a Firehose stream, consisting of a key-value\n         pair.</p>"
+            }
+        },
+        "com.amazonaws.firehose#TagDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#TagDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#TagDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds or updates tags for the specified Firehose stream. A tag is a key-value pair\n         that you can define and assign to Amazon Web Services resources. If you specify a tag that\n         already exists, the tag value is replaced with the value that you specify in the request.\n         Tags are metadata. For example, you can add friendly names and descriptions or other types\n         of information that can help you distinguish the Firehose stream. For more information\n         about tags, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using Cost Allocation\n            Tags</a> in the <i>Amazon Web Services Billing and Cost Management User\n            Guide</i>. </p>\n         <p>Each Firehose stream can have up to 50 tags. </p>\n         <p>This operation has a limit of five transactions per second per account. </p>"
+            }
+        },
+        "com.amazonaws.firehose#TagDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream to which you want to add the tags.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.firehose#TagDeliveryStreamInputTagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs to use to create the tags.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#TagDeliveryStreamInputTagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.firehose#TagDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^(?!aws:)[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@%]*$"
+            }
+        },
+        "com.amazonaws.firehose#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.firehose#TagKey"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.firehose#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@%]*$"
+            }
+        },
+        "com.amazonaws.firehose#ThroughputHintInMBs": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.firehose#Timestamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.firehose#TopicName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9\\\\._\\\\-]+$"
+            }
+        },
+        "com.amazonaws.firehose#UntagDeliveryStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#UntagDeliveryStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#UntagDeliveryStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Removes tags from the specified Firehose stream. Removed tags are deleted, and you\n         can't recover them after this operation successfully completes.</p>\n         <p>If you specify a tag that doesn't exist, the operation ignores it.</p>\n         <p>This operation has a limit of five transactions per second per account. </p>"
+            }
+        },
+        "com.amazonaws.firehose#UntagDeliveryStreamInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TagKeys": {
+                    "target": "com.amazonaws.firehose#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tag keys. Each corresponding tag is removed from the delivery\n         stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#UntagDeliveryStreamOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#UpdateDestination": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.firehose#UpdateDestinationInput"
+            },
+            "output": {
+                "target": "com.amazonaws.firehose#UpdateDestinationOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.firehose#ConcurrentModificationException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#InvalidArgumentException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceInUseException"
+                },
+                {
+                    "target": "com.amazonaws.firehose#ResourceNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the specified destination of the specified Firehose stream.</p>\n         <p>Use this operation to change the destination type (for example, to replace the Amazon\n         S3 destination with Amazon Redshift) or change the parameters associated with a destination\n         (for example, to change the bucket name of the Amazon S3 destination). The update might not\n         occur immediately. The target Firehose stream remains active while the configurations are\n         updated, so data writes to the Firehose stream can continue during this process. The\n         updated configurations are usually effective within a few minutes.</p>\n         <p>Switching between Amazon OpenSearch Service and other services is not supported. For\n         an Amazon OpenSearch Service destination, you can only update to another Amazon OpenSearch\n         Service destination.</p>\n         <p>If the destination type is the same, Firehose merges the configuration\n         parameters specified with the destination configuration that already exists on the delivery\n         stream. If any of the parameters are not specified in the call, the existing values are\n         retained. For example, in the Amazon S3 destination, if <a>EncryptionConfiguration</a> is not specified, then the existing\n            <code>EncryptionConfiguration</code> is maintained on the destination.</p>\n         <p>If the destination type is not the same, for example, changing the destination from\n         Amazon S3 to Amazon Redshift, Firehose does not merge any parameters. In this\n         case, all parameters must be specified.</p>\n         <p>Firehose uses <code>CurrentDeliveryStreamVersionId</code> to avoid race\n         conditions and conflicting merges. This is a required field, and the service updates the\n         configuration only if the existing configuration has a version ID that matches. After the\n         update is applied successfully, the version ID is updated, and can be retrieved using <a>DescribeDeliveryStream</a>. Use the new version ID to set\n            <code>CurrentDeliveryStreamVersionId</code> in the next call.</p>"
+            }
+        },
+        "com.amazonaws.firehose#UpdateDestinationInput": {
+            "type": "structure",
+            "members": {
+                "DeliveryStreamName": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Firehose stream.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CurrentDeliveryStreamVersionId": {
+                    "target": "com.amazonaws.firehose#DeliveryStreamVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Obtain this value from the <code>VersionId</code> result of <a>DeliveryStreamDescription</a>. This value is required, and helps the service\n         perform conditional operations. For example, if there is an interleaving update and this\n         value is null, then the update destination fails. After the update is successful, the\n            <code>VersionId</code> value is updated. The service then performs a merge of the old\n         configuration with the new configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DestinationId": {
+                    "target": "com.amazonaws.firehose#DestinationId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the destination.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "S3DestinationUpdate": {
+                    "target": "com.amazonaws.firehose#S3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#deprecated": {},
+                        "smithy.api#documentation": "<p>[Deprecated] Describes an update for a destination in Amazon S3.</p>"
+                    }
+                },
+                "ExtendedS3DestinationUpdate": {
+                    "target": "com.amazonaws.firehose#ExtendedS3DestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in Amazon S3.</p>"
+                    }
+                },
+                "RedshiftDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#RedshiftDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in Amazon Redshift.</p>"
+                    }
+                },
+                "ElasticsearchDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#ElasticsearchDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "AmazonopensearchserviceDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#AmazonopensearchserviceDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in Amazon OpenSearch Service.</p>"
+                    }
+                },
+                "SplunkDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#SplunkDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in Splunk.</p>"
+                    }
+                },
+                "HttpEndpointDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#HttpEndpointDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update to the specified HTTP endpoint destination.</p>"
+                    }
+                },
+                "AmazonOpenSearchServerlessDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#AmazonOpenSearchServerlessDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Describes an update for a destination in the Serverless offering for Amazon OpenSearch\n         Service.</p>"
+                    }
+                },
+                "SnowflakeDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#SnowflakeDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Update to the Snowflake destination configuration settings.</p>"
+                    }
+                },
+                "IcebergDestinationUpdate": {
+                    "target": "com.amazonaws.firehose#IcebergDestinationUpdate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n         Describes an update for a destination in Apache Iceberg Tables.\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.firehose#UpdateDestinationOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.firehose#Username": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 512
+                },
+                "smithy.api#pattern": ".*",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.firehose#VpcConfiguration": {
+            "type": "structure",
+            "members": {
+                "SubnetIds": {
+                    "target": "com.amazonaws.firehose#SubnetIdList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IDs of the subnets that you want Firehose to use to create ENIs in the\n         VPC of the Amazon OpenSearch Service destination. Make sure that the routing tables and inbound and\n         outbound rules allow traffic to flow from the subnets whose IDs are specified here to the\n         subnets that have the destination Amazon OpenSearch Service endpoints. Firehose creates at\n         least one ENI in each of the subnets that are specified here. Do not delete or modify these\n         ENIs.</p>\n         <p>The number of ENIs that Firehose creates in the subnets specified here\n         scales up and down automatically based on throughput. To enable Firehose to\n         scale up the number of ENIs to match throughput, ensure that you have sufficient quota. To\n         help you calculate the quota you need, assume that Firehose can create up to\n         three ENIs for this Firehose stream for each of the subnets specified here. For more\n         information about ENI quota, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-enis\">Network Interfaces\n         </a> in the Amazon VPC Quotas topic.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role that you want the Firehose stream to use to create endpoints in\n         the destination VPC. You can use your existing Firehose delivery role or you\n         can specify a new role. In either case, make sure that the role trusts the Firehose service principal and that it grants the following permissions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ec2:DescribeVpcs</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeVpcAttribute</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeSubnets</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeSecurityGroups</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeNetworkInterfaces</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:CreateNetworkInterface</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:CreateNetworkInterfacePermission</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DeleteNetworkInterface</code>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>When you specify subnets for delivering data to the destination in a private VPC, make sure you have enough number of free IP addresses in chosen subnets. If there is no available free IP address in a specified subnet, Firehose cannot create or add ENIs for the data delivery in the private VPC, and the delivery will be degraded or fail.</p>\n         </important>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SecurityGroupIds": {
+                    "target": "com.amazonaws.firehose#SecurityGroupIdList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IDs of the security groups that you want Firehose to use when it\n         creates ENIs in the VPC of the Amazon OpenSearch Service destination. You can use the same security group\n         that the Amazon OpenSearch Service domain uses or different ones. If you specify different security groups\n         here, ensure that they allow outbound HTTPS traffic to the Amazon OpenSearch Service domain's security\n         group. Also ensure that the Amazon OpenSearch Service domain's security group allows HTTPS traffic from the\n         security groups specified here. If you use the same security group for both your delivery\n         stream and the Amazon OpenSearch Service domain, make sure the security group inbound rule allows HTTPS\n         traffic. For more information about security group rules, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#SecurityGroupRules\">Security group\n            rules</a> in the Amazon VPC documentation.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details of the VPC of the Amazon OpenSearch or Amazon OpenSearch Serverless\n         destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#VpcConfigurationDescription": {
+            "type": "structure",
+            "members": {
+                "SubnetIds": {
+                    "target": "com.amazonaws.firehose#SubnetIdList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IDs of the subnets that Firehose uses to create ENIs in the VPC of the\n         Amazon OpenSearch Service destination. Make sure that the routing tables and inbound and outbound rules\n         allow traffic to flow from the subnets whose IDs are specified here to the subnets that\n         have the destination Amazon OpenSearch Service endpoints. Firehose creates at least one ENI in\n         each of the subnets that are specified here. Do not delete or modify these ENIs.</p>\n         <p>The number of ENIs that Firehose creates in the subnets specified here\n         scales up and down automatically based on throughput. To enable Firehose to\n         scale up the number of ENIs to match throughput, ensure that you have sufficient quota. To\n         help you calculate the quota you need, assume that Firehose can create up to\n         three ENIs for this Firehose stream for each of the subnets specified here. For more\n         information about ENI quota, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-enis\">Network Interfaces\n         </a> in the Amazon VPC Quotas topic.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RoleARN": {
+                    "target": "com.amazonaws.firehose#RoleARN",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role that the Firehose stream uses to create endpoints in the\n         destination VPC. You can use your existing Firehose delivery role or you can\n         specify a new role. In either case, make sure that the role trusts the Firehose service principal and that it grants the following permissions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ec2:DescribeVpcs</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeVpcAttribute</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeSubnets</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeSecurityGroups</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DescribeNetworkInterfaces</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:CreateNetworkInterface</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:CreateNetworkInterfacePermission</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ec2:DeleteNetworkInterface</code>\n               </p>\n            </li>\n         </ul>\n         <p>If you revoke these permissions after you create the Firehose stream, Firehose can't scale out by creating more ENIs when necessary. You might therefore see a\n         degradation in performance.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SecurityGroupIds": {
+                    "target": "com.amazonaws.firehose#SecurityGroupIdList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IDs of the security groups that Firehose uses when it creates ENIs in\n         the VPC of the Amazon OpenSearch Service destination. You can use the same security group that the Amazon\n         ES domain uses or different ones. If you specify different security groups, ensure that\n         they allow outbound HTTPS traffic to the Amazon OpenSearch Service domain's security group. Also ensure\n         that the Amazon OpenSearch Service domain's security group allows HTTPS traffic from the security groups\n         specified here. If you use the same security group for both your Firehose stream and the\n         Amazon OpenSearch Service domain, make sure the security group inbound rule allows HTTPS traffic. For more\n         information about security group rules, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#SecurityGroupRules\">Security group\n            rules</a> in the Amazon VPC documentation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VpcId": {
+                    "target": "com.amazonaws.firehose#NonEmptyStringWithoutWhitespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the Amazon OpenSearch Service destination's VPC.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The details of the VPC of the Amazon OpenSearch Service destination.</p>"
+            }
+        },
+        "com.amazonaws.firehose#VpcEndpointServiceName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 47,
+                    "max": 255
+                },
+                "smithy.api#pattern": "^([a-zA-Z0-9\\-\\_]+\\.){2,3}vpce\\.[a-zA-Z0-9\\-]*\\.vpce-svc\\-[a-zA-Z0-9\\-]{17}$"
+            }
+        },
+        "com.amazonaws.firehose#WarehouseLocation": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^s3:\\/\\/"
+            }
+        }
+    }
+}

--- a/pkg/testdata/models/apis/firehose/0000-00-00/generator-set-for-nested-field.yaml
+++ b/pkg/testdata/models/apis/firehose/0000-00-00/generator-set-for-nested-field.yaml
@@ -1,0 +1,45 @@
+model_name: firehose
+ignore:
+  resource_names:
+     # - DeliveryStream
+  field_paths:
+    - CreateDeliveryStreamInput.AmazonOpenSearchServerlessDestinationConfiguration
+    - CreateDeliveryStreamInput.AmazonopensearchserviceDestinationConfiguration
+    - CreateDeliveryStreamInput.DatabaseSourceConfiguration
+    - CreateDeliveryStreamInput.DirectPutSourceConfiguration
+    - CreateDeliveryStreamInput.ElasticsearchDestinationConfiguration
+    - CreateDeliveryStreamInput.ExtendedS3DestinationConfiguration
+    #- CreateDeliveryStreamInput.HttpEndpointDestinationConfiguration
+    - CreateDeliveryStreamInput.IcebergDestinationConfiguration
+    - CreateDeliveryStreamInput.KinesisStreamSourceConfiguration
+    - CreateDeliveryStreamInput.MSKSourceConfiguration
+    - CreateDeliveryStreamInput.RedshiftDestinationConfiguration
+    - CreateDeliveryStreamInput.SnowflakeDestinationConfiguration
+    - CreateDeliveryStreamInput.SplunkDestinationConfiguration
+    - CreateDeliveryStreamInput.S3DestinationConfiguration
+
+
+operations:
+  UpdateDestination:
+    resource_name: DeliveryStream
+    operation_type: 
+      - Update
+
+resources:
+  DeliveryStream:
+    renames:
+      operations:
+        UpdateDestination:
+          input_fields:
+            HttpEndpointDestinationUpdate: HttpEndpointDestinationConfiguration
+            HttpEndpointDestinationConfiguration.S3Update: S3Configuration
+            S3Update: S3Configuration
+
+    fields:
+      HTTPEndpointDestinationConfiguration.S3Configuration:
+        set:
+          - method: Update
+            to: S3Update
+        
+
+


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add support for applying Set config's `-to` to child fields of Struct field.

- Check for SetConfigs for child fields in SetSDKForStruct
- Add testdata for firehose service
- Add unit test to verify nested set behavior.
- Cleanup leftover print statement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
