### PR TITLE
add cluster role/rolebinding for iamroleselector on namespace scope

### DIFF
--- a/templates/helm/templates/caches-role.yaml.tpl
+++ b/templates/helm/templates/caches-role.yaml.tpl
@@ -1,3 +1,4 @@
+{{ VarIncludeTemplate "featuregates" "feature-gates" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,6 +11,16 @@ metadata:
     k8s-app: {{ IncludeTemplate "app.name" }}
     helm.sh/chart: {{ IncludeTemplate "chart.name-version" }}
 rules:
+{{ "{{ if contains \"IAMRoleSelector=true\" $featuregates }}" }}
+- apiGroups:
+  - services.k8s.aws
+  resources:
+  - iamroleselectors
+  verbs:
+  - get
+  - list
+  - watch
+{{ "{{ end }}" }}
 - apiGroups:
   - ""
   resources:
@@ -19,6 +30,7 @@ rules:
   - list
   - watch
 ---
+{{ "{{ if eq .Values.enableCARM true }}" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -40,3 +52,4 @@ rules:
   - get
   - list
   - watch
+{{ "{{ end }}" }}

--- a/templates/pkg/resource/registry.go.tpl
+++ b/templates/pkg/resource/registry.go.tpl
@@ -7,7 +7,7 @@ import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
-// +kubebuilder:rbac:groups=services.k8s.aws,resources=iamroleselectors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=iamroleselectors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=iamroleselectors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=fieldexports,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=fieldexports/status,verbs=get;update;patch


### PR DESCRIPTION
Issue [#2755](https://github.com/aws-controllers-k8s/community/issues/2755)

Description of changes:
added changes:
* Add IAMRoleSelector permissions to cache role if feature is enabled
* When running with namespaced scope, ensure namespace cache role only has access
   to namespaces the controller is watching


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
