### PR TITLE
fix: fail on missing CRDs for `compat-check` command

### DIFF
--- a/cmd/ack-generate/command/crd_compat_check.go
+++ b/cmd/ack-generate/command/crd_compat_check.go
@@ -70,7 +70,7 @@ func checkCRDCompat(cmd *cobra.Command, args []string) error {
 
 	if len(crdFiles) == 0 {
 		fmt.Println("No CRD files found, nothing to check.")
-		return nil
+		return fmt.Errorf("no CRD files found in %v", optCRDPaths)
 	}
 
 	hasBreaking := false


### PR DESCRIPTION
Description of changes:
This command is meant to be ran inside an ACK controller directory.
Currently it has been silently failing if it can't discover missing
CRDs. With this change, we will fail if we can't detect CRD files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
