### PR TITLE
replace conditional synced condition with ready condition in printcolumn

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -395,6 +395,7 @@ type PrintConfig struct {
 	// resource in `kubectl get` response.
 	//
 	// Default value is true.
+	// Deprecated: We now print Ready condition by default
 	AddSyncedColumn *bool `json:"add_synced_column"`
 	// OrderBy is the field used to sort the list of PrinterColumn options.
 	OrderBy string `json:"order_by"`
@@ -481,23 +482,6 @@ func (c *Config) ResourceDisplaysAgeColumn(resourceName string) bool {
 	}
 	if rConfig.Print != nil {
 		return rConfig.Print.AddAgeColumn
-	}
-	return false
-}
-
-// ResourceDisplaysSyncedColumn returns true if the resource is
-// configured to display the synced status.
-func (c *Config) ResourceDisplaysSyncedColumn(resourceName string) bool {
-	if c == nil {
-		return false
-	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
-		return false
-	}
-	if rConfig.Print != nil {
-		// default value should be true.
-		return rConfig.Print.AddSyncedColumn == nil || *rConfig.Print.AddSyncedColumn
 	}
 	return false
 }

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -599,12 +599,6 @@ func (r *CRD) PrintAgeColumn() bool {
 	return r.cfg.ResourceDisplaysAgeColumn(r.Names.Camel)
 }
 
-// PrintSyncedColumn returns whether the code generator should append 'Sync'
-// kubebuilder:printcolumn comment marker
-func (r *CRD) PrintSyncedColumn() bool {
-	return r.cfg.ResourceDisplaysSyncedColumn(r.Names.Camel)
-}
-
 func (r *CRD) addAdditionalPrinterColumns(additionalColumns []*ackgenconfig.AdditionalColumnConfig) {
 	for _, additionalColumn := range additionalColumns {
 		printerColumn := &PrinterColumn{}

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -60,9 +60,7 @@ type {{ .CRD.Kind }}Status struct {
 {{- range $column := .CRD.AdditionalPrinterColumns }}
 // +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},priority={{$column.Priority}},JSONPath=`{{$column.JSONPath}}`
 {{- end }}
-{{- if .CRD.PrintSyncedColumn }}
-// +kubebuilder:printcolumn:name="Synced",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"ACK.ResourceSynced\")].status"
-{{- end }}
+// +kubebuilder:printcolumn:name="Ready",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
 {{- if .CRD.PrintAgeColumn }}
 // +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
 {{- end }}


### PR DESCRIPTION
Issue [#2204](https://github.com/aws-controllers-k8s/community/issues/2204)

Description of changes:
This change adds removes the conditional check that adds the Synced condition,
and replaces it with a default Ready condition.

Ready condition represents that the resource is ready to be consumed by whatever it
depends on

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
