### PR TITLE
Add fallback to ShapeRef documentation when Shape.Documenation is empty

### DIFF
--- a/pkg/model/attr.go
+++ b/pkg/model/attr.go
@@ -24,6 +24,7 @@ type Attr struct {
 	Names       names.Names
 	GoType      string
 	Shape       *awssdkmodel.Shape
+	ShapeRef    *awssdkmodel.ShapeRef
 	GoTag       string
 	IsImmutable bool
 }
@@ -32,12 +33,28 @@ func NewAttr(
 	names names.Names,
 	goType string,
 	shape *awssdkmodel.Shape,
+	shapeRef *awssdkmodel.ShapeRef,
 ) *Attr {
 	return &Attr{
-		Names:  names,
-		GoType: goType,
-		Shape:  shape,
+		Names:    names,
+		GoType:   goType,
+		Shape:    shape,
+		ShapeRef: shapeRef,
 	}
+}
+
+// Documentation returns the godoc-formatted documentation for this attribute.
+// It checks the Shape documentation first (type-level docs), then falls back
+// to the ShapeRef documentation (member-specific docs for fields like
+// primitives where the Shape is shared).
+func (a *Attr) Documentation() string {
+	if a.Shape != nil && a.Shape.Documentation != "" {
+		return a.Shape.Documentation
+	}
+	if a.ShapeRef != nil && a.ShapeRef.Documentation != "" {
+		return a.ShapeRef.Documentation
+	}
+	return ""
 }
 
 // GetGoTag returns the Go Tag to inject for this attribute. If the GoTag

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -638,7 +638,7 @@ func (m *Model) GetTypeDefs() ([]*TypeDef, error) {
 			if err != nil {
 				return nil, err
 			}
-			attrs[memberName] = NewAttr(memberNames, gt, memberShape)
+			attrs[memberName] = NewAttr(memberNames, gt, memberShape, memberRef)
 		}
 		if len(attrs) == 0 {
 			// Just ignore these...
@@ -951,7 +951,7 @@ func addReferenceAttribute(td *TypeDef, attr *Attr) error {
 	if attr.Shape.Type == "list" {
 		refAttrGoType = fmt.Sprintf("[]%s", refAttrGoType)
 	}
-	refAttr := NewAttr(refAttrName, refAttrGoType, refAttrShape)
+	refAttr := NewAttr(refAttrName, refAttrGoType, refAttrShape, nil)
 	// Add reference attribute to the parent field typedef
 	td.Attrs[refAttrName.Original] = refAttr
 	return nil

--- a/templates/apis/type_def.go.tpl
+++ b/templates/apis/type_def.go.tpl
@@ -5,8 +5,8 @@
 type {{ .Names.Camel }} struct {
 {{- range $attrName := .SortedAttrNames }}
 {{- $attr := (index $.Attrs $attrName) }}
-	{{- if $attr.Shape.Documentation }}
-	{{ $attr.Shape.Documentation }}
+	{{- if $attr.Documentation }}
+	{{ $attr.Documentation }}
 	{{- end }}
 	{{- if $attr.IsImmutable }}
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"

--- a/templates/crossplane/apis/type_def.go.tpl
+++ b/templates/crossplane/apis/type_def.go.tpl
@@ -3,8 +3,8 @@
 type {{ .Names.Camel }} struct {
 {{- range $attrName := .SortedAttrNames }}
 {{- $attr := (index $.Attrs $attrName) }}
-	{{- if $attr.Shape }}
-	{{ $attr.Shape.Documentation }}
+	{{- if $attr.Documentation }}
+	{{ $attr.Documentation }}
 	{{- end }}
 	{{ $attr.Names.Camel }} {{ $attr.GoType }} `json:"{{ $attr.Names.CamelLower }},omitempty"`
 {{- end }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Primitive fields (string, integer, boolean, etc) fields that were nested in an object didn't have their CRD descriptions populated with the contents to their API shape's `#documentation` trait. This was due the TypeDef Attrs using a generic primitive shape instead the member's ShapeRef. This PR adds a fallback to using ShapeRef.Documentation when Shape.Documentation.

- Update Attr type to include ShapeRef property
- Add Attr.Documentation() func to handle fallback to ShapeRef.Documentation if Shape.Documentation is unavailable
- Update type_def.go.tpl to use new Attr.Documentation() func

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
