### PR TITLE
Include idempotency token by default

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -116,12 +116,14 @@ type ResourceConfig struct {
 	// TagConfig contains instructions for the code generator to generate
 	// custom code for ensuring tags
 	TagConfig *TagConfig `json:"tags,omitempty"`
-	// IgnoreIdempotencyToken instructs the code generator to automatically
-	// exclude fields that have the smithy.api#idempotencyToken trait (or the
-	// equivalent idempotencyToken trait in the v1 SDK model). These fields are
-	// SDK implementation details that are auto-filled by the SDK middleware
-	// when nil and should not be exposed in the CRD.
-	IgnoreIdempotencyToken bool `json:"ignore_idempotency_token,omitempty"`
+	// IncludeIdempotencyToken instructs the code generator to keep fields
+	// that have the smithy.api#idempotencyToken trait (or the equivalent
+	// idempotencyToken trait in the v1 SDK model). By default, these fields
+	// are automatically excluded because they are SDK implementation details
+	// that are auto-filled by the SDK middleware when nil and should not be
+	// exposed in the CRD. Set this to true only if you need to expose
+	// idempotency token fields in the CRD.
+	IncludeIdempotencyToken bool `json:"include_idempotency_token,omitempty"`
 }
 
 // TagConfig instructs the code  generator on how to generate functions that

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -2207,9 +2207,6 @@ func TestSetSDK_MQ_Broker_Create(t *testing.T) {
 		}
 		res.Configuration = f3
 	}
-	if r.ko.Spec.CreatorRequestID != nil {
-		res.CreatorRequestId = r.ko.Spec.CreatorRequestID
-	}
 	if r.ko.Spec.DeploymentMode != nil {
 		res.DeploymentMode = svcsdktypes.DeploymentMode(*r.ko.Spec.DeploymentMode)
 	}
@@ -5179,9 +5176,6 @@ func TestEMRContainers_VirtualCluster_WithUnion(t *testing.T) {
 	assert.NotNil(crd.Ops.Create)
 
 	expected := `
-	if r.ko.Spec.ClientToken != nil {
-		res.ClientToken = r.ko.Spec.ClientToken
-	}
 	if r.ko.Spec.ContainerProvider != nil {
 		f1 := &svcsdktypes.ContainerProvider{}
 		if r.ko.Spec.ContainerProvider.ID != nil {
@@ -6496,11 +6490,10 @@ func TestSetSDK_EMRServerless_Application_Create(t *testing.T) {
 		"Should use original SDK shape name WorkerTypeSpecificationInput, not renamed version")
 
 	// Verify idempotency token fields are excluded from the generated code
-	// when ignore_idempotency_token is enabled on the resource in generator.yaml.
-	// The ClientToken field in CreateApplicationInput has the
-	// smithy.api#idempotencyToken trait, and the emr-serverless test config
-	// has ignore_idempotency_token: true on Application, so the code generator
-	// should exclude it from the CRD and generated SDK code. The SDK middleware
+	// by default. The ClientToken field in CreateApplicationInput has the
+	// smithy.api#idempotencyToken trait, so the code generator should
+	// exclude it from the CRD and generated SDK code unless
+	// include_idempotency_token is set to true. The SDK middleware
 	// auto-fills it with a UUID when nil.
 	assert.NotContains(got, "ClientToken",
 		"ClientToken (idempotency token) should not appear in Create SDK code")
@@ -6535,8 +6528,7 @@ func TestSetSDK_EMRServerless_Application_Update(t *testing.T) {
 			"Should use original SDK shape name in Update operation")
 	}
 
-	// Verify idempotency token fields are excluded from Update as well
-	// when ignore_idempotency_token is enabled on the resource.
+	// Verify idempotency token fields are excluded from Update by default.
 	// UpdateApplicationInput.ClientToken also has the
 	// smithy.api#idempotencyToken trait.
 	assert.NotContains(got, "ClientToken",
@@ -6564,6 +6556,27 @@ func TestSetSDK_EMRServerless_Application_InitialCapacityConfig(t *testing.T) {
 	// The generated code should properly handle the nested WorkerCount field
 	// which has a bad default value in the SDK model
 	assert.Contains(got, "WorkerCount")
+}
+
+// TestSetSDK_EMRServerless_Application_IncludeIdempotencyToken tests that
+// setting include_idempotency_token: true in generator.yaml causes the
+// ClientToken field to appear in the generated SDK code.
+func TestSetSDK_EMRServerless_Application_IncludeIdempotencyToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "emr-serverless", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-include-idempotency-token.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Application")
+	require.NotNil(crd)
+
+	got, err := code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1)
+	require.NoError(err)
+
+	assert.Contains(got, "ClientToken",
+		"ClientToken should appear in Create SDK code when include_idempotency_token is true")
 }
 
 // TestSetSDK_QuickSight_DataSet_Create tests that the SetSDK code generation

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -177,12 +177,13 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 			// Idempotency tokens are SDK implementation details that are
 			// auto-filled by the SDK middleware when nil. They should not
 			// be exposed in the CRD as they are not resource properties.
-			// This filtering is opt-in via resources.<name>.ignore_idempotency_token
-			// in generator.yaml.
-			resConfig := m.cfg.GetResourceConfig(crdName)
-			if resConfig != nil && resConfig.IgnoreIdempotencyToken &&
-				(memberShapeRef.IdempotencyToken || memberShapeRef.Shape.IdempotencyToken) {
-				continue
+			// This filtering is on by default. Set include_idempotency_token
+			// to true in generator.yaml to keep these fields.
+			if memberShapeRef.IdempotencyToken || memberShapeRef.Shape.IdempotencyToken {
+				resConfig := m.cfg.GetResourceConfig(crdName)
+				if resConfig == nil || !resConfig.IncludeIdempotencyToken {
+					continue
+				}
 			}
 
 			// If this is the wrapper field and we have input_wrapper_field_path

--- a/pkg/model/model_ec2_test.go
+++ b/pkg/model/model_ec2_test.go
@@ -126,7 +126,6 @@ func TestEC2_Volume(t *testing.T) {
 
 	expSpecFieldCamel := []string{
 		"AvailabilityZone",
-		"ClientToken",
 		"DryRun",
 		"Encrypted",
 		"IOPS",

--- a/pkg/testdata/models/apis/emr-serverless/0000-00-00/generator-include-idempotency-token.yaml
+++ b/pkg/testdata/models/apis/emr-serverless/0000-00-00/generator-include-idempotency-token.yaml
@@ -6,6 +6,7 @@ sdk_names:
   model_name: emr-serverless
 resources:
   Application:
+      include_idempotency_token: true
       fields:
           WorkerTypeSpecifications:
             from:


### PR DESCRIPTION
## Make `ignore_idempotency_token` opt-out instead of opt-in

Idempotency token fields (e.g. `ClientToken`) are SDK implementation details auto-filled by middleware. Previously, each controller had to explicitly set `ignore_idempotency_token: true` to exclude them from CRDs.

This PR flips the default: idempotency token fields are now excluded automatically. Controllers that need to keep them can set `include_idempotency_token: true`.

### Changes
- Renamed `IgnoreIdempotencyToken` to `IncludeIdempotencyToken` in `ResourceConfig`
- Inverted filtering logic in `model.go`
- Updated affected tests (EC2, MQ, EMRContainers, EMR Serverless)
- Added opt-in validation test
- 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
