### PR TITLE
Handle double and long shape types in setSDKForScalar for list members

### DIFF
--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1765,6 +1765,16 @@ func setSDKForScalar(
 		}
 		out += fmt.Sprintf("%stemp := int32(%s)\n", indent, setTo)
 		out += fmt.Sprintf("%s%s = &temp\n", indent, targetVarPath)
+	} else if shape.Type == "double" || shape.Type == "long" {
+		targetVarPath := targetVarName
+		if targetFieldName != "" {
+			targetVarPath += "." + targetFieldName
+		}
+		if isListMember {
+			out += fmt.Sprintf("%s%s = %s\n", indent, targetVarPath, setTo)
+		} else {
+			out += fmt.Sprintf("%s%s = %s\n", indent, targetVarPath, strings.TrimPrefix(setTo, "*"))
+		}
 	} else {
 
 		targetVarPath := targetVarName

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -6656,3 +6656,55 @@ func TestSetSDK_QuickSight_DataSet_Update(t *testing.T) {
 	// should also use value-type access
 	assert.NotContains(got, "= &f6elemf0f0f0iter.Time")
 }
+
+// TestSetSDK_QuickSight_Analysis_Create tests that the SetSDK code generation
+// for the QuickSight Analysis resource correctly handles "double" type list
+// members. The Analysis Definition contains DecimalParameterDeclaration with
+// DefaultValues.StaticValues which is []float64 in the SDK but []*float64 in
+// the CRD. The generated code must dereference the CRD pointer element (*iter)
+// when assigning to the SDK value element.
+func TestSetSDK_QuickSight_Analysis_Create(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "quicksight")
+
+	crd := testutil.GetCRDByName(t, g, "Analysis")
+	require.NotNil(crd)
+	assert.NotNil(crd.Ops.Create)
+
+	got, err := code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1)
+	require.NoError(err)
+
+	// --- Double list members (DecimalParameterDeclaration.DefaultValues.StaticValues) ---
+	// The StaticValues field is []float64 in the SDK (value type) but
+	// []*float64 in the CRD (pointer type). When iterating over the CRD
+	// slice, the loop variable is *float64 and must be dereferenced to
+	// assign to the SDK's float64 element variable.
+	assert.Contains(got, "[]float64{}")
+	// The dereference must be present: elem = *iter
+	assert.Contains(got, "= *f2f6elemf1f0f1iter")
+	// Must NOT have the broken non-dereferenced assignment
+	assert.NotContains(got, "= f2f6elemf1f0f1iter\n")
+}
+
+// TestSetSDK_QuickSight_Analysis_Update tests that the same double list
+// dereference fix applies to the Update operation.
+func TestSetSDK_QuickSight_Analysis_Update(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "quicksight")
+
+	crd := testutil.GetCRDByName(t, g, "Analysis")
+	require.NotNil(crd)
+	assert.NotNil(crd.Ops.Update)
+
+	got, err := code.SetSDK(crd.Config(), crd, model.OpTypeUpdate, "r.ko", "res", 1)
+	require.NoError(err)
+
+	// Same pattern as Create: double list elements must be dereferenced
+	assert.Contains(got, "[]float64{}")
+	assert.Contains(got, "= *f2f6elemf1f0f1iter")
+	assert.NotContains(got, "= f2f6elemf1f0f1iter\n")
+}

--- a/pkg/generate/code/set_sdk_whitebox_test.go
+++ b/pkg/generate/code/set_sdk_whitebox_test.go
@@ -115,6 +115,70 @@ func TestSetSDKForScalar(t *testing.T) {
 	res.Temperature = &temperatureCopy
 `,
 		},
+		{
+			// "double" maps to float64 natively — no range check or cast
+			// needed. In non-list context, the CRD source is *float64 and
+			// the SDK target is *float64, so we strip the dereference.
+			name:            "double scalar non-list",
+			targetFieldName: "Value",
+			targetVarName:   "res",
+			targetVarType:   "structure",
+			sourceFieldPath: "Value",
+			sourceVarName:   "ko.Spec.Value",
+			isListMember:    false,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type: "double",
+				},
+				OriginalMemberName: "Value",
+			},
+			indentLevel: 1,
+			expected:    "\tres.Value = ko.Spec.Value\n",
+		},
+		{
+			// In a list context, the CRD source element is *float64 but
+			// the SDK target element is float64 (value type). The generated
+			// code must dereference with *.
+			name:            "double scalar list member",
+			targetFieldName: "",
+			targetVarName:   "f0elem",
+			targetVarType:   "",
+			sourceFieldPath: "Values",
+			sourceVarName:   "f0iter",
+			isListMember:    true,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type:      "double",
+					ShapeName: "Double",
+				},
+				OriginalMemberName: "Values",
+				OrigShapeName:      "Double",
+			},
+			indentLevel: 1,
+			expected:    "\tf0elem = *f0iter\n",
+		},
+		{
+			// "long" maps to int64 natively — no range check or cast needed.
+			// In a list context, the CRD source element is *int64 but the
+			// SDK target element is int64 (value type). Must dereference.
+			name:            "long scalar list member",
+			targetFieldName: "",
+			targetVarName:   "f0elem",
+			targetVarType:   "",
+			sourceFieldPath: "Values",
+			sourceVarName:   "f0iter",
+			isListMember:    true,
+			shapeRef: &awssdkmodel.ShapeRef{
+				Shape: &awssdkmodel.Shape{
+					Type:      "long",
+					ShapeName: "Long",
+				},
+				OriginalMemberName: "Values",
+				OrigShapeName:      "Long",
+			},
+			indentLevel: 1,
+			expected:    "\tf0elem = *f0iter\n",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/testdata/codegen/sdk-codegen/aws-models/quicksight.json
+++ b/pkg/testdata/codegen/sdk-codegen/aws-models/quicksight.json
@@ -6189,6 +6189,22573 @@
         "smithy.api#error": "client",
         "smithy.api#httpError": 404
       }
+    },
+    "com.amazonaws.quicksight#SelectedTooltipType": {
+      "type": "enum",
+      "members": {
+        "BASIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BASIC"
+          }
+        },
+        "DETAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DETAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomizationAdditionalFieldsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2500
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DestinationParameterValueConfiguration": {
+      "type": "structure",
+      "members": {
+        "CustomValuesConfiguration": {
+          "target": "com.amazonaws.quicksight#CustomValuesConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of custom values for destination parameter in <code>DestinationParameterValueConfiguration</code>.</p>"
+          }
+        },
+        "SelectAllValueOptions": {
+          "target": "com.amazonaws.quicksight#SelectAllValueOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that selects all options.</p>"
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the destination parameter.</p>"
+          }
+        },
+        "SourceField": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source field ID of the destination parameter.</p>"
+          }
+        },
+        "SourceColumn": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of destination parameter values.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlLayoutList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetControlLayout"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#TableConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "ConditionalFormatting": {
+          "target": "com.amazonaws.quicksight#TableConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for a <code>PivotTableVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A table visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/tabular.html\">Using tables as visuals</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "Elements": {
+          "target": "com.amazonaws.quicksight#FreeFromLayoutElementList",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements that are included in a free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutCanvasSizeOptions"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a free-form layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UpdateAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "AwsAccountId": {
+          "target": "com.amazonaws.quicksight#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services account that contains the analysis that you're updating.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for the analysis that you're updating. This ID displays in the URL of the\n            analysis.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#AnalysisName",
+          "traits": {
+            "smithy.api#documentation": "<p>A descriptive name for the analysis that you're updating. This name displays for the\n            analysis in the Amazon Quick Sight console.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Parameters": {
+          "target": "com.amazonaws.quicksight#Parameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter names and override values that you want to use. An analysis can have \n            any parameter type, and some parameters might accept multiple values. </p>"
+          }
+        },
+        "SourceEntity": {
+          "target": "com.amazonaws.quicksight#AnalysisSourceEntity",
+          "traits": {
+            "smithy.api#documentation": "<p>A source entity to use for the analysis that you're updating. This metadata structure\n            contains details that describe a source template and one or more datasets.</p>"
+          }
+        },
+        "ThemeArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the theme to apply to the analysis that you're\n            creating. To see the theme in the Amazon Quick Sight console, make sure that you have access to\n            it.</p>"
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.quicksight#AnalysisDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition of an analysis.</p>\n         <p>A definition is the data model of all features in a Dashboard, Template, or Analysis.</p>"
+          }
+        },
+        "ValidationStrategy": {
+          "target": "com.amazonaws.quicksight#ValidationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The option to relax the validation needed to update an analysis with definition objects. This skips the validation step for specific errors.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingIconSet": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression that determines the formatting configuration for the icon set.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IconSetType": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIconSetType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the icon set type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for icon set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CalculatedField": {
+      "type": "structure",
+      "members": {
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The data set that is used in this calculated field.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#ColumnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the calculated field.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Expression": {
+          "target": "com.amazonaws.quicksight#CalculatedFieldExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression of the calculated field.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The calculated field of an analysis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilteredVisualsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SmallMultiplesAxisProperties": {
+      "type": "structure",
+      "members": {
+        "Scale": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesAxisScale",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether scale of the axes are shared or independent. The default value is <code>SHARED</code>.</p>"
+          }
+        },
+        "Placement": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesAxisPlacement",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the placement of the axis. By default, axes are rendered <code>OUTSIDE</code> of the panels. Axes with <code>INDEPENDENT</code> scale are rendered <code>INSIDE</code> the panels.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configures the properties of a chart's axes that are used by small multiples panels.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Visibility": {
+      "type": "enum",
+      "members": {
+        "HIDDEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIDDEN"
+          }
+        },
+        "VISIBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VISIBLE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartMarkerShape": {
+      "type": "enum",
+      "members": {
+        "CIRCLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE"
+          }
+        },
+        "TRIANGLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRIANGLE"
+          }
+        },
+        "SQUARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SQUARE"
+          }
+        },
+        "DIAMOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND"
+          }
+        },
+        "ROUNDED_SQUARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROUNDED_SQUARE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CreateAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "AwsAccountId": {
+          "target": "com.amazonaws.quicksight#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services account where you are creating an analysis.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for the analysis that you're creating. This ID displays in the URL of the\n            analysis.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#AnalysisName",
+          "traits": {
+            "smithy.api#documentation": "<p>A descriptive name for the analysis that you're creating. This name displays for the\n            analysis in the Amazon Quick Sight console. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Parameters": {
+          "target": "com.amazonaws.quicksight#Parameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter names and override values that you want to use. An analysis can have \n            any parameter type, and some parameters might accept multiple values. </p>"
+          }
+        },
+        "Permissions": {
+          "target": "com.amazonaws.quicksight#ResourcePermissionList",
+          "traits": {
+            "smithy.api#documentation": "<p>A structure that describes the principals and the resource-level permissions on an\n            analysis. You can use the <code>Permissions</code> structure to grant permissions by\n            providing a list of Identity and Access Management (IAM) action information for each\n            principal listed by Amazon Resource Name (ARN). </p>\n         <p>To specify no permissions, omit <code>Permissions</code>.</p>"
+          }
+        },
+        "SourceEntity": {
+          "target": "com.amazonaws.quicksight#AnalysisSourceEntity",
+          "traits": {
+            "smithy.api#documentation": "<p>A source entity to use for the analysis that you're creating. This metadata structure\n            contains details that describe a source template and one or more datasets.</p>\n         <p>Either a <code>SourceEntity</code> or a <code>Definition</code> must be provided in \n            order for the request to be valid.</p>"
+          }
+        },
+        "ThemeArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for the theme to apply to the analysis that you're creating. To see the theme\n            in the Amazon Quick Sight console, make sure that you have access to it.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.quicksight#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a map of the key-value pairs for the resource tag or tags assigned to the\n            analysis.</p>"
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.quicksight#AnalysisDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition of an analysis.</p>\n         <p>A definition is the data model of all features in a Dashboard, Template, or Analysis.</p>\n         <p>Either a <code>SourceEntity</code> or a <code>Definition</code> must be provided in \n            order for the request to be valid.</p>"
+          }
+        },
+        "ValidationStrategy": {
+          "target": "com.amazonaws.quicksight#ValidationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The option to relax the validation needed to create an analysis with definition objects. This skips the validation step for specific errors.</p>"
+          }
+        },
+        "FolderArns": {
+          "target": "com.amazonaws.quicksight#FolderArnList",
+          "traits": {
+            "smithy.api#documentation": "<p>When you create the analysis, Amazon Quick Sight adds the analysis to these folders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.quicksight#Padding": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FieldLabelType": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the field that is targeted by the field\n            label.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the field label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field label type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#FunnelChartDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field wells of a funnel chart. Values are grouped by category fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#FunnelChartMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a funnel chart. Values are aggregated based on categories.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a <code>FunnelChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisSourceTemplate": {
+      "type": "structure",
+      "members": {
+        "DataSetReferences": {
+          "target": "com.amazonaws.quicksight#DataSetReferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset references of the source template of an analysis.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the source template of an analysis.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source template of an analysis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#ComboChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#ComboChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>ComboChartVisual</code>.</p>"
+          }
+        },
+        "BarsArrangement": {
+          "target": "com.amazonaws.quicksight#BarsArrangement",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the bar arrangement in a combo chart. The following are valid values in this structure:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CLUSTERED</code>: For clustered bar combo charts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STACKED</code>: For stacked bar combo charts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STACKED_PERCENT</code>: Do not use. If you use this value, the operation returns a validation error.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CategoryAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The category axis of a combo chart.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of a combo chart category (group/color) field well.</p>"
+          }
+        },
+        "PrimaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, and axis step) of a combo chart's primary y-axis (bar) field well.</p>"
+          }
+        },
+        "PrimaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of a combo chart's primary y-axis (bar) field well.</p>"
+          }
+        },
+        "SecondaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, axis step) of a combo chart's secondary y-axis (line) field well.</p>"
+          }
+        },
+        "SecondaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of a combo chart's secondary y-axis(line) field well.</p>"
+          }
+        },
+        "SingleAxisOptions": {
+          "target": "com.amazonaws.quicksight#SingleAxisOptions"
+        },
+        "ColorLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of a combo chart's color field well.</p>"
+          }
+        },
+        "DefaultSeriesSettings": {
+          "target": "com.amazonaws.quicksight#ComboChartDefaultSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default presentation of all series in <code>ComboChartVisual</code>.</p>"
+          }
+        },
+        "Series": {
+          "target": "com.amazonaws.quicksight#ComboSeriesItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>The series item configuration of a <code>ComboChartVisual</code>.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "BarDataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>\n         <p>The data label options for a bar in a combo chart.</p>"
+          }
+        },
+        "LineDataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>\n         <p>The data label options for a line in a combo chart.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "ReferenceLines": {
+          "target": "com.amazonaws.quicksight#ReferenceLineList",
+          "traits": {
+            "smithy.api#documentation": "<p>The reference line setup of the visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>ComboChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartArcConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ForegroundColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the arc foreground color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the arc of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TotalOptions": {
+      "type": "structure",
+      "members": {
+        "TotalsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration for the total cells.</p>"
+          }
+        },
+        "Placement": {
+          "target": "com.amazonaws.quicksight#TableTotalsPlacement",
+          "traits": {
+            "smithy.api#documentation": "<p>The placement (start, end) for the total cells.</p>"
+          }
+        },
+        "ScrollStatus": {
+          "target": "com.amazonaws.quicksight#TableTotalsScrollStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The scroll status (pinned, scrolled) for the total cells.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label string for the total cells.</p>"
+          }
+        },
+        "TotalCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Cell styling options for the total cells.</p>"
+          }
+        },
+        "TotalAggregationOptions": {
+          "target": "com.amazonaws.quicksight#TotalAggregationOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The total aggregation settings for each value field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The total options for a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionRepeatDimensionConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#BodySectionRepeatDimensionConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomParameterValues": {
+      "type": "structure",
+      "members": {
+        "StringValues": {
+          "target": "com.amazonaws.quicksight#StringDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of string-type parameter values.</p>"
+          }
+        },
+        "IntegerValues": {
+          "target": "com.amazonaws.quicksight#IntegerDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of integer-type parameter values.</p>"
+          }
+        },
+        "DecimalValues": {
+          "target": "com.amazonaws.quicksight#DecimalDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of decimal-type parameter values.</p>"
+          }
+        },
+        "DateTimeValues": {
+          "target": "com.amazonaws.quicksight#DateTimeDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of datetime-type parameter values.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The customized parameter values.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ConditionalFormattingOptions": {
+          "target": "com.amazonaws.quicksight#KPIConditionalFormattingOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting options of a KPI visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldImageConfiguration": {
+      "type": "structure",
+      "members": {
+        "SizingOptions": {
+          "target": "com.amazonaws.quicksight#TableCellImageSizingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sizing options for the table image configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The image configuration of a table field URL.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialSolidColor": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the color.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.quicksight#GeospatialColorState",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables and disables the view state of the color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition for a solid color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIConditionalFormattingOption": {
+      "type": "structure",
+      "members": {
+        "PrimaryValue": {
+          "target": "com.amazonaws.quicksight#KPIPrimaryValueConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the primary value of a KPI visual.</p>"
+          }
+        },
+        "ProgressBar": {
+          "target": "com.amazonaws.quicksight#KPIProgressBarConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the progress bar of a KPI visual.</p>"
+          }
+        },
+        "ActualValue": {
+          "target": "com.amazonaws.quicksight#KPIActualValueConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the actual value of a KPI visual.</p>"
+          }
+        },
+        "ComparisonValue": {
+          "target": "com.amazonaws.quicksight#KPIComparisonValueConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the comparison value of a KPI visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting options of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "FreeFormLayout": {
+          "target": "com.amazonaws.quicksight#FreeFormSectionLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The free-form layout configuration of a section.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The layout configuration of a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisScale": {
+      "type": "structure",
+      "members": {
+        "Linear": {
+          "target": "com.amazonaws.quicksight#AxisLinearScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The linear axis scale setup.</p>"
+          }
+        },
+        "Logarithmic": {
+          "target": "com.amazonaws.quicksight#AxisLogarithmicScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The logarithmic axis scale setup.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The scale setup\n            options for a numeric axis display.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapShapeConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the filled map shape.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Format": {
+          "target": "com.amazonaws.quicksight#ShapeConditionalFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting that determines the background color of a filled map's shape.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting that determines the shape of the filled map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ArcConfiguration": {
+      "type": "structure",
+      "members": {
+        "ArcAngle": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The option that determines the arc angle of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "ArcThickness": {
+          "target": "com.amazonaws.quicksight#ArcThicknessOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the arc thickness of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The arc configuration of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIVisualStandardLayoutType": {
+      "type": "enum",
+      "members": {
+        "CLASSIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLASSIC"
+          }
+        },
+        "VERTICAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VERTICAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericEqualityDrillDownFilter": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The value of the double input numeric drill down filter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The numeric equality type drill down filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category sort options of a radar chart.</p>"
+          }
+        },
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The category items limit for a radar chart.</p>"
+          }
+        },
+        "ColorSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color sort configuration of a radar chart.</p>"
+          }
+        },
+        "ColorItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The color items limit of a radar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a <code>RadarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateDimensionField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>DateDimensionField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DateGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The date granularity of the <code>DateDimensionField</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>YEAR</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>QUARTER</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>MONTH</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WEEK</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DAY</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>HOUR</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>MINUTE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SECOND</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>MILLISECOND</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom hierarchy ID.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#DateTimeFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dimension type field with date type columns.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the data labels.</p>"
+          }
+        },
+        "CategoryLabelVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the category field labels.</p>"
+          }
+        },
+        "MeasureLabelVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the measure field labels.</p>"
+          }
+        },
+        "DataLabelTypes": {
+          "target": "com.amazonaws.quicksight#DataLabelTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the data label type.</p>"
+          }
+        },
+        "Position": {
+          "target": "com.amazonaws.quicksight#DataLabelPosition",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the position of the data labels.</p>"
+          }
+        },
+        "LabelContent": {
+          "target": "com.amazonaws.quicksight#DataLabelContent",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the content of the data labels.</p>"
+          }
+        },
+        "LabelFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the font configuration of the data labels.</p>"
+          }
+        },
+        "LabelColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color of the data labels.</p>"
+          }
+        },
+        "Overlap": {
+          "target": "com.amazonaws.quicksight#DataLabelOverlap",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether overlap is enabled or disabled for the data labels.</p>"
+          }
+        },
+        "TotalsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the total.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the data labels.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Opacity": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DecimalParameter": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>A display name for the decimal parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#SensitiveDoubleList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values for the decimal parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A decimal parameter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "HeatMapRowSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The field sort configuration of the rows fields.</p>"
+          }
+        },
+        "HeatMapColumnSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column sort configuration for heat map for columns that aren't a part of a field well.</p>"
+          }
+        },
+        "HeatMapRowItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of rows that are displayed in a heat map.</p>"
+          }
+        },
+        "HeatMapColumnItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of columns that are displayed in a heat map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a heat map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SetParameterValueConfiguration": {
+      "type": "structure",
+      "members": {
+        "DestinationParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination parameter name of the <code>SetParameterValueConfiguration</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#DestinationParameterValueConfiguration",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of adding parameters in action.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetElementRenderingRuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetElementRenderingRule"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerColorField": {
+      "type": "structure",
+      "members": {
+        "ColorDimensionsFields": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of color dimension fields.</p>"
+          }
+        },
+        "ColorValuesFields": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of color measure fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color field that defines a gradient or categorical style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SpatialStaticFile": {
+      "type": "structure",
+      "members": {
+        "StaticFileId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the spatial static file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.quicksight#StaticFileSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the spatial static file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A static file that contains the geospatial data.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericEqualityMatchOperator": {
+      "type": "enum",
+      "members": {
+        "EQUALS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EQUALS"
+          }
+        },
+        "DOES_NOT_EQUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOES_NOT_EQUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutScreenCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "ResizeOption": {
+          "target": "com.amazonaws.quicksight#ResizeOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This value determines the layout behavior when the viewport is resized.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FIXED</code>: A fixed width will be used when optimizing the layout. In\n                    the Quick Sight console, this option is called <code>Classic</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RESPONSIVE</code>: The width of the canvas will be responsive and\n                    optimized to the view port. In the Quick Sight console, this option is called <code>Tiled</code>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "OptimizedViewPortWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width that the view port will be optimized for when the layout renders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the sizing of the canvas used in a grid layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TimeBasedForecastProperties": {
+      "type": "structure",
+      "members": {
+        "PeriodsForward": {
+          "target": "com.amazonaws.quicksight#PeriodsForward",
+          "traits": {
+            "smithy.api#documentation": "<p>The periods forward setup of a forecast computation.</p>"
+          }
+        },
+        "PeriodsBackward": {
+          "target": "com.amazonaws.quicksight#PeriodsBackward",
+          "traits": {
+            "smithy.api#documentation": "<p>The periods backward setup of a forecast computation.</p>"
+          }
+        },
+        "UpperBoundary": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The upper boundary setup of a forecast computation.</p>"
+          }
+        },
+        "LowerBoundary": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The lower boundary setup of a forecast computation.</p>"
+          }
+        },
+        "PredictionInterval": {
+          "target": "com.amazonaws.quicksight#PredictionInterval",
+          "traits": {
+            "smithy.api#documentation": "<p>The prediction interval setup of a forecast computation.</p>"
+          }
+        },
+        "Seasonality": {
+          "target": "com.amazonaws.quicksight#Seasonality",
+          "traits": {
+            "smithy.api#documentation": "<p>The seasonality setup of a forecast computation. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NULL</code>: The input is set to <code>NULL</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULL</code>: The input is set to a custom value.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The forecast properties setup of a forecast in the line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineStaticDataConfiguration": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.quicksight#SensitiveDouble",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The double input of the static data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The static data configuration of the reference line data configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ClusterMarkerConfiguration": {
+      "type": "structure",
+      "members": {
+        "ClusterMarker": {
+          "target": "com.amazonaws.quicksight#ClusterMarker",
+          "traits": {
+            "smithy.api#documentation": "<p>The cluster marker that is a part of the cluster marker configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The cluster marker configuration of the geospatial map selected point style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelPosition": {
+      "type": "enum",
+      "members": {
+        "INSIDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSIDE"
+          }
+        },
+        "OUTSIDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OUTSIDE"
+          }
+        },
+        "LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEFT"
+          }
+        },
+        "TOP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TOP"
+          }
+        },
+        "BOTTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOTTOM"
+          }
+        },
+        "RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RIGHT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldLinkConfiguration": {
+      "type": "structure",
+      "members": {
+        "Target": {
+          "target": "com.amazonaws.quicksight#URLTargetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL target (new tab, new window, same tab) for the table link configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Content": {
+          "target": "com.amazonaws.quicksight#TableFieldLinkContentConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL content (text, icon) for the table link configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The link configuration of a table field URL.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ListControlSearchOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the search options in a list control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of the search options in a list control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TrendArrowOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the trend arrows.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of trend arrows in a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisSourceEntity": {
+      "type": "structure",
+      "members": {
+        "SourceTemplate": {
+          "target": "com.amazonaws.quicksight#AnalysisSourceTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>The source template for the source entity of the analysis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source entity of an analysis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCircleRadius": {
+      "type": "structure",
+      "members": {
+        "Radius": {
+          "target": "com.amazonaws.quicksight#GeospatialRadius",
+          "traits": {
+            "smithy.api#documentation": "<p>The positive value for the radius of a circle.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The geospatial radius for a circle.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "GroupBy": {
+          "target": "com.amazonaws.quicksight#WordCloudDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The group by field well of a word cloud. Values are grouped by group by fields.</p>"
+          }
+        },
+        "Size": {
+          "target": "com.amazonaws.quicksight#WordCloudMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The size field well of a word cloud. Values are aggregated based on group by fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field wells of a word cloud.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TimeEqualityFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of a <code>TimeEquality</code> filter.</p>\n         <p>This field is mutually exclusive to <code>RollingDate</code> and <code>ParameterName</code>.</p>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter whose value should be used for the filter value.</p>\n         <p>This field is mutually exclusive to <code>Value</code> and <code>RollingDate</code>.</p>"
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>"
+          }
+        },
+        "RollingDate": {
+          "target": "com.amazonaws.quicksight#RollingDateConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The rolling date input for the <code>TimeEquality</code> filter.</p>\n         <p>This field is mutually exclusive to <code>Value</code> and <code>ParameterName</code>.</p>"
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>TimeEqualityFilter</code> filters values that are equal to a given value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionAfterPageBreak": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.quicksight#SectionPageBreakStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that enables or disables a page break at the end of a section.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a page break after a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterControlList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ParameterControl"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DecalSettingsConfiguration": {
+      "type": "structure",
+      "members": {
+        "CustomDecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettingsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 50 decal settings.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Decal settings configuration for a column</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "RowSort": {
+          "target": "com.amazonaws.quicksight#RowSortList",
+          "traits": {
+            "smithy.api#documentation": "<p>The field sort options for rows in the table.</p>"
+          }
+        },
+        "PaginationConfiguration": {
+          "target": "com.amazonaws.quicksight#PaginationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination configuration (page size, page number) for the table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration for a <code>TableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VerticalTextAlignment": {
+      "type": "enum",
+      "members": {
+        "TOP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TOP"
+          }
+        },
+        "MIDDLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIDDLE"
+          }
+        },
+        "BOTTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOTTOM"
+          }
+        },
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of info icon label options.</p>"
+          }
+        },
+        "InfoIconText": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconText",
+          "traits": {
+            "smithy.api#documentation": "<p> The text content of info icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display info icons for filters and parameters.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldOrderList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FieldId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialColorState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DataFieldBarSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>Field ID of the field that you are setting the series configuration for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#SensitiveString",
+          "traits": {
+            "smithy.api#documentation": "<p>Field value of the field that you are setting the series configuration for.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#BarChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Options that determine the presentation of bar series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data field series item configuration of a  <code>BarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FontConfiguration": {
+      "type": "structure",
+      "members": {
+        "FontSize": {
+          "target": "com.amazonaws.quicksight#FontSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the text display size.</p>"
+          }
+        },
+        "FontDecoration": {
+          "target": "com.amazonaws.quicksight#FontDecoration",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the appearance of decorative lines on the text.</p>"
+          }
+        },
+        "FontColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color of the text.</p>"
+          }
+        },
+        "FontWeight": {
+          "target": "com.amazonaws.quicksight#FontWeight",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the text display weight, or boldness.</p>"
+          }
+        },
+        "FontStyle": {
+          "target": "com.amazonaws.quicksight#FontStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the text display face that is inherited by the given font family.</p>"
+          }
+        },
+        "FontFamily": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The font family that you want to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configures the display properties of the given text.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormattingOption": {
+      "type": "structure",
+      "members": {
+        "Cell": {
+          "target": "com.amazonaws.quicksight#PivotTableCellConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell conditional formatting option for a pivot table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Conditional formatting options for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionTrigger": {
+      "type": "enum",
+      "members": {
+        "DATA_POINT_CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_CLICK"
+          }
+        },
+        "DATA_POINT_MENU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_MENU"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetDefinition": {
+      "type": "structure",
+      "members": {
+        "SheetId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a sheet.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the sheet.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.quicksight#SheetDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the sheet.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#SheetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the sheet. This name is displayed on the sheet's tab in the Quick Suite\n            console.</p>"
+          }
+        },
+        "ParameterControls": {
+          "target": "com.amazonaws.quicksight#ParameterControlList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of parameter controls that are on a sheet.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/parameters-controls.html\">Using a Control with a Parameter in Amazon Quick Sight</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "FilterControls": {
+          "target": "com.amazonaws.quicksight#FilterControlList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of filter controls that are on a sheet.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/filter-controls.html\">Adding filter controls to analysis sheets</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "Visuals": {
+          "target": "com.amazonaws.quicksight#VisualList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the visuals that are on a sheet. Visual placement is determined by the layout of the sheet.</p>"
+          }
+        },
+        "TextBoxes": {
+          "target": "com.amazonaws.quicksight#SheetTextBoxList",
+          "traits": {
+            "smithy.api#documentation": "<p>The text boxes that are on a sheet.</p>"
+          }
+        },
+        "Images": {
+          "target": "com.amazonaws.quicksight#SheetImageList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of images on a sheet.</p>"
+          }
+        },
+        "Layouts": {
+          "target": "com.amazonaws.quicksight#LayoutList",
+          "traits": {
+            "smithy.api#documentation": "<p>Layouts define how the components of a sheet are arranged.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/types-of-layout.html\">Types of layout</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "SheetControlLayouts": {
+          "target": "com.amazonaws.quicksight#SheetControlLayoutList",
+          "traits": {
+            "smithy.api#documentation": "<p>The control layouts of the sheet.</p>"
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.quicksight#SheetContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The layout content type of the sheet. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PAGINATED</code>: Creates a sheet for a paginated report.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INTERACTIVE</code>: Creates a sheet for an interactive dashboard.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomActionDefaults": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionDefaults",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of visual custom actions for the sheet.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A sheet is an object that contains a set of visuals that\n            are viewed together on one page in a paginated report. Every analysis and dashboard must contain at least one sheet.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "LineChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#LineChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a line chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableConditionalFormattingOption": {
+      "type": "structure",
+      "members": {
+        "Cell": {
+          "target": "com.amazonaws.quicksight#TableCellConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell conditional formatting option for a table.</p>"
+          }
+        },
+        "Row": {
+          "target": "com.amazonaws.quicksight#TableRowConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The row conditional formatting option for a table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Conditional formatting options for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ConditionalFormattingOptions": {
+          "target": "com.amazonaws.quicksight#GaugeChartConditionalFormattingOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>Conditional formatting options of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualAxisName": {
+      "type": "enum",
+      "members": {
+        "GROUP_BY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GROUP_BY"
+          }
+        },
+        "VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TextControlPlaceholderOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the placeholder options in a text control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of the placeholder options in a text control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#OtherCategories": {
+      "type": "enum",
+      "members": {
+        "INCLUDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INCLUDE"
+          }
+        },
+        "EXCLUDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXCLUDE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomActionOperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#LayerCustomActionOperation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GradientStopList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GradientStop"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ColumnHierarchyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnHierarchy"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ParameterDeclarationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ParameterDeclaration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 400
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DescribeAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "AwsAccountId": {
+          "target": "com.amazonaws.quicksight#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services account that contains the analysis. You must be using the \n            Amazon Web Services account that the analysis is in.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the analysis that you're describing. The ID is part of the URL of the\n            analysis.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageTooltipText": {
+      "type": "structure",
+      "members": {
+        "PlainText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The plain text format.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The text that appears in the sheet image tooltip.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPointStyleOptions": {
+      "type": "structure",
+      "members": {
+        "SelectedPointStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialSelectedPointStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected point styles (point, cluster) of the geospatial map.</p>"
+          }
+        },
+        "ClusterMarkerConfiguration": {
+          "target": "com.amazonaws.quicksight#ClusterMarkerConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The cluster marker configuration of the geospatial point style.</p>"
+          }
+        },
+        "HeatmapConfiguration": {
+          "target": "com.amazonaws.quicksight#GeospatialHeatmapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The heatmap configuration of the geospatial point style.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The point style of the geospatial map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#HeatMapFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#HeatMapSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a heat map.</p>"
+          }
+        },
+        "RowAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the row axis label.</p>"
+          }
+        },
+        "RowLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options of the row that is displayed in a <code>heat map</code>.</p>"
+          }
+        },
+        "ColumnAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the row axis label.</p>"
+          }
+        },
+        "ColumnLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options of the column that is displayed in a heat map.</p>"
+          }
+        },
+        "ColorScale": {
+          "target": "com.amazonaws.quicksight#ColorScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The color options (gradient color, point of divergence) in a heat map.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a heat map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomContentImageScalingConfiguration": {
+      "type": "enum",
+      "members": {
+        "FIT_TO_HEIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIT_TO_HEIGHT"
+          }
+        },
+        "FIT_TO_WIDTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIT_TO_WIDTH"
+          }
+        },
+        "DO_NOT_SCALE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DO_NOT_SCALE"
+          }
+        },
+        "SCALE_TO_VISUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCALE_TO_VISUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ArcAxisConfiguration": {
+      "type": "structure",
+      "members": {
+        "Range": {
+          "target": "com.amazonaws.quicksight#ArcAxisDisplayRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The arc axis range of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "ReserveRange": {
+          "target": "com.amazonaws.quicksight#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The reserved range of the arc axis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The arc axis configuration of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapFieldWells": {
+      "type": "structure",
+      "members": {
+        "TreeMapAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#TreeMapAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a tree map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a tree map.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FontWeight": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#FontWeightName",
+          "traits": {
+            "smithy.api#documentation": "<p>The lexical name for the level of boldness of the text display.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the text display weight, or boldness.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "PluginVisualTableQuerySort": {
+          "target": "com.amazonaws.quicksight#PluginVisualTableQuerySort",
+          "traits": {
+            "smithy.api#documentation": "<p>The table query sorting options for the plugin visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines how the plugin visual sorts the data during query.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NarrativeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 150000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "WaterfallChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#WaterfallChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a waterfall visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomAction": {
+      "type": "structure",
+      "members": {
+        "CustomActionId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the custom action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#ImageCustomActionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the custom action.</p>"
+          }
+        },
+        "Trigger": {
+          "target": "com.amazonaws.quicksight#ImageCustomActionTrigger",
+          "traits": {
+            "smithy.api#documentation": "<p>The trigger of the <code>VisualCustomAction</code>.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CLICK</code>: Initiates a custom action by a left pointer click on a data point.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MENU</code>: Initiates a custom action by right pointer click from the menu.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActionOperations": {
+          "target": "com.amazonaws.quicksight#ImageCustomActionOperationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ImageCustomActionOperations</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A custom action defined on an image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PaperOrientation": {
+      "type": "enum",
+      "members": {
+        "PORTRAIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PORTRAIT"
+          }
+        },
+        "LANDSCAPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LANDSCAPE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PercentileAggregation": {
+      "type": "structure",
+      "members": {
+        "PercentileValue": {
+          "target": "com.amazonaws.quicksight#PercentileValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentile value. This value can be any numeric constant 0\u2013100. A percentile value of 50 computes the median value of the measure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An aggregation based on the percentile of values in a dimension or measure.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionDynamicCategoryDimensionConfiguration": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicDimensionLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of values to use from the column for repetition.</p>"
+          }
+        },
+        "SortByMetrics": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicDimensionSortConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Sort criteria on the column values that you use for repetition. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the <b>Category</b> dataset column and constraints for the dynamic values used to repeat the contents of a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutElementBackgroundStyle": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The background visibility of a free-form layout element.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The background color of a free-form layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The background style configuration of a free-form layout element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisiblePanelRows": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TooltipOptions": {
+      "type": "structure",
+      "members": {
+        "TooltipVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the tooltip is visible.</p>"
+          }
+        },
+        "SelectedTooltipType": {
+          "target": "com.amazonaws.quicksight#SelectedTooltipType",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected type for the tooltip. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>BASIC</code>: A basic tooltip.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DETAILED</code>: A detailed tooltip.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "FieldBasedTooltip": {
+          "target": "com.amazonaws.quicksight#FieldBasedTooltip",
+          "traits": {
+            "smithy.api#documentation": "<p>The setup for the detailed tooltip. The tooltip setup is always saved. The display type is decided based on the tooltip type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options for the visual tooltip.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "ScreenCanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutScreenCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the sizing of the canvas used in a free-form layout.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration options for the canvas of a free-form layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisDisplayRange": {
+      "type": "structure",
+      "members": {
+        "MinMax": {
+          "target": "com.amazonaws.quicksight#AxisDisplayMinMaxRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum and maximum setup of an axis display range.</p>"
+          }
+        },
+        "DataDriven": {
+          "target": "com.amazonaws.quicksight#AxisDisplayDataDrivenRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The data-driven setup of an axis display range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The range setup of a numeric axis display range.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DrillDownFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DrillDownFilter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Analysis": {
+      "type": "structure",
+      "members": {
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the analysis.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the analysis.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#AnalysisName",
+          "traits": {
+            "smithy.api#documentation": "<p>The descriptive name of the analysis.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#ResourceStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status associated with the analysis.</p>"
+          }
+        },
+        "Errors": {
+          "target": "com.amazonaws.quicksight#AnalysisErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>Errors associated with the analysis.</p>"
+          }
+        },
+        "DataSetArns": {
+          "target": "com.amazonaws.quicksight#DataSetArnsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the datasets of the analysis.</p>"
+          }
+        },
+        "ThemeArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the theme of the analysis.</p>"
+          }
+        },
+        "CreatedTime": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the analysis was created.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the analysis was last updated.</p>"
+          }
+        },
+        "Sheets": {
+          "target": "com.amazonaws.quicksight#SheetList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the associated sheets with the unique identifier and name of each sheet.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Metadata structure for an analysis in Quick Sight</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#BarChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#BarChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>BarChartVisual</code>.</p>"
+          }
+        },
+        "Orientation": {
+          "target": "com.amazonaws.quicksight#BarChartOrientation",
+          "traits": {
+            "smithy.api#documentation": "<p>The orientation of the bars in a bar chart visual. There are two valid values in this structure:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HORIZONTAL</code>: Used for charts that have horizontal bars. Visuals that use this value are horizontal bar charts, horizontal stacked bar charts, and horizontal stacked 100% bar charts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>VERTICAL</code>: Used for charts that have vertical bars. Visuals that use this value are vertical bar charts, vertical stacked bar charts, and vertical stacked 100% bar charts.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "BarsArrangement": {
+          "target": "com.amazonaws.quicksight#BarsArrangement",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the arrangement of the bars. The orientation and arrangement of bars determine the type of bar that is used in the visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "SmallMultiplesOptions": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples setup for the visual.</p>"
+          }
+        },
+        "CategoryAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, axis step) for bar chart category.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility and sort icon visibility) for a bar chart.</p>"
+          }
+        },
+        "ValueAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, axis step) for a bar chart value.</p>"
+          }
+        },
+        "ValueLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility and sort icon visibility) for a bar chart value.</p>"
+          }
+        },
+        "ColorLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility and sort icon visibility) for a color that is used in a bar chart.</p>"
+          }
+        },
+        "DefaultSeriesSettings": {
+          "target": "com.amazonaws.quicksight#BarChartDefaultSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default presentation of all bar series in <code>BarChartVisual</code>.</p>"
+          }
+        },
+        "Series": {
+          "target": "com.amazonaws.quicksight#BarSeriesItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>The series item configuration of a  <code>BarChartVisual</code>.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "ReferenceLines": {
+          "target": "com.amazonaws.quicksight#ReferenceLineList",
+          "traits": {
+            "smithy.api#documentation": "<p>The reference line setup of the visual.</p>"
+          }
+        },
+        "ContributionAnalysisDefaults": {
+          "target": "com.amazonaws.quicksight#ContributionAnalysisDefaultList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contribution analysis (anomaly configuration) setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>BarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#IntegerParameterDeclaration": {
+      "type": "structure",
+      "members": {
+        "ParameterValueType": {
+          "target": "com.amazonaws.quicksight#ParameterValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The value type determines whether the parameter is a single-value or multi-value parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that is being declared.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultValues": {
+          "target": "com.amazonaws.quicksight#IntegerDefaultValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The default values of a parameter. If the parameter is a single-value parameter, a maximum of one default value can be provided.</p>"
+          }
+        },
+        "ValueWhenUnset": {
+          "target": "com.amazonaws.quicksight#IntegerValueWhenUnsetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A parameter declaration for the <code>Integer</code> data type.</p>"
+          }
+        },
+        "MappedDataSetParameters": {
+          "target": "com.amazonaws.quicksight#MappedDataSetParameters"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A parameter declaration for the <code>Integer</code> data type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SimpleAttributeAggregationFunction": {
+      "type": "enum",
+      "members": {
+        "UNIQUE_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNIQUE_VALUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PeriodOverPeriodComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The period over period computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NegativeValueDisplayMode": {
+      "type": "enum",
+      "members": {
+        "POSITIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POSITIVE"
+          }
+        },
+        "NEGATIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEGATIVE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineValueLabelConfiguration": {
+      "type": "structure",
+      "members": {
+        "RelativePosition": {
+          "target": "com.amazonaws.quicksight#ReferenceLineValueLabelRelativePosition",
+          "traits": {
+            "smithy.api#documentation": "<p>The relative position of the value label. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>BEFORE_CUSTOM_LABEL</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>AFTER_CUSTOM_LABEL</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the value label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The value label configuration of the label in a reference line.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialHeatmapConfiguration": {
+      "type": "structure",
+      "members": {
+        "HeatmapColor": {
+          "target": "com.amazonaws.quicksight#GeospatialHeatmapColorScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The color scale specification for the heatmap point style.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The heatmap configuration of the geospatial point style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Rows": {
+          "target": "com.amazonaws.quicksight#PivotTableDimensionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rows field well for a pivot table. Values are grouped by rows fields.</p>"
+          }
+        },
+        "Columns": {
+          "target": "com.amazonaws.quicksight#PivotTableDimensionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The columns field well for a pivot table. Values are grouped by columns fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#PivotMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values field well for a pivot table. Values are aggregated based on rows and columns fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well for the pivot table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineLabelHorizontalPosition": {
+      "type": "enum",
+      "members": {
+        "LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEFT"
+          }
+        },
+        "CENTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CENTER"
+          }
+        },
+        "RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RIGHT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BarSeriesItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#BarSeriesItem"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultFilterControlOptions": {
+      "type": "structure",
+      "members": {
+        "DefaultDateTimePickerOptions": {
+          "target": "com.amazonaws.quicksight#DefaultDateTimePickerControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the filter control type of a <code>DateTimePicker</code>.</p>"
+          }
+        },
+        "DefaultListOptions": {
+          "target": "com.amazonaws.quicksight#DefaultFilterListControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>List</code> filter control type.</p>"
+          }
+        },
+        "DefaultDropdownOptions": {
+          "target": "com.amazonaws.quicksight#DefaultFilterDropDownControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>Dropdown</code> filter control type.</p>"
+          }
+        },
+        "DefaultTextFieldOptions": {
+          "target": "com.amazonaws.quicksight#DefaultTextFieldControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>TextField</code> filter control type.</p>"
+          }
+        },
+        "DefaultTextAreaOptions": {
+          "target": "com.amazonaws.quicksight#DefaultTextAreaControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>TextArea</code> filter control type.</p>"
+          }
+        },
+        "DefaultSliderOptions": {
+          "target": "com.amazonaws.quicksight#DefaultSliderControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>Slider</code> filter control type.</p>"
+          }
+        },
+        "DefaultRelativeDateTimeOptions": {
+          "target": "com.amazonaws.quicksight#DefaultRelativeDateTimeControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The default options that correspond to the <code>RelativeDateTime</code> filter control type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that corresponds to the control type of the filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableBorderThickness": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 4
+        }
+      }
+    },
+    "com.amazonaws.quicksight#StaticFileS3SourceOptions": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ObjectKey": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the static file in the Amazon S3 bucket.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Region": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Region of the Amazon S3 account that contains the bucket.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The structure that contains the Amazon S3 location to download the static file from.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlLayout": {
+      "type": "structure",
+      "members": {
+        "Configuration": {
+          "target": "com.amazonaws.quicksight#SheetControlLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that determines the elements and canvas size options of sheet control.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A grid layout to define the placement of sheet control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SmallMultiplesAxisScale": {
+      "type": "enum",
+      "members": {
+        "SHARED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHARED"
+          }
+        },
+        "INDEPENDENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INDEPENDENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PeriodToDateComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "PeriodTimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The time granularity setup of period to date computation. Choose from the following options:</p>\n         <ul>\n            <li>\n               <p>YEAR: Year to date.</p>\n            </li>\n            <li>\n               <p>MONTH: Month to date.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The period to date computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualOptions": {
+      "type": "structure",
+      "members": {
+        "VisualProperties": {
+          "target": "com.amazonaws.quicksight#PluginVisualPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The persisted properties and their values.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options and persisted properties for the plugin visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomActionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudWordPadding": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMALL"
+          }
+        },
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LARGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableRowsLayout": {
+      "type": "enum",
+      "members": {
+        "TABULAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABULAR"
+          }
+        },
+        "HIERARCHY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIERARCHY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualItemsLimitConfiguration": {
+      "type": "structure",
+      "members": {
+        "ItemsLimit": {
+          "target": "com.amazonaws.quicksight#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines how many values are be fetched at once.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A query limits configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPolygonStyle": {
+      "type": "structure",
+      "members": {
+        "PolygonSymbolStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialPolygonSymbolStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The polygon symbol style for a polygon layer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The polygon style for a polygon layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category (y-axis) field well of a bar chart.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a bar chart. Values are aggregated by\n            category.</p>"
+          }
+        },
+        "Colors": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color (group/color) field well of a bar chart.</p>"
+          }
+        },
+        "SmallMultiples": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples field well of a bar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field wells of a bar chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramFieldWells": {
+      "type": "structure",
+      "members": {
+        "HistogramAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#HistogramAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a histogram.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a histogram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ShapeConditionalFormat": {
+      "type": "structure",
+      "members": {
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the shape background color of a filled map visual.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The shape conditional formatting of a filled map visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomRankedComputationResultSize": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormattingOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 500
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SankeyDiagramAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Source": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The source field wells of a sankey diagram.</p>"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The destination field wells of a sankey diagram.</p>"
+          }
+        },
+        "Weight": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The weight field wells of a sankey diagram.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a sankey diagram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeaderFooterSectionConfiguration": {
+      "type": "structure",
+      "members": {
+        "SectionId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the header or footer section.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Layout": {
+          "target": "com.amazonaws.quicksight#SectionLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The layout configuration of the header or footer section.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Style": {
+          "target": "com.amazonaws.quicksight#SectionStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The style options of a header or footer section.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a header or footer section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UniqueValuesComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field that is used in a computation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The unique values computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColorFillType": {
+      "type": "enum",
+      "members": {
+        "DISCRETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISCRETE"
+          }
+        },
+        "GRADIENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GRADIENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterOperationTargetVisualsConfiguration": {
+      "type": "structure",
+      "members": {
+        "SameSheetTargetVisualConfiguration": {
+          "target": "com.amazonaws.quicksight#SameSheetTargetVisualConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the same-sheet target visuals that you want to be filtered.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of target visuals that you want to be filtered.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataFieldComboSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>Field ID of the field that you are setting the series configuration for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#SensitiveString",
+          "traits": {
+            "smithy.api#documentation": "<p>Field value of the field that you are setting the series configuration for.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#ComboChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Options that determine the presentation of series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data field series item configuration of a <code>ComboChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WidgetStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualProperty": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the plugin visual property.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the plugin visual property.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The key value pair of the persisted property.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ResourceStatus": {
+      "type": "enum",
+      "members": {
+        "CREATION_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATION_IN_PROGRESS"
+          }
+        },
+        "CREATION_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATION_SUCCESSFUL"
+          }
+        },
+        "CREATION_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATION_FAILED"
+          }
+        },
+        "UPDATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_SUCCESSFUL"
+          }
+        },
+        "UPDATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_FAILED"
+          }
+        },
+        "DELETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MaximumMinimumComputationType": {
+      "type": "enum",
+      "members": {
+        "MAXIMUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAXIMUM"
+          }
+        },
+        "MINIMUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MINIMUM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageScalingConfiguration": {
+      "type": "structure",
+      "members": {
+        "ScalingType": {
+          "target": "com.amazonaws.quicksight#SheetImageScalingType",
+          "traits": {
+            "smithy.api#documentation": "<p>The scaling option to use when fitting the image inside the container.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SCALE_TO_WIDTH</code>: The image takes up the entire width of the container. The image aspect ratio is preserved.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SCALE_TO_HEIGHT</code>: The image takes up the entire height of the container. The image aspect ratio is preserved.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SCALE_TO_CONTAINER</code>: The image takes up the entire width and height of the container. The image aspect ratio is not preserved.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SCALE_NONE</code>: The image is displayed in its original size and is not scaled to the container.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines how the image is scaled</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TooltipItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TooltipItem"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomLabel": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Filter": {
+      "type": "structure",
+      "members": {
+        "CategoryFilter": {
+          "target": "com.amazonaws.quicksight#CategoryFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>CategoryFilter</code> filters text values.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/add-a-text-filter-data-prep.html\">Adding text filters</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "NumericRangeFilter": {
+          "target": "com.amazonaws.quicksight#NumericRangeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>NumericRangeFilter</code> filters numeric values that are either inside or outside a given numeric range.</p>"
+          }
+        },
+        "NumericEqualityFilter": {
+          "target": "com.amazonaws.quicksight#NumericEqualityFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>NumericEqualityFilter</code> filters numeric values that equal or do not equal a given numeric value.</p>"
+          }
+        },
+        "TimeEqualityFilter": {
+          "target": "com.amazonaws.quicksight#TimeEqualityFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>TimeEqualityFilter</code> filters date-time values that equal or do not equal\n            a given date/time value.</p>"
+          }
+        },
+        "TimeRangeFilter": {
+          "target": "com.amazonaws.quicksight#TimeRangeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>TimeRangeFilter</code> filters date-time values that are either inside or outside a given date/time range.</p>"
+          }
+        },
+        "RelativeDatesFilter": {
+          "target": "com.amazonaws.quicksight#RelativeDatesFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>RelativeDatesFilter</code> filters date values that are relative to a given date.</p>"
+          }
+        },
+        "TopBottomFilter": {
+          "target": "com.amazonaws.quicksight#TopBottomFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>TopBottomFilter</code> filters data to the top or bottom values for a given column.</p>"
+          }
+        },
+        "NestedFilter": {
+          "target": "com.amazonaws.quicksight#NestedFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>NestedFilter</code> filters data with a subset of data that is defined by the nested inner filter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>With a <code>Filter</code>, you can remove portions of data from a particular visual or view.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComparisonFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "NumberDisplayFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumberDisplayFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The number display format.</p>"
+          }
+        },
+        "PercentageDisplayFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#PercentageDisplayFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage display format.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The format of the comparison.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapFieldWells": {
+      "type": "structure",
+      "members": {
+        "FilledMapAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#FilledMapAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field well of the filled map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a <code>FilledMapVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultSectionBasedLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#SectionBasedLayoutCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the screen canvas size options for a section-based layout.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default settings for a section-based layout configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchyPostCodeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableInlineVisualization": {
+      "type": "structure",
+      "members": {
+        "DataBars": {
+          "target": "com.amazonaws.quicksight#DataBarsOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the inline visualization of the data bars within a chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The inline visualization of a specific type to display within a chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "DateTimeFormat": {
+          "target": "com.amazonaws.quicksight#DateTimeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the <code>DateTime</code> format.</p>"
+          }
+        },
+        "NullValueFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NullValueFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+          }
+        },
+        "NumericFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The formatting configuration for numeric <code>DateTime</code> fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for <code>DateTime</code> fields.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialHeatmapDataColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GeospatialHeatmapDataColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingColor": {
+      "type": "structure",
+      "members": {
+        "Solid": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingSolidColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for solid color.</p>"
+          }
+        },
+        "Gradient": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingGradientColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for gradient color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The formatting configuration for the color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelOverlap": {
+      "type": "enum",
+      "members": {
+        "DISABLE_OVERLAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLE_OVERLAP"
+          }
+        },
+        "ENABLE_OVERLAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLE_OVERLAP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldOption": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the pivot table field.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#CustomLabel",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label of the pivot table field.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the pivot table field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The selected field options for the pivot table field options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ForecastScenario": {
+      "type": "structure",
+      "members": {
+        "WhatIfPointScenario": {
+          "target": "com.amazonaws.quicksight#WhatIfPointScenario",
+          "traits": {
+            "smithy.api#documentation": "<p>The what-if analysis forecast setup with the target date.</p>"
+          }
+        },
+        "WhatIfRangeScenario": {
+          "target": "com.amazonaws.quicksight#WhatIfRangeScenario",
+          "traits": {
+            "smithy.api#documentation": "<p>The what-if analysis forecast setup with the date range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The forecast scenario of a forecast in the line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchy": {
+      "type": "structure",
+      "members": {
+        "Country": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchyCountryString",
+          "traits": {
+            "smithy.api#documentation": "<p>The country value for the preference hierarchy.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchyStateString",
+          "traits": {
+            "smithy.api#documentation": "<p>The state/region value for the preference hierarchy.</p>"
+          }
+        },
+        "County": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchyCountyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The county/district value for the preference hierarchy.</p>"
+          }
+        },
+        "City": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchyCityString",
+          "traits": {
+            "smithy.api#documentation": "<p>The city value for the preference hierarchy.</p>"
+          }
+        },
+        "PostCode": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchyPostCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The postcode value for the preference hierarchy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The preference hierarchy for the geocode preference.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#RadarChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A radar chart visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalPlacesConfiguration": {
+      "type": "structure",
+      "members": {
+        "DecimalPlaces": {
+          "target": "com.amazonaws.quicksight#DecimalPlaces",
+          "traits": {
+            "smithy.api#documentation": "<p>The values of the decimal places.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the decimal places configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetReference": {
+      "type": "structure",
+      "members": {
+        "DataSetPlaceholder": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>Dataset placeholder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataSetArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Dataset Amazon Resource Name (ARN).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Dataset reference.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableTotalOptions": {
+      "type": "structure",
+      "members": {
+        "RowSubtotalOptions": {
+          "target": "com.amazonaws.quicksight#SubtotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The row subtotal options.</p>"
+          }
+        },
+        "ColumnSubtotalOptions": {
+          "target": "com.amazonaws.quicksight#SubtotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The column subtotal options.</p>"
+          }
+        },
+        "RowTotalOptions": {
+          "target": "com.amazonaws.quicksight#PivotTotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The row total options.</p>"
+          }
+        },
+        "ColumnTotalOptions": {
+          "target": "com.amazonaws.quicksight#PivotTotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The column total options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The total options for a pivot table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartMeasureDataLabelStyle": {
+      "type": "enum",
+      "members": {
+        "VALUE_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE_ONLY"
+          }
+        },
+        "PERCENTAGE_BY_FIRST_STAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENTAGE_BY_FIRST_STAGE"
+          }
+        },
+        "PERCENTAGE_BY_PREVIOUS_STAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENTAGE_BY_PREVIOUS_STAGE"
+          }
+        },
+        "VALUE_AND_PERCENTAGE_BY_FIRST_STAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE_AND_PERCENTAGE_BY_FIRST_STAGE"
+          }
+        },
+        "VALUE_AND_PERCENTAGE_BY_PREVIOUS_STAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE_AND_PERCENTAGE_BY_PREVIOUS_STAGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterSliderControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#SliderControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlSliderType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>FilterSliderControl</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SINGLE_POINT</code>: Filter against(equals) a single data point.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code>: Filter data that is in a specified range.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "MaximumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The larger value that is displayed at the right of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MinimumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The smaller value that is displayed at the left of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepSize": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of increments that the slider bar is divided into.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a horizontal toggle bar. This is used to change a value by sliding the toggle.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    "com.amazonaws.quicksight#StringParameter": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>A display name for a string parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#SensitiveStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values of a string parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A string parameter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalParameterDeclaration": {
+      "type": "structure",
+      "members": {
+        "ParameterValueType": {
+          "target": "com.amazonaws.quicksight#ParameterValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The value type determines whether the parameter is a single-value or multi-value parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that is being declared.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultValues": {
+          "target": "com.amazonaws.quicksight#DecimalDefaultValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The default values of a parameter. If the parameter is a single-value parameter, a maximum of one default value can be provided.</p>"
+          }
+        },
+        "ValueWhenUnset": {
+          "target": "com.amazonaws.quicksight#DecimalValueWhenUnsetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>Decimal</code> parameter when a value has not been set.</p>"
+          }
+        },
+        "MappedDataSetParameters": {
+          "target": "com.amazonaws.quicksight#MappedDataSetParameters"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A parameter declaration for the <code>Decimal</code> data type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SpecialValue": {
+      "type": "enum",
+      "members": {
+        "EMPTY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMPTY"
+          }
+        },
+        "NULL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NULL"
+          }
+        },
+        "OTHER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OTHER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayoutElementType": {
+      "type": "enum",
+      "members": {
+        "VISUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VISUAL"
+          }
+        },
+        "FILTER_CONTROL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FILTER_CONTROL"
+          }
+        },
+        "PARAMETER_CONTROL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARAMETER_CONTROL"
+          }
+        },
+        "TEXT_BOX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXT_BOX"
+          }
+        },
+        "IMAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IMAGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ValidationStrategy": {
+      "type": "structure",
+      "members": {
+        "Mode": {
+          "target": "com.amazonaws.quicksight#ValidationStrategyMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of validation for the asset to be created or updated. When you set this value to <code>STRICT</code>, strict validation for every error is enforced. When you set this value to <code>LENIENT</code>, validation is skipped for specific UI errors.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option to relax the validation that is required to create and update analyses, dashboards, and templates with definition objects. When you set this value to <code>LENIENT</code>, validation is skipped for specific errors.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ValueWhenUnsetOption": {
+      "type": "enum",
+      "members": {
+        "RECOMMENDED_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RECOMMENDED_VALUE"
+          }
+        },
+        "NULL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NULL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TransposedColumnIndex": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#documentation": "<p>The integer value of a column index in the transposed table.</p>",
+        "smithy.api#range": {
+          "min": 0,
+          "max": 9999
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterSelectableValues": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#ParameterSelectableValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are used in the <code>FilterSelectableValues</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableCellConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the cell for conditional formatting.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TextFormat": {
+          "target": "com.amazonaws.quicksight#TextConditionalFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The text format of the cell for conditional formatting.</p>"
+          }
+        },
+        "Scope": {
+          "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The scope of the cell for conditional formatting.</p>"
+          }
+        },
+        "Scopes": {
+          "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingScopeList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of cell scopes for conditional formatting.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The cell conditional formatting option for a pivot table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionRepeatDimensionConfiguration": {
+      "type": "structure",
+      "members": {
+        "DynamicCategoryDimensionConfiguration": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicCategoryDimensionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the <b>Category</b> dataset column and constraints around the dynamic values that will be used in repeating the section contents.</p>"
+          }
+        },
+        "DynamicNumericDimensionConfiguration": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicNumericDimensionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the <b>Numeric</b> dataset column and constraints around the dynamic values used to repeat the  contents of a section.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the dataset column and constraints for the dynamic values used to repeat the contents of a section. The dataset column is either <b>Category</b> or <b>Numeric</b> column configuration</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelType": {
+      "type": "structure",
+      "members": {
+        "FieldLabelType": {
+          "target": "com.amazonaws.quicksight#FieldLabelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the label configuration for the entire field.</p>"
+          }
+        },
+        "DataPathLabelType": {
+          "target": "com.amazonaws.quicksight#DataPathLabelType",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that specifies individual data values for labels.</p>"
+          }
+        },
+        "RangeEndsLabelType": {
+          "target": "com.amazonaws.quicksight#RangeEndsLabelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the label configuration for range end value in a visual.</p>"
+          }
+        },
+        "MinimumLabelType": {
+          "target": "com.amazonaws.quicksight#MinimumLabelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the label configuration for the minimum value in a visual.</p>"
+          }
+        },
+        "MaximumLabelType": {
+          "target": "com.amazonaws.quicksight#MaximumLabelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the label configuration for the maximum value in a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the data label type.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomizationFieldsConfiguration": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.quicksight#DashboardCustomizationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether dashboard readers can customize fields for this visual. This option is <code>ENABLED</code> by default.</p>"
+          }
+        },
+        "AdditionalFields": {
+          "target": "com.amazonaws.quicksight#VisualCustomizationAdditionalFieldsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The additional dataset fields available for dashboard readers to customize the visual with, beyond the fields already configured on the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that controls field customization options available to dashboard readers for a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StaticFileList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#StaticFile"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableCellImageScalingConfiguration": {
+      "type": "enum",
+      "members": {
+        "FIT_TO_CELL_HEIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIT_TO_CELL_HEIGHT"
+          }
+        },
+        "FIT_TO_CELL_WIDTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIT_TO_CELL_WIDTH"
+          }
+        },
+        "DO_NOT_SCALE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DO_NOT_SCALE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterGroup": {
+      "type": "structure",
+      "members": {
+        "FilterGroupId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The value that uniquely identifies a <code>FilterGroup</code> within a dashboard, template, or analysis.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.quicksight#FilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of filters that are present in a <code>FilterGroup</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ScopeConfiguration": {
+          "target": "com.amazonaws.quicksight#FilterScopeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that specifies what scope to apply to a <code>FilterGroup</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the <code>FilterGroup</code>.</p>"
+          }
+        },
+        "CrossDataset": {
+          "target": "com.amazonaws.quicksight#CrossDatasetTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter new feature which can apply filter group to all data sets. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_DATASETS</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_DATASET</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A grouping of individual filters. Filter groups are applied to the same group of visuals.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/add-a-compound-filter.html\">Adding filter conditions (group filters) with AND and OR operators</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldWells": {
+      "type": "structure",
+      "members": {
+        "PivotTableAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#PivotTableAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field well for the pivot table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells for a pivot table visual.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ConditionalFormattingOptions": {
+          "target": "com.amazonaws.quicksight#TableConditionalFormattingOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>Conditional formatting options for a <code>PivotTableVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComputationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Computation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveDoubleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveDouble"
+      }
+    },
+    "com.amazonaws.quicksight#SheetElementRenderingRule": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression of the rendering rules of a sheet.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigurationOverrides": {
+          "target": "com.amazonaws.quicksight#SheetElementConfigurationOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>The override configuration of the rendering rules of a sheet.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The rendering rules of a sheet that uses a free-form layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualHighlightTrigger": {
+      "type": "enum",
+      "members": {
+        "DATA_POINT_CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_CLICK"
+          }
+        },
+        "DATA_POINT_HOVER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_HOVER"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingSolidColor": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression that determines the formatting configuration for solid color.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for solid color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetIdentifierDeclarationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataSetIdentifierDeclaration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartAxesRangeScale": {
+      "type": "enum",
+      "members": {
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "INDEPENDENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INDEPENDENT"
+          }
+        },
+        "SHARED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHARED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterOperationSelectedFieldsConfiguration": {
+      "type": "structure",
+      "members": {
+        "SelectedFields": {
+          "target": "com.amazonaws.quicksight#SelectedFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>Chooses the fields that are filtered in <code>CustomActionFilterOperation</code>.</p>"
+          }
+        },
+        "SelectedFieldOptions": {
+          "target": "com.amazonaws.quicksight#SelectedFieldOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>A structure that contains the options that choose which fields are filtered in the <code>CustomActionFilterOperation</code>.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_FIELDS</code>: Applies the filter operation to all fields.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SelectedColumns": {
+          "target": "com.amazonaws.quicksight#CustomActionColumnList",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected columns of a dataset.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of selected fields in the<code>CustomActionFilterOperation</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DropDownControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#ListControlSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the <code>Select all</code> options in a\n            dropdown control.</p>"
+          }
+        },
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#IntegerDefaultValues": {
+      "type": "structure",
+      "members": {
+        "DynamicValue": {
+          "target": "com.amazonaws.quicksight#DynamicDefaultValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The dynamic value of the <code>IntegerDefaultValues</code>. Different defaults are displayed according to users, groups, and values mapping.</p>"
+          }
+        },
+        "StaticValues": {
+          "target": "com.amazonaws.quicksight#IntegerDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The static values of the <code>IntegerDefaultValues</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default values of the <code>IntegerParameterDeclaration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DigitGroupingStyle": {
+      "type": "enum",
+      "members": {
+        "DEFAULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT"
+          }
+        },
+        "LAKHS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAKHS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MissingDataConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MissingDataConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "NumberDisplayFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumberDisplayFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the number display format configuration.</p>"
+          }
+        },
+        "CurrencyDisplayFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#CurrencyDisplayFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the currency display format configuration.</p>"
+          }
+        },
+        "PercentageDisplayFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#PercentageDisplayFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the percentage display format configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the numeric format configuration.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TextAreaControlDelimiter": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CoordinateLongitudeDouble": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": -180.0,
+          "max": 180.0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ListControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "SearchOptions": {
+          "target": "com.amazonaws.quicksight#ListControlSearchOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the search options in a list control.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#ListControlSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the <code>Select all</code> options in a list control.</p>"
+          }
+        },
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterListConfiguration": {
+      "type": "structure",
+      "members": {
+        "MatchOperator": {
+          "target": "com.amazonaws.quicksight#CategoryFilterMatchOperator",
+          "traits": {
+            "smithy.api#documentation": "<p>The match operator that is used to determine if a filter should be applied.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CategoryValues": {
+          "target": "com.amazonaws.quicksight#CategoryValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of category values for the filter.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#CategoryFilterSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Select all of the values. Null is not the assigned value of select all.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FILTER_ALL_VALUES</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of filter configurations.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GradientStop": {
+      "type": "structure",
+      "members": {
+        "GradientOffset": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Determines gradient offset value.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines the data value.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the gradient stop configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#EntityList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Entity"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ParameterListControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the <code>ParameterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#ListControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of <code>ParameterListControl</code>.</p>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#ParameterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        },
+        "CascadingControlConfiguration": {
+          "target": "com.amazonaws.quicksight#CascadingControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a list with buttons or boxes that are used to select either a single value or multiple values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecalSettingsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DecalSettings"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldWells": {
+      "type": "structure",
+      "members": {
+        "TableAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#TableAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field well for the table.</p>"
+          }
+        },
+        "TableUnaggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#TableUnaggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The unaggregated field well for the table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells for a table visual.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageMenuOption": {
+      "type": "structure",
+      "members": {
+        "AvailabilityStatus": {
+          "target": "com.amazonaws.quicksight#DashboardBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The availability status of the image menu. If the value of this property is set to <code>ENABLED</code>, dashboard readers can interact with the image menu.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The menu options for the interactions of an image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotFieldWells": {
+      "type": "structure",
+      "members": {
+        "ScatterPlotCategoricallyAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#ScatterPlotCategoricallyAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a scatter plot. The x and y-axes of scatter plots with aggregated field wells are aggregated by category, label, or both.</p>"
+          }
+        },
+        "ScatterPlotUnaggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#ScatterPlotUnaggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The unaggregated field wells of a scatter plot. The x and y-axes of these scatter plots are\n            unaggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a scatter plot.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataPathSort": {
+      "type": "structure",
+      "members": {
+        "Direction": {
+          "target": "com.amazonaws.quicksight#SortDirection",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the sort direction.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SortPaths": {
+          "target": "com.amazonaws.quicksight#DataPathValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of data paths that need to be sorted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Allows data paths to be sorted by a specific data value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultFilterDropDownControlOptions": {
+      "type": "structure",
+      "members": {
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DropDownControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>FilterDropDownControl</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MULTI_SELECT</code>: The user can select multiple entries from a dropdown menu.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_SELECT</code>: The user can select a single entry from a dropdown menu.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#FilterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>FilterDropDownControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>Dropdown</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "RadarChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#RadarChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a radar chart visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a radar chart visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeDefaultValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveTimestamp"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementBackgroundStyle": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The background visibility of a grid layout element.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The background color of a grid layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The background style configuration of a grid layout element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldBarSeriesItem": {
+          "target": "com.amazonaws.quicksight#FieldBarSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The field series item configuration of a  <code>BarChartVisual</code>.</p>"
+          }
+        },
+        "DataFieldBarSeriesItem": {
+          "target": "com.amazonaws.quicksight#DataFieldBarSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The data field series item configuration of a  <code>BarChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The series item configuration of a  <code>BarChartVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableSortBy": {
+      "type": "structure",
+      "members": {
+        "Field": {
+          "target": "com.amazonaws.quicksight#FieldSort",
+          "traits": {
+            "smithy.api#documentation": "<p>The field sort (field id, direction) for the pivot table sort by options.</p>"
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnSort",
+          "traits": {
+            "smithy.api#documentation": "<p>The column sort (field id, direction) for the pivot table sort by options.</p>"
+          }
+        },
+        "DataPath": {
+          "target": "com.amazonaws.quicksight#DataPathSort",
+          "traits": {
+            "smithy.api#documentation": "<p>The data path sort (data path value, direction) for the pivot table sort by options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort by field for the field sort options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldHeight": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 8,
+          "max": 500
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ColumnHierarchy": {
+      "type": "structure",
+      "members": {
+        "ExplicitHierarchy": {
+          "target": "com.amazonaws.quicksight#ExplicitHierarchy",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the hierarchy of the fields that are built within a visual's field wells. These fields can't be duplicated to other visuals.</p>"
+          }
+        },
+        "DateTimeHierarchy": {
+          "target": "com.amazonaws.quicksight#DateTimeHierarchy",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the hierarchy of any <code>DateTime</code> fields.</p>"
+          }
+        },
+        "PredefinedHierarchy": {
+          "target": "com.amazonaws.quicksight#PredefinedHierarchy",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the hierarchy of the fields that are defined during data preparation. These fields are available to use in any analysis that uses the data source.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the hierarchy of the fields for a visual element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SecondaryValueOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the secondary value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the secondary value of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlSliderType": {
+      "type": "enum",
+      "members": {
+        "SINGLE_POINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SINGLE_POINT"
+          }
+        },
+        "RANGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RANGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLineLayer": {
+      "type": "structure",
+      "members": {
+        "Style": {
+          "target": "com.amazonaws.quicksight#GeospatialLineStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization style for a line layer.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The geospatial Line layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#ScatterPlotConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A scatter plot.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/scatter-plot.html\">Using scatter plots</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableDimensionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 40
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#TooltipItem": {
+      "type": "structure",
+      "members": {
+        "FieldTooltipItem": {
+          "target": "com.amazonaws.quicksight#FieldTooltipItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip item for the fields.</p>"
+          }
+        },
+        "ColumnTooltipItem": {
+          "target": "com.amazonaws.quicksight#ColumnTooltipItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip item for the columns that are not part of a field well.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tooltip.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalDefaultValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveDoubleObject"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WhatIfRangeScenario": {
+      "type": "structure",
+      "members": {
+        "StartDate": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The start date in the date range that you need the forecast results for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EndDate": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The end date in the date range that you need the forecast results for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The target value that you want to meet for the provided date range.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the forecast to meet the target for a particular date range.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterSelectableValues": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#ParameterSelectableValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are used in <code>ParameterSelectableValues</code>.</p>"
+          }
+        },
+        "LinkToDataSetColumn": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column identifier that fetches values from the data set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CoordinateLatitudeDouble": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": -90.0,
+          "max": 90.0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormattingScopeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingScope"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the location fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a <code>FilledMapVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualMenuOption": {
+      "type": "structure",
+      "members": {
+        "AvailabilityStatus": {
+          "target": "com.amazonaws.quicksight#DashboardBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The availaiblity status of a visual's menu options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The menu options for a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartLineStyle": {
+      "type": "enum",
+      "members": {
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        },
+        "DOTTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOTTED"
+          }
+        },
+        "DASHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DASHED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BinCountValue": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomAction": {
+      "type": "structure",
+      "members": {
+        "CustomActionId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the custom action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#LayerCustomActionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the <code>LayerCustomAction</code>.</p>"
+          }
+        },
+        "Trigger": {
+          "target": "com.amazonaws.quicksight#LayerCustomActionTrigger",
+          "traits": {
+            "smithy.api#documentation": "<p>The trigger of the <code>LayerCustomAction</code>.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DATA_POINT_CLICK</code>: Initiates a custom action by a left pointer click on a data point.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DATA_POINT_MENU</code>: Initiates a custom action by right pointer click from the menu.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActionOperations": {
+          "target": "com.amazonaws.quicksight#LayerCustomActionOperationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>LayerCustomActionOperations</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A layer custom action.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineLabelVerticalPosition": {
+      "type": "enum",
+      "members": {
+        "ABOVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ABOVE"
+          }
+        },
+        "BELOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BELOW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutElementBorderStyle": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The border visibility of a free-form layout element.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The border color of a free-form layout element.</p>"
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#Width",
+          "traits": {
+            "smithy.api#documentation": "<p>The border width of a free-form layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The background style configuration of a free-form layout element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingIconDisplayOption": {
+      "type": "enum",
+      "members": {
+        "ICON_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ICON_ONLY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultRelativeDateTimeControlOptions": {
+      "type": "structure",
+      "members": {
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#RelativeDateTimeControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>RelativeDateTimeControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>RelativeDateTime</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SimpleTotalAggregationFunction": {
+      "type": "enum",
+      "members": {
+        "DEFAULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT"
+          }
+        },
+        "SUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUM"
+          }
+        },
+        "AVERAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVERAGE"
+          }
+        },
+        "MIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIN"
+          }
+        },
+        "MAX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAX"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BinCountOptions": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.quicksight#BinCountValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the bin count value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the bin count of a histogram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerType": {
+      "type": "enum",
+      "members": {
+        "POINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POINT"
+          }
+        },
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        },
+        "POLYGON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POLYGON"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericAxisOptions": {
+      "type": "structure",
+      "members": {
+        "Scale": {
+          "target": "com.amazonaws.quicksight#AxisScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The scale setup of a numeric axis.</p>"
+          }
+        },
+        "Range": {
+          "target": "com.amazonaws.quicksight#AxisDisplayRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The range setup of a numeric axis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for an axis with a numeric field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PanelTitleOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not panel titles are displayed.</p>"
+          }
+        },
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration"
+        },
+        "HorizontalTextAlignment": {
+          "target": "com.amazonaws.quicksight#HorizontalTextAlignment",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the horizontal text alignment of the title within each panel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the title styles for each small multiples\n            panel.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "GroupBy": {
+          "target": "com.amazonaws.quicksight#BoxPlotDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The group by field well of a box plot chart. Values are grouped based on group by fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#BoxPlotMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field well of a box plot chart. Values are aggregated based on group by fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well for a box plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ForecastComputationCustomSeasonalityValue": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 180
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DeleteAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.quicksight#StatusCode",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The HTTP status of the request.</p>",
+            "smithy.api#httpResponseCode": {}
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the deleted analysis.</p>"
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the deleted analysis.</p>"
+          }
+        },
+        "DeletionTime": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the analysis is scheduled to be deleted.</p>"
+          }
+        },
+        "RequestId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services request ID for this operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ShortRestrictiveResourceId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        },
+        "smithy.api#pattern": "^[\\w\\-]+$"
+      }
+    },
+    "com.amazonaws.quicksight#MappedDataSetParameters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MappedDataSetParameter"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of dataset parameters that are mapped to an analysis parameter.</p>",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 150
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetTextBoxContent": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 150000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FieldBasedTooltip": {
+      "type": "structure",
+      "members": {
+        "AggregationVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of <code>Show aggregations</code>.</p>"
+          }
+        },
+        "TooltipTitleType": {
+          "target": "com.amazonaws.quicksight#TooltipTitleType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type for the >tooltip title. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NONE</code>: Doesn't use the primary value as the title.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PRIMARY_VALUE</code>: Uses primary value as the title.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "TooltipFields": {
+          "target": "com.amazonaws.quicksight#TooltipItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>The fields configuration in the\n            tooltip.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The setup for the detailed tooltip.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionDynamicDimensionLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the category fields.</p>"
+          }
+        },
+        "BreakdownItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of bar groups that are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartConditionalFormattingOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GaugeChartConditionalFormattingOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#UnaggregatedFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#UnaggregatedField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialNullDataSettings": {
+      "type": "structure",
+      "members": {
+        "SymbolStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialNullSymbolStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The symbol style for null data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties for the visualization of null data.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#QueryExecutionMode": {
+      "type": "enum",
+      "members": {
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "MANUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#FilledMapFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#FilledMapSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>FilledMapVisual</code>.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "WindowOptions": {
+          "target": "com.amazonaws.quicksight#GeospatialWindowOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The window options of the filled map visual.</p>"
+          }
+        },
+        "MapStyleOptions": {
+          "target": "com.amazonaws.quicksight#GeospatialMapStyleOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The map style options of the filled map visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a <code>FilledMapVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionRepeatConfiguration": {
+      "type": "structure",
+      "members": {
+        "DimensionConfigurations": {
+          "target": "com.amazonaws.quicksight#BodySectionRepeatDimensionConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of <code>BodySectionRepeatDimensionConfiguration</code> values that describe the dataset column and constraints for the column used to repeat the contents of a section.</p>"
+          }
+        },
+        "PageBreakConfiguration": {
+          "target": "com.amazonaws.quicksight#BodySectionRepeatPageBreakConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Page break configuration to apply for each repeating instance.</p>"
+          }
+        },
+        "NonRepeatingVisuals": {
+          "target": "com.amazonaws.quicksight#NonRepeatingVisualsList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of visuals to exclude from repetition in repeating sections. The visuals will render identically, and ignore the repeating configurations in all repeating instances.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the configurations that are required to declare a section as repeating.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SankeyDiagramChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#SankeyDiagramFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a sankey diagram.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#SankeyDiagramSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a sankey diagram.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data label configuration of a sankey diagram.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a sankey diagram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColorScaleColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AggregationSortConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#AggregationSortConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterRelativeDateTimeControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#RelativeDateTimeControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>FilterRelativeDateTimeControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control from a date filter that is used to specify the relative date.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Geospatial": {
+          "target": "com.amazonaws.quicksight#FilledMapDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated location field well of the filled map. Values are grouped by location fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#FilledMapMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated color field well of a filled map. Values are aggregated based on location fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well of the filled map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ArcAxisDisplayRange": {
+      "type": "structure",
+      "members": {
+        "Min": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The minimum value of the arc axis range.</p>"
+          }
+        },
+        "Max": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The maximum value of the arc axis range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The arc axis range of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BinWidthOptions": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.quicksight#BinWidthValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the bin width value.</p>"
+          }
+        },
+        "BinCountLimit": {
+          "target": "com.amazonaws.quicksight#BinCountLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the bin count limit.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the bin width of a histogram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LegendPosition": {
+      "type": "enum",
+      "members": {
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RIGHT"
+          }
+        },
+        "BOTTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOTTOM"
+          }
+        },
+        "TOP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TOP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#InsightVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "InsightConfiguration": {
+          "target": "com.amazonaws.quicksight#InsightConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of an insight visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset that is used in the insight visual.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An insight visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/computational-insights.html\">Working with insights</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ValidationStrategyMode": {
+      "type": "enum",
+      "members": {
+        "STRICT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STRICT"
+          }
+        },
+        "LENIENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LENIENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DateTimePickerControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "DateTimeFormat": {
+          "target": "com.amazonaws.quicksight#DateTimeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Customize how dates are formatted in controls.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        },
+        "HelperTextVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The helper text visibility of the <code>DateTimePickerControlDisplayOptions</code>.</p>"
+          }
+        },
+        "DateIconVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The date icon visibility of the <code>DateTimePickerControlDisplayOptions</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the field for which you are setting the axis binding.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AxisBinding": {
+          "target": "com.amazonaws.quicksight#AxisBinding",
+          "traits": {
+            "smithy.api#documentation": "<p>The axis that you are binding the field to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#LineChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of line series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field series item configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateAggregationFunction": {
+      "type": "enum",
+      "members": {
+        "COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT"
+          }
+        },
+        "DISTINCT_COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISTINCT_COUNT"
+          }
+        },
+        "MIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIN"
+          }
+        },
+        "MAX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAX"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#QBusinessInsightsStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#GaugeChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "GaugeChartOptions": {
+          "target": "com.amazonaws.quicksight#GaugeChartOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data label configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "TooltipOptions": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual palette configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "ColorConfiguration": {
+          "target": "com.amazonaws.quicksight#GaugeChartColorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The color configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomFilterConfiguration": {
+      "type": "structure",
+      "members": {
+        "MatchOperator": {
+          "target": "com.amazonaws.quicksight#CategoryFilterMatchOperator",
+          "traits": {
+            "smithy.api#documentation": "<p>The match operator that is used to determine if a filter should be applied.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CategoryValue": {
+          "target": "com.amazonaws.quicksight#CategoryValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The category value for the filter.</p>\n         <p>This field is mutually exclusive to <code>ParameterName</code>.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#CategoryFilterSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Select all of the values. Null is not the assigned value of select all.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FILTER_ALL_VALUES</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter whose value should be used for the filter value.</p>\n         <p>This field is mutually exclusive to <code>CategoryValue</code>.</p>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A custom filter that filters based on a single value. This filter can be partially matched.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisDataOptions": {
+      "type": "structure",
+      "members": {
+        "NumericAxisOptions": {
+          "target": "com.amazonaws.quicksight#NumericAxisOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for an axis with a numeric field.</p>"
+          }
+        },
+        "DateAxisOptions": {
+          "target": "com.amazonaws.quicksight#DateAxisOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for an axis with a date field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data options for an axis.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TotalAggregationOption": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field id that's associated with the total aggregation option.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TotalAggregationFunction": {
+          "target": "com.amazonaws.quicksight#TotalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The total aggregation function that you want to set for a specified field id.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The total aggregation settings map of a field id.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomActionNavigationOperation": {
+      "type": "structure",
+      "members": {
+        "LocalNavigationConfiguration": {
+          "target": "com.amazonaws.quicksight#LocalNavigationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that chooses the navigation target.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The navigation operation that navigates between different sheets in the same analysis.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionRepeatPageBreakConfiguration": {
+      "type": "structure",
+      "members": {
+        "After": {
+          "target": "com.amazonaws.quicksight#SectionAfterPageBreak"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The page break configuration to apply for each repeating instance.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineDynamicDataConfiguration": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the dynamic data targets.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MeasureAggregationFunction": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function that is used in the dynamic data.</p>"
+          }
+        },
+        "Calculation": {
+          "target": "com.amazonaws.quicksight#NumericalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The calculation that is used in the dynamic data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dynamic configuration of the reference line data configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SelectAllValueOptions": {
+      "type": "enum",
+      "members": {
+        "ALL_VALUES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_VALUES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoricalMeasureField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>CategoricalMeasureField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#CategoricalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the measure field.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#StringFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The measure type field with categorical type columns.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomRankedComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "ResultSize": {
+          "target": "com.amazonaws.quicksight#TopBottomRankedComputationResultSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The result size of a top and bottom ranked computation.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#TopBottomComputationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The computation type. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>TOP: A top ranked computation.</p>\n            </li>\n            <li>\n               <p>BOTTOM: A bottom ranked computation.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The top ranked and bottom ranked computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Categories": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field wells of a waterfall visual.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a waterfall visual.</p>"
+          }
+        },
+        "Breakdowns": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The breakdown field wells of a waterfall visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineLabelConfiguration": {
+      "type": "structure",
+      "members": {
+        "ValueLabelConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineValueLabelConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The value label configuration of the label in a reference line.</p>"
+          }
+        },
+        "CustomLabelConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineCustomLabelConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label configuration of the label in a reference line.</p>"
+          }
+        },
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration of the label in a reference line.</p>"
+          }
+        },
+        "FontColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The font color configuration of the label in a reference line.</p>"
+          }
+        },
+        "HorizontalPosition": {
+          "target": "com.amazonaws.quicksight#ReferenceLineLabelHorizontalPosition",
+          "traits": {
+            "smithy.api#documentation": "<p>The horizontal position configuration of the label in a reference line. Choose one of\n            the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>LEFT</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>CENTER</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RIGHT</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VerticalPosition": {
+          "target": "com.amazonaws.quicksight#ReferenceLineLabelVerticalPosition",
+          "traits": {
+            "smithy.api#documentation": "<p>The vertical position configuration of the label in a reference line. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ABOVE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>BELOW</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The label configuration of a reference line.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudMaximumStringLength": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomContentConfiguration": {
+      "type": "structure",
+      "members": {
+        "ContentUrl": {
+          "target": "com.amazonaws.quicksight#URLOperationTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>The input URL that links to the custom content that you want in the custom visual.</p>"
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.quicksight#CustomContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The content type of the custom content visual. You can use this to have the visual render as an image.</p>"
+          }
+        },
+        "ImageScaling": {
+          "target": "com.amazonaws.quicksight#CustomContentImageScalingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sizing options for the size of the custom content visual. This structure is required when the <code>ContentType</code> of the visual is <code>'IMAGE'</code>.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>CustomContentVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultGridLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#GridLayoutCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the screen canvas size options for a grid layout.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default settings for a grid layout configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudWordOrientation": {
+      "type": "enum",
+      "members": {
+        "HORIZONTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HORIZONTAL"
+          }
+        },
+        "HORIZONTAL_AND_VERTICAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HORIZONTAL_AND_VERTICAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetImage": {
+      "type": "structure",
+      "members": {
+        "SheetImageId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the sheet image.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.quicksight#SheetImageSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the image.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Scaling": {
+          "target": "com.amazonaws.quicksight#SheetImageScalingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines how the image is scaled.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#SheetImageTooltipConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip to be shown when hovering over the image.</p>"
+          }
+        },
+        "ImageContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the image.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#ImageInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general image interactions setup for an image.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#ImageCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of custom actions that are configured for an image.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An image that is located on a sheet.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerMapConfiguration": {
+      "type": "structure",
+      "members": {
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions"
+        },
+        "MapLayers": {
+          "target": "com.amazonaws.quicksight#GeospatialMapLayerList",
+          "traits": {
+            "smithy.api#documentation": "<p>The geospatial layers to visualize on the map.</p>"
+          }
+        },
+        "MapState": {
+          "target": "com.amazonaws.quicksight#GeospatialMapState",
+          "traits": {
+            "smithy.api#documentation": "<p>The map state properties for the map.</p>"
+          }
+        },
+        "MapStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialMapStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The map style properties for the map.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The map definition that defines map state, map style, and geospatial layers.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#BoxPlotFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#BoxPlotSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>BoxPlotVisual</code>.</p>"
+          }
+        },
+        "BoxPlotOptions": {
+          "target": "com.amazonaws.quicksight#BoxPlotOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The box plot chart options for a box plot visual</p>"
+          }
+        },
+        "CategoryAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, axis step) of a box plot category.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility and sort Icon visibility) of a box plot category.</p>"
+          }
+        },
+        "PrimaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, axis step) of a box plot category.</p>"
+          }
+        },
+        "PrimaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility and sort icon visibility) of a box plot value.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions"
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "ReferenceLines": {
+          "target": "com.amazonaws.quicksight#ReferenceLineList",
+          "traits": {
+            "smithy.api#documentation": "<p>The reference line setup of the visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>BoxPlotVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchyStateString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingIconDisplayConfiguration": {
+      "type": "structure",
+      "members": {
+        "IconDisplayOption": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIconDisplayOption",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the icon display configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the icon display configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeaderFooterSectionConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#HeaderFooterSectionConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultFreeFormLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the screen canvas size options for a free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default settings of a free-form layout configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementRowIndex": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 9009
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisualSubtitleLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the subtitle label.</p>"
+          }
+        },
+        "FormatText": {
+          "target": "com.amazonaws.quicksight#LongFormatText",
+          "traits": {
+            "smithy.api#documentation": "<p>The long text format of the subtitle label, such as plain text or rich text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The subtitle label options for a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CascadingControlConfiguration": {
+      "type": "structure",
+      "members": {
+        "SourceControls": {
+          "target": "com.amazonaws.quicksight#CascadingControlSourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of source controls that determine the values that are used in the current control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisiblePanelColumns": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultDateTimePickerControlOptions": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlDateTimePickerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The date time picker type of the <code>DefaultDateTimePickerControlOptions</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SINGLE_VALUED</code>: The filter condition is a fixed date.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DATE_RANGE</code>: The filter condition is a date time range.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DateTimePickerControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>DateTimePickerControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the filter control type of a <code>DateTimePicker</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableCellStyle": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the table cells.</p>"
+          }
+        },
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration of the table cells.</p>"
+          }
+        },
+        "TextWrap": {
+          "target": "com.amazonaws.quicksight#TextWrap",
+          "traits": {
+            "smithy.api#documentation": "<p>The text wrap (none, wrap) for the table cells.</p>"
+          }
+        },
+        "HorizontalTextAlignment": {
+          "target": "com.amazonaws.quicksight#HorizontalTextAlignment",
+          "traits": {
+            "smithy.api#documentation": "<p>The horizontal text alignment (left, center, right, auto) for the table cells.</p>"
+          }
+        },
+        "VerticalTextAlignment": {
+          "target": "com.amazonaws.quicksight#VerticalTextAlignment",
+          "traits": {
+            "smithy.api#documentation": "<p>The vertical text alignment (top, middle, bottom) for the table cells.</p>"
+          }
+        },
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The background color for the table cells.</p>"
+          }
+        },
+        "Height": {
+          "target": "com.amazonaws.quicksight#TableFieldHeight",
+          "traits": {
+            "smithy.api#documentation": "<p>The height color for the table cells.</p>"
+          }
+        },
+        "Border": {
+          "target": "com.amazonaws.quicksight#GlobalTableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The borders for the table cells.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table cell style for a cell in pivot table or table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Integer": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.quicksight#ParameterValueType": {
+      "type": "enum",
+      "members": {
+        "MULTI_VALUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI_VALUED"
+          }
+        },
+        "SINGLE_VALUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SINGLE_VALUED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DashboardCustomizationVisualOptions": {
+      "type": "structure",
+      "members": {
+        "FieldsConfiguration": {
+          "target": "com.amazonaws.quicksight#VisualCustomizationFieldsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that controls field customization options available to dashboard readers for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that define customizations available to dashboard readers for a specific visual</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RowSortList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FieldSortOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchyCountyString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericRangeFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IncludeMinimum": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines whether the minimum value in the filter value range should be included in the filtered results.</p>"
+          }
+        },
+        "IncludeMaximum": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines whether the maximum value in the filter value range should be included in the filtered results.</p>"
+          }
+        },
+        "RangeMinimum": {
+          "target": "com.amazonaws.quicksight#NumericRangeFilterValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum value for the filter value range.</p>"
+          }
+        },
+        "RangeMaximum": {
+          "target": "com.amazonaws.quicksight#NumericRangeFilterValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum value for the filter value range.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#NumericFilterSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Select all of the values. Null is not the assigned value of select all.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FILTER_ALL_VALUES</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the filter.</p>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>NumericRangeFilter</code> filters values that are within the value range.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionBasedLayoutCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "PaperCanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#SectionBasedLayoutPaperCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for a paper canvas of a section-based layout.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for the canvas of a section-based layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisLinearScale": {
+      "type": "structure",
+      "members": {
+        "StepCount": {
+          "target": "com.amazonaws.quicksight#Integer",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The step count setup of a linear axis.</p>"
+          }
+        },
+        "StepSize": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The step size setup of a linear axis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The liner axis scale setup.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIFieldWells": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a KPI visual.</p>"
+          }
+        },
+        "TargetValues": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The target value field wells of a KPI visual.</p>"
+          }
+        },
+        "TrendGroups": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The trend group field wells of a KPI visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "ScatterPlotLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a scatter plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartOrientation": {
+      "type": "enum",
+      "members": {
+        "HORIZONTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HORIZONTAL"
+          }
+        },
+        "VERTICAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VERTICAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeHierarchy": {
+      "type": "structure",
+      "members": {
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The hierarchy ID of the <code>DateTime</code> hierarchy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DrillDownFilters": {
+          "target": "com.amazonaws.quicksight#DrillDownFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the drill down filters for the\n                <code>DateTime</code> hierarchy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the hierarchy of any <code>DateTime</code> fields.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PercentNumber": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ForecastConfiguration": {
+      "type": "structure",
+      "members": {
+        "ForecastProperties": {
+          "target": "com.amazonaws.quicksight#TimeBasedForecastProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The forecast properties setup of a forecast in the line\n            chart.</p>"
+          }
+        },
+        "Scenario": {
+          "target": "com.amazonaws.quicksight#ForecastScenario",
+          "traits": {
+            "smithy.api#documentation": "<p>The forecast scenario of a forecast in the line chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The forecast configuration that is used in a line chart's display properties.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TextBoxInteractionOptions": {
+      "type": "structure",
+      "members": {
+        "TextBoxMenuOption": {
+          "target": "com.amazonaws.quicksight#TextBoxMenuOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The menu options for the textbox.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The general textbox interactions setup for textbox publish options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GridLayoutElement"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 430
+        }
+      }
+    },
+    "com.amazonaws.quicksight#StaticFile": {
+      "type": "structure",
+      "members": {
+        "ImageStaticFile": {
+          "target": "com.amazonaws.quicksight#ImageStaticFile",
+          "traits": {
+            "smithy.api#documentation": "<p>The image static file.</p>"
+          }
+        },
+        "SpatialStaticFile": {
+          "target": "com.amazonaws.quicksight#SpatialStaticFile",
+          "traits": {
+            "smithy.api#documentation": "<p>The spacial static file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The static file.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CurrencyCode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[A-Z]{3}$"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionOperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#VisualCustomActionOperation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PieChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the category fields.</p>"
+          }
+        },
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of categories that are displayed in a pie chart.</p>"
+          }
+        },
+        "SmallMultiplesSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the small multiples field.</p>"
+          }
+        },
+        "SmallMultiplesLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of small multiples panels that are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a pie chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarsArrangement": {
+      "type": "enum",
+      "members": {
+        "CLUSTERED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTERED"
+          }
+        },
+        "STACKED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STACKED"
+          }
+        },
+        "STACKED_PERCENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STACKED_PERCENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableInlineVisualizationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TableInlineVisualization"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ContextMenuOption": {
+      "type": "structure",
+      "members": {
+        "AvailabilityStatus": {
+          "target": "com.amazonaws.quicksight#DashboardBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The availability status of the context menu options. If the value of this property is set to <code>ENABLED</code>, dashboard readers can interact with the context menu.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The context menu options for a visual's interactions.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericFilterSelectAllOptions": {
+      "type": "enum",
+      "members": {
+        "FILTER_ALL_VALUES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FILTER_ALL_VALUES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AggregationFunction": {
+      "type": "structure",
+      "members": {
+        "NumericalAggregationFunction": {
+          "target": "com.amazonaws.quicksight#NumericalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>Aggregation for numerical values.</p>"
+          }
+        },
+        "CategoricalAggregationFunction": {
+          "target": "com.amazonaws.quicksight#CategoricalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>Aggregation for categorical values.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COUNT</code>: Aggregate by the total number of values, including duplicates.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISTINCT_COUNT</code>: Aggregate by the total number of distinct values.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DateAggregationFunction": {
+          "target": "com.amazonaws.quicksight#DateAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>Aggregation for date values.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COUNT</code>: Aggregate by the total number of values, including duplicates.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISTINCT_COUNT</code>: Aggregate by the total number of distinct values.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MIN</code>: Select the smallest date value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MAX</code>: Select the largest date value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "AttributeAggregationFunction": {
+          "target": "com.amazonaws.quicksight#AttributeAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>Aggregation for attributes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An aggregation function aggregates values from a dimension or measure.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerItem": {
+      "type": "structure",
+      "members": {
+        "LayerId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the layer.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LayerType": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The layer type.</p>"
+          }
+        },
+        "DataSource": {
+          "target": "com.amazonaws.quicksight#GeospatialDataSourceItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The data source for the layer.</p>"
+          }
+        },
+        "Label": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The label that is displayed for the layer.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of visibility for the layer.</p>"
+          }
+        },
+        "LayerDefinition": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition properties for a layer.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions"
+        },
+        "JoinDefinition": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerJoinDefinition",
+          "traits": {
+            "smithy.api#documentation": "<p>The join definition properties for a layer.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#LayerCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of custom actions for a layer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties for a single geospatial layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterGroupList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FilterGroup"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#UnicodeIcon": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[^\\u0000-\\u00FF]$"
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartPrimaryValueConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the primary value text color.</p>"
+          }
+        },
+        "Icon": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the primary value icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the primary value of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Groups": {
+          "target": "com.amazonaws.quicksight#TreeMapDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The group by field well of a tree map. Values are grouped based on group by fields.</p>"
+          }
+        },
+        "Sizes": {
+          "target": "com.amazonaws.quicksight#TreeMapMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The size field well of a tree map. Values are aggregated based on group by fields.</p>"
+          }
+        },
+        "Colors": {
+          "target": "com.amazonaws.quicksight#TreeMapMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color field well of a tree map. Values are grouped by aggregations based on group by fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Aggregated field wells of a tree map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementColumnSpan": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 36
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterDateTimePickerControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DateTimePickerControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlDateTimePickerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>FilterDropDownControl</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MULTI_SELECT</code>: The user can select multiple entries from a dropdown menu.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_SELECT</code>: The user can select a single entry from a dropdown menu.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configurationof the Apply button on a <code>DateTimePickerControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control from a date filter that is used to specify date and time.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetImage"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartType": {
+      "type": "enum",
+      "members": {
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        },
+        "AREA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AREA"
+          }
+        },
+        "STACKED_AREA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STACKED_AREA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomActionOperation": {
+      "type": "structure",
+      "members": {
+        "FilterOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionFilterOperation"
+        },
+        "NavigationOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionNavigationOperation"
+        },
+        "URLOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionURLOperation"
+        },
+        "SetParametersOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionSetParametersOperation"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The operation that is defined by the custom action.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#VisualCustomAction"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BinCountLimit": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingGradientColor": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression that determines the formatting configuration for gradient color.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#GradientColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for gradient color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericSeparatorSymbol": {
+      "type": "enum",
+      "members": {
+        "COMMA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMMA"
+          }
+        },
+        "DOT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOT"
+          }
+        },
+        "SPACE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPACE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartValuesFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DataPathColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataPathColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldOption": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID for a table field.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width for a table field.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#CustomLabel",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label for a table field.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of a table field.</p>"
+          }
+        },
+        "URLStyling": {
+          "target": "com.amazonaws.quicksight#TableFieldURLConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL configuration for a table field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for a table field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "TargetValues": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The target value field wells of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeValueWhenUnsetConfiguration": {
+      "type": "structure",
+      "members": {
+        "ValueWhenUnsetOption": {
+          "target": "com.amazonaws.quicksight#ValueWhenUnsetOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The built-in options for default values. The value can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>RECOMMENDED</code>: The recommended value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code>: The <code>NULL</code> value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomValue": {
+          "target": "com.amazonaws.quicksight#SensitiveTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom value that's used when the value of a parameter isn't set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>DateTime</code> parameter when a value has not been set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingIconSetType": {
+      "type": "enum",
+      "members": {
+        "PLUS_MINUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PLUS_MINUS"
+          }
+        },
+        "CHECK_X": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHECK_X"
+          }
+        },
+        "THREE_COLOR_ARROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THREE_COLOR_ARROW"
+          }
+        },
+        "THREE_GRAY_ARROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THREE_GRAY_ARROW"
+          }
+        },
+        "CARET_UP_MINUS_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CARET_UP_MINUS_DOWN"
+          }
+        },
+        "THREE_SHAPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THREE_SHAPE"
+          }
+        },
+        "THREE_CIRCLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THREE_CIRCLE"
+          }
+        },
+        "FLAGS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FLAGS"
+          }
+        },
+        "BARS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BARS"
+          }
+        },
+        "FOUR_COLOR_ARROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FOUR_COLOR_ARROW"
+          }
+        },
+        "FOUR_GRAY_ARROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FOUR_GRAY_ARROW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultNewSheetConfiguration": {
+      "type": "structure",
+      "members": {
+        "InteractiveLayoutConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultInteractiveLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default settings for interactive layout configuration.</p>"
+          }
+        },
+        "PaginatedLayoutConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultPaginatedLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default settings for a paginated layout configuration.</p>"
+          }
+        },
+        "SheetContentType": {
+          "target": "com.amazonaws.quicksight#SheetContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the sheet content type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for default new sheet settings.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#IntegerParameterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#IntegerParameter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableTotalsScrollStatus": {
+      "type": "enum",
+      "members": {
+        "PINNED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PINNED"
+          }
+        },
+        "SCROLLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCROLLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartConditionalFormattingOption": {
+      "type": "structure",
+      "members": {
+        "PrimaryValue": {
+          "target": "com.amazonaws.quicksight#GaugeChartPrimaryValueConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the primary value of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "Arc": {
+          "target": "com.amazonaws.quicksight#GaugeChartArcConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the arc of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Conditional formatting options of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SimpleNumericalAggregationFunction": {
+      "type": "enum",
+      "members": {
+        "SUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUM"
+          }
+        },
+        "AVERAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVERAGE"
+          }
+        },
+        "MIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIN"
+          }
+        },
+        "MAX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAX"
+          }
+        },
+        "COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT"
+          }
+        },
+        "DISTINCT_COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISTINCT_COUNT"
+          }
+        },
+        "VAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VAR"
+          }
+        },
+        "VARP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARP"
+          }
+        },
+        "STDEV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STDEV"
+          }
+        },
+        "STDEVP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STDEVP"
+          }
+        },
+        "MEDIAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIAN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MissingDataTreatmentOption": {
+      "type": "enum",
+      "members": {
+        "INTERPOLATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERPOLATE"
+          }
+        },
+        "SHOW_AS_ZERO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHOW_AS_ZERO"
+          }
+        },
+        "SHOW_AS_BLANK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHOW_AS_BLANK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialGradientColor": {
+      "type": "structure",
+      "members": {
+        "StepColors": {
+          "target": "com.amazonaws.quicksight#GeospatialGradientStepColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of gradient step colors for the gradient.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NullDataVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of visibility for null data.</p>"
+          }
+        },
+        "NullDataSettings": {
+          "target": "com.amazonaws.quicksight#GeospatialNullDataSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The null data visualization settings.</p>"
+          }
+        },
+        "DefaultOpacity": {
+          "target": "com.amazonaws.quicksight#Opacity",
+          "traits": {
+            "smithy.api#documentation": "<p>The default opacity for the gradient color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition for a gradient color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialHeatmapColorScale": {
+      "type": "structure",
+      "members": {
+        "Colors": {
+          "target": "com.amazonaws.quicksight#GeospatialHeatmapDataColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of colors to be used in heatmap point style.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color scale specification for the heatmap point style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PieChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#PieChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a pie chart.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A pie or donut chart.</p>\n         <p>The <code>PieChartVisual</code> structure describes a visual that is a member of the pie chart family.</p>\n         <p>The following charts can be described by using this structure:</p>\n         <ul>\n            <li>\n               <p>Pie charts</p>\n            </li>\n            <li>\n               <p>Donut charts</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/pie-chart.html\">Using pie charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/donut-chart.html\">Using donut charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisDefinition": {
+      "type": "structure",
+      "members": {
+        "DataSetIdentifierDeclarations": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifierDeclarationList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of dataset identifier declarations. This mapping allows the usage of dataset identifiers instead\n            of dataset ARNs throughout analysis sub-structures.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Sheets": {
+          "target": "com.amazonaws.quicksight#SheetDefinitionList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of sheet definitions for an analysis. Each <code>SheetDefinition</code> provides detailed information about\n            a sheet within this analysis.</p>"
+          }
+        },
+        "CalculatedFields": {
+          "target": "com.amazonaws.quicksight#CalculatedFields",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of calculated field definitions for the analysis.</p>"
+          }
+        },
+        "ParameterDeclarations": {
+          "target": "com.amazonaws.quicksight#ParameterDeclarationList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of parameter declarations for an analysis.</p>\n         <p>Parameters are named variables that can transfer a value for use by an action or an object.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/parameters-in-quicksight.html\">Parameters in Amazon Quick Sight</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "FilterGroups": {
+          "target": "com.amazonaws.quicksight#FilterGroupList",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter definitions for an analysis.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/adding-a-filter.html\">Filtering Data in Amazon Quick Sight</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "ColumnConfigurations": {
+          "target": "com.amazonaws.quicksight#ColumnConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            An array of analysis-level column configurations. Column configurations can be used to set default\n            formatting for a column to be used throughout an analysis.\n        </p>"
+          }
+        },
+        "AnalysisDefaults": {
+          "target": "com.amazonaws.quicksight#AnalysisDefaults"
+        },
+        "Options": {
+          "target": "com.amazonaws.quicksight#AssetOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of option definitions for an analysis.</p>"
+          }
+        },
+        "QueryExecutionOptions": {
+          "target": "com.amazonaws.quicksight#QueryExecutionOptions"
+        },
+        "StaticFiles": {
+          "target": "com.amazonaws.quicksight#StaticFileList",
+          "traits": {
+            "smithy.api#documentation": "<p>The static files for the definition.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition of an analysis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CrossDatasetTypes": {
+      "type": "enum",
+      "members": {
+        "ALL_DATASETS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_DATASETS"
+          }
+        },
+        "SINGLE_DATASET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SINGLE_DATASET"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TotalAggregationComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The total aggregation computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SankeyDiagramVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#SankeyDiagramChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a sankey diagram.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A sankey diagram.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/sankey-diagram.html\">Using Sankey diagrams</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TransposedTableOption": {
+      "type": "structure",
+      "members": {
+        "ColumnIndex": {
+          "target": "com.amazonaws.quicksight#TransposedColumnIndex",
+          "traits": {
+            "smithy.api#documentation": "<p>The index of a columns in a transposed table. The index range is 0-9999.</p>"
+          }
+        },
+        "ColumnWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of a column in a transposed table.</p>"
+          }
+        },
+        "ColumnType": {
+          "target": "com.amazonaws.quicksight#TransposedColumnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The column type of the column in a transposed table. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ROW_HEADER_COLUMN</code>: Refers to the leftmost column of the row header in the transposed table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>VALUE_COLUMN</code>: Refers to all value columns in the transposed table.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The column option of the transposed table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisLabelReferenceOptions": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field that the axis label is targeted to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the axis label is targeted to.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The reference that specifies where the axis label is applied to.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldTooltipItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the field that is targeted by the tooltip.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Label": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The label of the tooltip item.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the tooltip item.</p>"
+          }
+        },
+        "TooltipTarget": {
+          "target": "com.amazonaws.quicksight#TooltipTarget",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the target of the field tooltip item in a combo chart visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tooltip item for the fields.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GrowthRatePeriodSize": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 2,
+          "max": 52
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PaginationConfiguration": {
+      "type": "structure",
+      "members": {
+        "PageSize": {
+          "target": "com.amazonaws.quicksight#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates how many items render in one page.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PageNumber": {
+          "target": "com.amazonaws.quicksight#PageNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the page number.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The pagination configuration for a table visual or boxplot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomAction": {
+      "type": "structure",
+      "members": {
+        "CustomActionId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>VisualCustomAction</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the <code>VisualCustomAction</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the <code>VisualCustomAction</code>.</p>"
+          }
+        },
+        "Trigger": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionTrigger",
+          "traits": {
+            "smithy.api#documentation": "<p>The trigger of the <code>VisualCustomAction</code>.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DATA_POINT_CLICK</code>: Initiates a custom action by a left pointer click on a data point.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DATA_POINT_MENU</code>: Initiates a custom action by right pointer click from the menu.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActionOperations": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionOperationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>VisualCustomActionOperations</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A custom action defined on a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SmallMultiplesDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PluginVisualProperty"
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomActionTrigger": {
+      "type": "enum",
+      "members": {
+        "DATA_POINT_CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_CLICK"
+          }
+        },
+        "DATA_POINT_MENU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_POINT_MENU"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartStartAngle": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": -360,
+          "max": 360
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ThousandSeparatorOptions": {
+      "type": "structure",
+      "members": {
+        "Symbol": {
+          "target": "com.amazonaws.quicksight#NumericSeparatorSymbol",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the thousands separator symbol.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the thousands separator.</p>"
+          }
+        },
+        "GroupingStyle": {
+          "target": "com.amazonaws.quicksight#DigitGroupingStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the way numbers are styled to accommodate different readability standards. The <code>DEFAULT</code> value uses the standard international grouping system and groups numbers by the thousands. The <code>LAKHS</code> value uses the Indian numbering system and groups numbers by lakhs and crores.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the thousands separator configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlInfoIconText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FontSize": {
+      "type": "structure",
+      "members": {
+        "Relative": {
+          "target": "com.amazonaws.quicksight#RelativeFontSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The lexical name for the text size, proportional to its surrounding context.</p>"
+          }
+        },
+        "Absolute": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The font size that you want to use in px.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the text display size.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#HistogramMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a histogram. Values are aggregated by <code>COUNT</code> or <code>DISTINCT_COUNT</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a histogram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableRowsLabelText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DataPathValue": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the field that needs to be sorted.</p>"
+          }
+        },
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#FieldValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The actual value of the field that needs to be sorted.</p>"
+          }
+        },
+        "DataPathType": {
+          "target": "com.amazonaws.quicksight#DataPathType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data path that needs to be sorted.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#URLTargetConfiguration": {
+      "type": "enum",
+      "members": {
+        "NEW_TAB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEW_TAB"
+          }
+        },
+        "NEW_WINDOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEW_WINDOW"
+          }
+        },
+        "SAME_TAB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SAME_TAB"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#EmptyVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The data set that is used in the empty visual. Every visual requires a dataset to render.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An empty visual.</p>\n         <p>Empty visuals are used in layouts but have not been configured to show any data. A new visual created in the Quick Sight console is considered an <code>EmptyVisual</code> until a visual type is selected.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CascadingControlSource": {
+      "type": "structure",
+      "members": {
+        "SourceSheetControlId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The source sheet control ID of a <code>CascadingControlSource</code>.</p>"
+          }
+        },
+        "ColumnToMatch": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column identifier that determines which column to look up for the source sheet control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source controls that are used in a <code>CascadingControlConfiguration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PercentageDisplayFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "Prefix": {
+          "target": "com.amazonaws.quicksight#Prefix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the prefix value of the percentage format.</p>"
+          }
+        },
+        "Suffix": {
+          "target": "com.amazonaws.quicksight#Suffix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the suffix value of the percentage format.</p>"
+          }
+        },
+        "SeparatorConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericSeparatorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the numeric separator configuration.</p>"
+          }
+        },
+        "DecimalPlacesConfiguration": {
+          "target": "com.amazonaws.quicksight#DecimalPlacesConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the decimal places configuration.</p>"
+          }
+        },
+        "NegativeValueConfiguration": {
+          "target": "com.amazonaws.quicksight#NegativeValueConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the negative value configuration.</p>"
+          }
+        },
+        "NullValueFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NullValueFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the percentage display format configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TargetVisualList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotFieldWells": {
+      "type": "structure",
+      "members": {
+        "BoxPlotAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#BoxPlotAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a box plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a <code>BoxPlotVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotOptions": {
+      "type": "structure",
+      "members": {
+        "StyleOptions": {
+          "target": "com.amazonaws.quicksight#BoxPlotStyleOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The style options of the box plot.</p>"
+          }
+        },
+        "OutlierVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the outlier in a box plot.</p>"
+          }
+        },
+        "AllDataPointsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of all data points of the box plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options of a box plot visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalPlaces": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayerMapVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the visual.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions"
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions"
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerMapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset that is used to create the layer map visual. You can't create a visual without a dataset.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A layer map visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AnchorDateConfiguration": {
+      "type": "structure",
+      "members": {
+        "AnchorOption": {
+          "target": "com.amazonaws.quicksight#AnchorOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for the date configuration. Choose one of the options below:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NOW</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that is used for the anchor date configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The date configuration of the filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ListControlSelectAllOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the <code>Select all</code> options in a list control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of the <code>Select all</code> options in a list control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisDisplayMinMaxRange": {
+      "type": "structure",
+      "members": {
+        "Minimum": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The minimum setup for an axis display range.</p>"
+          }
+        },
+        "Maximum": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The maximum setup for an axis display range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The minimum and maximum setup for an axis display range.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudFieldWells": {
+      "type": "structure",
+      "members": {
+        "WordCloudAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#WordCloudAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a word cloud.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a word cloud visual.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableBorderStyle": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PixelLength": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "String based length that is composed of value and unit in px"
+      }
+    },
+    "com.amazonaws.quicksight#NumberFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the numeric format configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for number fields.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NonEmptyString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.quicksight#AllSheetsFilterScopeConfiguration": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>An empty object that represents that the <code>AllSheets</code> option is the chosen value for the <code>FilterScopeConfiguration</code> parameter. This structure applies the filter to all visuals on all sheets of an Analysis, Dashboard, or Template.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TablePinnedFieldOptions": {
+      "type": "structure",
+      "members": {
+        "PinnedLeftFields": {
+          "target": "com.amazonaws.quicksight#TableFieldOrderList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of columns to be pinned to the left of a table visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The settings for the pinned columns of a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlListType": {
+      "type": "enum",
+      "members": {
+        "MULTI_SELECT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI_SELECT"
+          }
+        },
+        "SINGLE_SELECT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SINGLE_SELECT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerDefinition": {
+      "type": "structure",
+      "members": {
+        "PointLayer": {
+          "target": "com.amazonaws.quicksight#GeospatialPointLayer",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition for a point layer.</p>"
+          }
+        },
+        "LineLayer": {
+          "target": "com.amazonaws.quicksight#GeospatialLineLayer",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition for a line layer.</p>"
+          }
+        },
+        "PolygonLayer": {
+          "target": "com.amazonaws.quicksight#GeospatialPolygonLayer",
+          "traits": {
+            "smithy.api#documentation": "<p>The definition for a polygon layer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition properties for a geospatial layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLinePatternType": {
+      "type": "enum",
+      "members": {
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        },
+        "DASHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DASHED"
+          }
+        },
+        "DOTTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOTTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldIconSetType": {
+      "type": "enum",
+      "members": {
+        "LINK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TextAreaControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "PlaceholderOptions": {
+          "target": "com.amazonaws.quicksight#TextControlPlaceholderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the placeholder options in a text area control.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SameSheetTargetVisualConfiguration": {
+      "type": "structure",
+      "members": {
+        "TargetVisuals": {
+          "target": "com.amazonaws.quicksight#TargetVisualList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the target visual IDs that are located in the same sheet of the analysis.</p>"
+          }
+        },
+        "TargetVisualOptions": {
+          "target": "com.amazonaws.quicksight#TargetVisualOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that choose the target visual in the same sheet.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VISUALS</code>: Applies the filter operation to all visuals in the same sheet.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of the same-sheet target visuals that you want to be filtered.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomActionOperation": {
+      "type": "structure",
+      "members": {
+        "NavigationOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionNavigationOperation"
+        },
+        "URLOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionURLOperation"
+        },
+        "SetParametersOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionSetParametersOperation"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The operation that is defined by the custom action.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CategoricalDimensionField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>CategoricalDimensionField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom hierarchy ID.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#StringFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dimension type field with categorical type columns..</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataPathColor": {
+      "type": "structure",
+      "members": {
+        "Element": {
+          "target": "com.amazonaws.quicksight#DataPathValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The element that the color needs to be applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color that needs to be applied to the element.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The time granularity of the field that the color needs to be applied to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color map that determines the color options for a particular element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlDateTimePickerType": {
+      "type": "enum",
+      "members": {
+        "SINGLE_VALUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SINGLE_VALUED"
+          }
+        },
+        "DATE_RANGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE_RANGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#LineChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a line chart.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#LineChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a line chart.</p>"
+          }
+        },
+        "ForecastConfigurations": {
+          "target": "com.amazonaws.quicksight#ForecastConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The forecast configuration of a line chart.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#LineChartType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the type of the line chart.</p>"
+          }
+        },
+        "SmallMultiplesOptions": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples setup for the visual.</p>"
+          }
+        },
+        "XAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the x-axis.</p>"
+          }
+        },
+        "XAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the x-axis label.</p>"
+          }
+        },
+        "PrimaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#LineSeriesAxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The series axis configuration of a line chart.</p>"
+          }
+        },
+        "PrimaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the y-axis label.</p>"
+          }
+        },
+        "SecondaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#LineSeriesAxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The series axis configuration of a line chart.</p>"
+          }
+        },
+        "SecondaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the secondary y-axis label.</p>"
+          }
+        },
+        "SingleAxisOptions": {
+          "target": "com.amazonaws.quicksight#SingleAxisOptions"
+        },
+        "DefaultSeriesSettings": {
+          "target": "com.amazonaws.quicksight#LineChartDefaultSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default presentation of all line series in <code>LineChartVisual</code>.</p>"
+          }
+        },
+        "Series": {
+          "target": "com.amazonaws.quicksight#SeriesItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>The series item configuration of a line chart.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend configuration of a line chart.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data label configuration of a line chart.</p>"
+          }
+        },
+        "ReferenceLines": {
+          "target": "com.amazonaws.quicksight#ReferenceLineList",
+          "traits": {
+            "smithy.api#documentation": "<p>The reference lines configuration of a line chart.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip configuration of a line chart.</p>"
+          }
+        },
+        "ContributionAnalysisDefaults": {
+          "target": "com.amazonaws.quicksight#ContributionAnalysisDefaultList",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configuration of a line chart's contribution analysis.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual palette configuration of a line chart.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeDefaultValues": {
+      "type": "structure",
+      "members": {
+        "DynamicValue": {
+          "target": "com.amazonaws.quicksight#DynamicDefaultValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The dynamic value of the  <code>DataTimeDefaultValues</code>. Different defaults are displayed according to users, groups, and values mapping.</p>"
+          }
+        },
+        "StaticValues": {
+          "target": "com.amazonaws.quicksight#DateTimeDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The static values of the <code>DataTimeDefaultValues</code>.</p>"
+          }
+        },
+        "RollingDate": {
+          "target": "com.amazonaws.quicksight#RollingDateConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The rolling date of the <code>DataTimeDefaultValues</code>. The date is determined from the dataset based on input expression.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default values of the <code>DateTimeParameterDeclaration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCategoricalDataColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GeospatialCategoricalDataColor"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveTimestampList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveTimestamp"
+      }
+    },
+    "com.amazonaws.quicksight#ResizeOption": {
+      "type": "enum",
+      "members": {
+        "FIXED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIXED"
+          }
+        },
+        "RESPONSIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESPONSIVE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "ScreenCanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#GridLayoutScreenCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the sizing of the canvas used in a grid layout.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration options for the canvas of a grid layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Seasonality": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 180
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldCollapseState": {
+      "type": "enum",
+      "members": {
+        "COLLAPSED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLLAPSED"
+          }
+        },
+        "EXPANDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXPANDED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ColumnConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Longitude": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": -1800,
+          "max": 1800
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableFieldOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartColorConfiguration": {
+      "type": "structure",
+      "members": {
+        "ForegroundColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The foreground color configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The background color configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color configuration of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SliderControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalParameterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DecimalParameter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#HexColorWithTransparency": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^#[A-F0-9]{6}(?:[A-F0-9]{2})?$"
+      }
+    },
+    "com.amazonaws.quicksight#ArcOptions": {
+      "type": "structure",
+      "members": {
+        "ArcThickness": {
+          "target": "com.amazonaws.quicksight#ArcThickness",
+          "traits": {
+            "smithy.api#documentation": "<p>The arc thickness of a <code>GaugeChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the arc thickness of a <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PeriodsForward": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AxisBinding": {
+      "type": "enum",
+      "members": {
+        "PRIMARY_YAXIS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRIMARY_YAXIS"
+          }
+        },
+        "SECONDARY_YAXIS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECONDARY_YAXIS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialColor": {
+      "type": "structure",
+      "members": {
+        "Solid": {
+          "target": "com.amazonaws.quicksight#GeospatialSolidColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization properties for the solid color.</p>"
+          }
+        },
+        "Gradient": {
+          "target": "com.amazonaws.quicksight#GeospatialGradientColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization properties for the gradient color.</p>"
+          }
+        },
+        "Categorical": {
+          "target": "com.amazonaws.quicksight#GeospatialCategoricalColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization properties for the categorical color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The visualization properties for solid, gradient, and categorical colors.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColumnRole": {
+      "type": "enum",
+      "members": {
+        "DIMENSION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIMENSION"
+          }
+        },
+        "MEASURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEASURE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoryDrillDownFilter": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CategoryValues": {
+          "target": "com.amazonaws.quicksight#CategoryValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the string inputs that are the values of the category drill down filter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The category drill down filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutScreenCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "OptimizedViewPortWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width that the view port will be optimized for when the layout renders.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the sizing of the canvas used in a free-form layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomActionOperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ImageCustomActionOperation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotFieldSortOptionsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotFieldSortOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialHeatmapDataColor": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The hex color to be used in the heatmap point style.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color to be used in the heatmap point style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DeleteAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.quicksight#DeleteAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.quicksight#DeleteAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.quicksight#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#UnsupportedUserEditionException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an analysis from Amazon Quick Sight. You can optionally include a recovery window during\n            which you can restore the analysis. If you don't specify a recovery window value, the\n            operation defaults to 30 days. Amazon Quick Sight attaches a <code>DeletionTime</code> stamp to\n            the response that specifies the end of the recovery window. At the end of the recovery\n            window, Amazon Quick Sight deletes the analysis permanently.</p>\n         <p>At any time before recovery window ends, you can use the <code>RestoreAnalysis</code>\n            API operation to remove the <code>DeletionTime</code> stamp and cancel the deletion of\n            the analysis. The analysis remains visible in the API until it's deleted, so you can\n            describe it but you can't make a template from it.</p>\n         <p>An analysis that's scheduled for deletion isn't accessible in the Amazon Quick Sight console.\n            To access it in the console, restore it. Deleting an analysis doesn't delete the\n            dashboards that you publish from it.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/accounts/{AwsAccountId}/analyses/{AnalysisId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#WaterfallChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for a waterfall visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A waterfall chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/waterfall-chart.html\">Using waterfall charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldComboSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>Field ID of the field for which you are setting the series configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#ComboChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Options that determine the presentation of series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field series item configuration of a <code>ComboChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableBorderOptions": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of a table border.</p>"
+          }
+        },
+        "Thickness": {
+          "target": "com.amazonaws.quicksight#TableBorderThickness",
+          "traits": {
+            "smithy.api#documentation": "<p>The thickness of a table border.</p>"
+          }
+        },
+        "Style": {
+          "target": "com.amazonaws.quicksight#TableBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The style (none, solid) of a table border.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The border options for a table border.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NonRepeatingVisualsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldCustomTextContent": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The string value of the custom text content for the table URL link content.</p>"
+          }
+        },
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration of the custom text content for the table URL link content.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom text content (value, font configuration) for the table link content configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerJoinDefinition": {
+      "type": "structure",
+      "members": {
+        "ShapeKeyField": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the field or property in the geospatial data source.</p>"
+          }
+        },
+        "DatasetKeyField": {
+          "target": "com.amazonaws.quicksight#UnaggregatedField"
+        },
+        "ColorField": {
+          "target": "com.amazonaws.quicksight#GeospatialLayerColorField",
+          "traits": {
+            "smithy.api#documentation": "<p>The geospatial color field for the join definition.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom actions for a layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomMoversComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "MoverSize": {
+          "target": "com.amazonaws.quicksight#TopBottomMoversComputationMoverSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The mover size setup of the top and bottom movers computation.</p>"
+          }
+        },
+        "SortOrder": {
+          "target": "com.amazonaws.quicksight#TopBottomSortOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort order setup of the top and bottom movers computation.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#TopBottomComputationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The computation type. Choose from the following options:</p>\n         <ul>\n            <li>\n               <p>TOP: Top movers computation.</p>\n            </li>\n            <li>\n               <p>BOTTOM: Bottom movers computation.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The top movers and bottom movers computation setup.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionContent": {
+      "type": "structure",
+      "members": {
+        "Layout": {
+          "target": "com.amazonaws.quicksight#SectionLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The layout configuration of a body section.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of content in a body section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialRadius": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapConditionalFormattingOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FilledMapConditionalFormattingOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ElementValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomActionFilterOperation": {
+      "type": "structure",
+      "members": {
+        "SelectedFieldsConfiguration": {
+          "target": "com.amazonaws.quicksight#FilterOperationSelectedFieldsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that chooses the fields to be filtered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetVisualsConfiguration": {
+          "target": "com.amazonaws.quicksight#FilterOperationTargetVisualsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that chooses the target visuals to be filtered.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter operation that filters data included in a visual or in an entire sheet.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Parameters": {
+      "type": "structure",
+      "members": {
+        "StringParameters": {
+          "target": "com.amazonaws.quicksight#StringParameterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameters that have a data type of string.</p>"
+          }
+        },
+        "IntegerParameters": {
+          "target": "com.amazonaws.quicksight#IntegerParameterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameters that have a data type of integer.</p>"
+          }
+        },
+        "DecimalParameters": {
+          "target": "com.amazonaws.quicksight#DecimalParameterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameters that have a data type of decimal.</p>"
+          }
+        },
+        "DateTimeParameters": {
+          "target": "com.amazonaws.quicksight#DateTimeParameterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameters that have a data type of date-time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of Quick Sight parameters and the list's override values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomActionTrigger": {
+      "type": "enum",
+      "members": {
+        "CLICK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLICK"
+          }
+        },
+        "MENU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MENU"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapStyle": {
+      "type": "structure",
+      "members": {
+        "BaseMapStyle": {
+          "target": "com.amazonaws.quicksight#BaseMapStyleType",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected base map style.</p>"
+          }
+        },
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The background color and opacity values for a map.</p>"
+          }
+        },
+        "BaseMapVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of visibility for the base map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The map style properties for a map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecalStyleType": {
+      "type": "enum",
+      "members": {
+        "Manual": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Manual"
+          }
+        },
+        "Auto": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Auto"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TransposedColumnType": {
+      "type": "enum",
+      "members": {
+        "ROW_HEADER_COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROW_HEADER_COLUMN"
+          }
+        },
+        "VALUE_COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE_COLUMN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLineWidth": {
+      "type": "structure",
+      "members": {
+        "LineWidth": {
+          "target": "com.amazonaws.quicksight#GeospatialWidth",
+          "traits": {
+            "smithy.api#documentation": "<p>The positive value for the width of a line.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The width properties for a line.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AggregationSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that determines the sort order of aggregated values.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SortDirection": {
+          "target": "com.amazonaws.quicksight#SortDirection",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort direction of values.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ASC</code>: Sort in ascending order.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DESC</code>: Sort in descending order.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The function that aggregates the values in <code>Column</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration options to sort aggregated values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Filter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#FilledMapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "ConditionalFormatting": {
+          "target": "com.amazonaws.quicksight#FilledMapConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of a <code>FilledMapVisual</code>.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        },
+        "GeocodingPreferences": {
+          "target": "com.amazonaws.quicksight#GeocodePreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The geocoding prefences for filled map visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A filled map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/filled-maps.html\">Creating filled maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TooltipTarget": {
+      "type": "enum",
+      "members": {
+        "BOTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOTH"
+          }
+        },
+        "BAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BAR"
+          }
+        },
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DashboardBehavior": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NegativeValueConfiguration": {
+      "type": "structure",
+      "members": {
+        "DisplayMode": {
+          "target": "com.amazonaws.quicksight#NegativeValueDisplayMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the display mode of the negative value configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the negative value configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecalPatternType": {
+      "type": "enum",
+      "members": {
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        },
+        "DIAGONAL_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_MEDIUM"
+          }
+        },
+        "CIRCLE_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE_MEDIUM"
+          }
+        },
+        "DIAMOND_GRID_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_GRID_MEDIUM"
+          }
+        },
+        "CHECKERBOARD_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHECKERBOARD_MEDIUM"
+          }
+        },
+        "TRIANGLE_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRIANGLE_MEDIUM"
+          }
+        },
+        "DIAGONAL_OPPOSITE_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_OPPOSITE_MEDIUM"
+          }
+        },
+        "DIAMOND_MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_MEDIUM"
+          }
+        },
+        "DIAGONAL_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_LARGE"
+          }
+        },
+        "CIRCLE_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE_LARGE"
+          }
+        },
+        "DIAMOND_GRID_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_GRID_LARGE"
+          }
+        },
+        "CHECKERBOARD_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHECKERBOARD_LARGE"
+          }
+        },
+        "TRIANGLE_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRIANGLE_LARGE"
+          }
+        },
+        "DIAGONAL_OPPOSITE_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_OPPOSITE_LARGE"
+          }
+        },
+        "DIAMOND_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_LARGE"
+          }
+        },
+        "DIAGONAL_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_SMALL"
+          }
+        },
+        "CIRCLE_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE_SMALL"
+          }
+        },
+        "DIAMOND_GRID_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_GRID_SMALL"
+          }
+        },
+        "CHECKERBOARD_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHECKERBOARD_SMALL"
+          }
+        },
+        "TRIANGLE_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRIANGLE_SMALL"
+          }
+        },
+        "DIAGONAL_OPPOSITE_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAGONAL_OPPOSITE_SMALL"
+          }
+        },
+        "DIAMOND_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIAMOND_SMALL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Prefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#HeatMapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a heat map.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A heat map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/heat-map.html\">Using heat maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableTotalsPlacement": {
+      "type": "enum",
+      "members": {
+        "START": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START"
+          }
+        },
+        "END": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "END"
+          }
+        },
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartOptions": {
+      "type": "structure",
+      "members": {
+        "PrimaryValueDisplayType": {
+          "target": "com.amazonaws.quicksight#PrimaryValueDisplayType",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the primary value display type.</p>"
+          }
+        },
+        "Comparison": {
+          "target": "com.amazonaws.quicksight#ComparisonConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The comparison configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "ArcAxis": {
+          "target": "com.amazonaws.quicksight#ArcAxisConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The arc axis configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "Arc": {
+          "target": "com.amazonaws.quicksight#ArcConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The arc configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "PrimaryValueFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the primary value font configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the <code>GaugeChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#URLOperationTemplate": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualFieldWells": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PluginVisualFieldWell"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#KPISparklineOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the sparkline.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#KPISparklineType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the sparkline.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the sparkline.</p>"
+          }
+        },
+        "TooltipVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip visibility of the sparkline.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the visibility, color, type, and tooltip visibility of the sparkline of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetVisualScopingConfigurations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetVisualScopingConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ItemsLimitConfiguration": {
+      "type": "structure",
+      "members": {
+        "ItemsLimit": {
+          "target": "com.amazonaws.quicksight#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The limit on how many items of a field are showed in the chart. For\n            example, the number of slices that are displayed in a pie chart.</p>"
+          }
+        },
+        "OtherCategories": {
+          "target": "com.amazonaws.quicksight#OtherCategories",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>Show\n                other</code> of an axis in the chart. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INCLUDE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>EXCLUDE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The limit configuration of the visual display for an axis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetElementConfigurationOverrides": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the overrides are visible. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>VISIBLE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>HIDDEN</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The override configuration of the rendering rules of a sheet.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterDeclaration": {
+      "type": "structure",
+      "members": {
+        "StringParameterDeclaration": {
+          "target": "com.amazonaws.quicksight#StringParameterDeclaration",
+          "traits": {
+            "smithy.api#documentation": "<p>A parameter declaration for the <code>String</code> data type.</p>"
+          }
+        },
+        "DecimalParameterDeclaration": {
+          "target": "com.amazonaws.quicksight#DecimalParameterDeclaration",
+          "traits": {
+            "smithy.api#documentation": "<p>A parameter declaration for the <code>Decimal</code> data type.</p>"
+          }
+        },
+        "IntegerParameterDeclaration": {
+          "target": "com.amazonaws.quicksight#IntegerParameterDeclaration",
+          "traits": {
+            "smithy.api#documentation": "<p>A parameter declaration for the <code>Integer</code> data type.</p>"
+          }
+        },
+        "DateTimeParameterDeclaration": {
+          "target": "com.amazonaws.quicksight#DateTimeParameterDeclaration",
+          "traits": {
+            "smithy.api#documentation": "<p>A parameter declaration for the <code>DateTime</code> data type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The declaration definition of a parameter.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/parameters-in-quicksight.html\">Parameters in Amazon Quick Sight</a> in the <i>Amazon Quick Suite User Guide</i>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NullValueFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "NullString": {
+          "target": "com.amazonaws.quicksight#NullString",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the null string of null values.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CategoryValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DrillDownFilter": {
+      "type": "structure",
+      "members": {
+        "NumericEqualityFilter": {
+          "target": "com.amazonaws.quicksight#NumericEqualityDrillDownFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The numeric equality type drill down filter. This filter is used for number type columns.</p>"
+          }
+        },
+        "CategoryFilter": {
+          "target": "com.amazonaws.quicksight#CategoryDrillDownFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The category type drill down filter. This filter is used for string type columns.</p>"
+          }
+        },
+        "TimeRangeFilter": {
+          "target": "com.amazonaws.quicksight#TimeRangeDrillDownFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The time range drill down filter. This filter is used for date time columns.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The drill down filter for the column hierarchies.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LegendOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the legend is visible.</p>"
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom title for the legend.</p>"
+          }
+        },
+        "Position": {
+          "target": "com.amazonaws.quicksight#LegendPosition",
+          "traits": {
+            "smithy.api#documentation": "<p>The positions for the legend. Choose one of the following\n            options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AUTO</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RIGHT</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>BOTTOM</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>LEFT</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the legend. If this value is omitted, a default width is used when rendering.</p>"
+          }
+        },
+        "Height": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The height of the legend. If this value is omitted, a default height is used when\n            rendering.</p>"
+          }
+        },
+        "ValueFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for the legend setup of a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DayOfTheWeek": {
+      "type": "enum",
+      "members": {
+        "SUNDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUNDAY"
+          }
+        },
+        "MONDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MONDAY"
+          }
+        },
+        "TUESDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TUESDAY"
+          }
+        },
+        "WEDNESDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WEDNESDAY"
+          }
+        },
+        "THURSDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THURSDAY"
+          }
+        },
+        "FRIDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FRIDAY"
+          }
+        },
+        "SATURDAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SATURDAY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartColorConfiguration": {
+      "type": "structure",
+      "members": {
+        "GroupColorConfiguration": {
+          "target": "com.amazonaws.quicksight#WaterfallChartGroupColorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The color configuration for individual groups within a waterfall visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color configuration of a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionBasedLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "HeaderSections": {
+          "target": "com.amazonaws.quicksight#HeaderFooterSectionConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of header section configurations.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BodySections": {
+          "target": "com.amazonaws.quicksight#BodySectionConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of body section configurations.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FooterSections": {
+          "target": "com.amazonaws.quicksight#HeaderFooterSectionConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of footer section configurations.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#SectionBasedLayoutCanvasSizeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for the canvas of a section-based layout.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a\n            section-based layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapFieldWells": {
+      "type": "structure",
+      "members": {
+        "HeatMapAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#HeatMapAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a heat map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a heat map.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldBarSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>Field ID of the field for which you are setting the series configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#BarChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Options that determine the presentation of bar series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field series item configuration of a  <code>BarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisLogarithmicScale": {
+      "type": "structure",
+      "members": {
+        "Base": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The base setup of a logarithmic axis scale.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The logarithmic axis scale setup.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialWidth": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldOptions": {
+      "type": "structure",
+      "members": {
+        "SelectedFieldOptions": {
+          "target": "com.amazonaws.quicksight#TableFieldOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The field options to be configured to a table.</p>"
+          }
+        },
+        "Order": {
+          "target": "com.amazonaws.quicksight#FieldOrderList",
+          "traits": {
+            "smithy.api#documentation": "<p>The order of the field IDs that are configured as field options for a table visual.</p>"
+          }
+        },
+        "PinnedFieldOptions": {
+          "target": "com.amazonaws.quicksight#TablePinnedFieldOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The settings for the pinned columns of a table visual.</p>"
+          }
+        },
+        "TransposedTableOptions": {
+          "target": "com.amazonaws.quicksight#TransposedTableOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>TableOptions</code> of a transposed table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field options of a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ExplicitHierarchy": {
+      "type": "structure",
+      "members": {
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The hierarchy ID of the explicit hierarchy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Columns": {
+          "target": "com.amazonaws.quicksight#ExplicitHierarchyColumnList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of columns that define the explicit hierarchy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DrillDownFilters": {
+          "target": "com.amazonaws.quicksight#DrillDownFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the drill down filters for the explicit hierarchy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the hierarchy of the fields that are built within a visual's field wells. These fields can't be duplicated to other visuals.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataLabelType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "GroupBy": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The group by field well for a pivot table. Values are grouped by group by fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values field well for a pivot table. Values are aggregated based on group by fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well for the table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomColorsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#CustomColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormattingScope": {
+      "type": "structure",
+      "members": {
+        "Role": {
+          "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingScopeRole",
+          "traits": {
+            "smithy.api#documentation": "<p>The role (field, field total, grand total) of the cell for conditional formatting.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The scope of the cell for conditional formatting.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComparisonConfiguration": {
+      "type": "structure",
+      "members": {
+        "ComparisonMethod": {
+          "target": "com.amazonaws.quicksight#ComparisonMethod",
+          "traits": {
+            "smithy.api#documentation": "<p>The method of the comparison. Choose from the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DIFFERENCE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>PERCENT_DIFFERENCE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>PERCENT</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "ComparisonFormat": {
+          "target": "com.amazonaws.quicksight#ComparisonFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the comparison.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The comparison display configuration of a KPI or gauge chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPointStyle": {
+      "type": "structure",
+      "members": {
+        "CircleSymbolStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialCircleSymbolStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The circle symbol style for a point layer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The point style for a point layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericalDimensionField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>NumericalDimensionField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom hierarchy ID.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumberFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dimension type field with numerical type columns.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SingleAxisOptions": {
+      "type": "structure",
+      "members": {
+        "YAxisOptions": {
+          "target": "com.amazonaws.quicksight#YAxisOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The Y axis options of a single axis configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The settings of a chart's single axis configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageInteractionOptions": {
+      "type": "structure",
+      "members": {
+        "ImageMenuOption": {
+          "target": "com.amazonaws.quicksight#ImageMenuOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The menu options for the image.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The general image interactions setup for image publish options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#KPIFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a KPI visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#KPISortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a KPI visual.</p>"
+          }
+        },
+        "KPIOptions": {
+          "target": "com.amazonaws.quicksight#KPIOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of a KPI visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Computation": {
+      "type": "structure",
+      "members": {
+        "TopBottomRanked": {
+          "target": "com.amazonaws.quicksight#TopBottomRankedComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The top ranked and bottom ranked computation configuration.</p>"
+          }
+        },
+        "TopBottomMovers": {
+          "target": "com.amazonaws.quicksight#TopBottomMoversComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The top movers and bottom movers computation configuration.</p>"
+          }
+        },
+        "TotalAggregation": {
+          "target": "com.amazonaws.quicksight#TotalAggregationComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The total aggregation computation configuration.</p>"
+          }
+        },
+        "MaximumMinimum": {
+          "target": "com.amazonaws.quicksight#MaximumMinimumComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum and minimum computation configuration.</p>"
+          }
+        },
+        "MetricComparison": {
+          "target": "com.amazonaws.quicksight#MetricComparisonComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The metric comparison computation configuration.</p>"
+          }
+        },
+        "PeriodOverPeriod": {
+          "target": "com.amazonaws.quicksight#PeriodOverPeriodComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The period over period computation configuration.</p>"
+          }
+        },
+        "PeriodToDate": {
+          "target": "com.amazonaws.quicksight#PeriodToDateComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The period to <code>DataSetIdentifier</code> computation configuration.</p>"
+          }
+        },
+        "GrowthRate": {
+          "target": "com.amazonaws.quicksight#GrowthRateComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The growth rate computation configuration.</p>"
+          }
+        },
+        "UniqueValues": {
+          "target": "com.amazonaws.quicksight#UniqueValuesComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique values computation configuration.</p>"
+          }
+        },
+        "Forecast": {
+          "target": "com.amazonaws.quicksight#ForecastComputation",
+          "traits": {
+            "smithy.api#documentation": "<p>The forecast computation configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The computation union that is used in an insight visual.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterControl": {
+      "type": "structure",
+      "members": {
+        "DateTimePicker": {
+          "target": "com.amazonaws.quicksight#ParameterDateTimePickerControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control from a date parameter that specifies date and time.</p>"
+          }
+        },
+        "List": {
+          "target": "com.amazonaws.quicksight#ParameterListControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a list with buttons or boxes that are used to select either a single value or multiple values.</p>"
+          }
+        },
+        "Dropdown": {
+          "target": "com.amazonaws.quicksight#ParameterDropDownControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a dropdown list with buttons that are used to select a single value.</p>"
+          }
+        },
+        "TextField": {
+          "target": "com.amazonaws.quicksight#ParameterTextFieldControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a text box that is used to enter a single entry.</p>"
+          }
+        },
+        "TextArea": {
+          "target": "com.amazonaws.quicksight#ParameterTextAreaControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a text box that is used to enter multiple entries.</p>"
+          }
+        },
+        "Slider": {
+          "target": "com.amazonaws.quicksight#ParameterSliderControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a horizontal toggle bar. This is used to change a value by sliding the toggle.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The control of a parameter that users can interact with in a dashboard or an analysis.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartDefaultSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings for all bar series in the visual.</p>"
+          }
+        },
+        "BorderSettings": {
+          "target": "com.amazonaws.quicksight#BorderSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Border settings for all bar series in the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default presentation of all bar series in <code>BarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Suffix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#LabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the label is visible.</p>"
+          }
+        },
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration of the label.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text for the label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The share label options for the labels.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartGroupColorConfiguration": {
+      "type": "structure",
+      "members": {
+        "PositiveBarColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the color for the positive bars of a waterfall chart.</p>"
+          }
+        },
+        "NegativeBarColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the color for the negative bars of a waterfall chart.</p>"
+          }
+        },
+        "TotalBarColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the color for the total bars of a waterfall chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color configuration for individual groups within a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisError": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.quicksight#AnalysisErrorType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the analysis error.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The message associated with the analysis error.</p>"
+          }
+        },
+        "ViolatedEntities": {
+          "target": "com.amazonaws.quicksight#EntityList",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists the violated entities that caused the analysis error</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Analysis error.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#ComboChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A combo chart.</p>\n         <p>The <code>ComboChartVisual</code> includes stacked bar combo charts and clustered bar combo charts</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/combo-charts.html\">Using combo charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldSeriesItem": {
+          "target": "com.amazonaws.quicksight#FieldSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The field series item configuration of a line chart.</p>"
+          }
+        },
+        "DataFieldSeriesItem": {
+          "target": "com.amazonaws.quicksight#DataFieldSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The data field series item configuration of a line chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The series item configuration of a line chart.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineInterpolation": {
+      "type": "enum",
+      "members": {
+        "LINEAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINEAR"
+          }
+        },
+        "SMOOTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMOOTH"
+          }
+        },
+        "STEPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STEPPED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DataColor": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color that is applied to the data value.</p>"
+          }
+        },
+        "DataValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The data value that the color is applied to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the color that is applied to a particular data value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RelativeDateTimeControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "DateTimeFormat": {
+          "target": "com.amazonaws.quicksight#DateTimeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Customize how dates are formatted in controls.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartOptions": {
+      "type": "structure",
+      "members": {
+        "TotalBarLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines the total bar label of a waterfall visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveLong": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#ScatterPlotFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#ScatterPlotSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a scatter plot.</p>"
+          }
+        },
+        "XAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of the scatter plot's x-axis.</p>"
+          }
+        },
+        "XAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, and axis step) of the scatter plot's x-axis.</p>"
+          }
+        },
+        "YAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) of the scatter plot's y-axis.</p>"
+          }
+        },
+        "YAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label display options (grid line, range, scale, and axis step) of the scatter plot's y-axis.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a scatter plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIActualValueConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the actual value's text color.</p>"
+          }
+        },
+        "Icon": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the actual value's icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the actual value of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLine": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the reference line. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "DataConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineDataConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The data configuration of the reference line.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StyleConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineStyleConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The style configuration of the reference line.</p>"
+          }
+        },
+        "LabelConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineLabelConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The label configuration of the reference line.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The reference line visual display options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableCellConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the cell for conditional formatting.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TextFormat": {
+          "target": "com.amazonaws.quicksight#TextConditionalFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The text format of the cell for conditional formatting.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The cell conditional formatting option for a table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultFilterListControlOptions": {
+      "type": "structure",
+      "members": {
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#ListControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>DefaultFilterListControlOptions</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MULTI_SELECT</code>: The user can select multiple entries from the list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_SELECT</code>: The user can select a single entry from the list.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#FilterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>List</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ConditionalFormattingOptions": {
+          "target": "com.amazonaws.quicksight#FilledMapConditionalFormattingOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>Conditional formatting options of a <code>FilledMapVisual</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting of a <code>FilledMapVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Sheet": {
+      "type": "structure",
+      "members": {
+        "SheetId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier associated with a sheet.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#SheetName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a sheet. This name is displayed on the sheet's tab in the Quick Sight\n            console.</p>"
+          }
+        },
+        "Images": {
+          "target": "com.amazonaws.quicksight#SheetImageList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of images on a sheet.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <i>sheet</i>, which is an object that contains a set of visuals that\n            are viewed together on one page in Quick Sight. Every analysis and dashboard\n            contains at least one sheet. Each sheet contains at least one visualization widget, for\n            example a chart, pivot table, or narrative insight. Sheets can be associated with other\n            components, such as controls, filters, and so on.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AssetOptions": {
+      "type": "structure",
+      "members": {
+        "Timezone": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the timezone for the analysis.</p>"
+          }
+        },
+        "WeekStart": {
+          "target": "com.amazonaws.quicksight#DayOfTheWeek",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the week start day for an analysis.</p>"
+          }
+        },
+        "QBusinessInsightsStatus": {
+          "target": "com.amazonaws.quicksight#QBusinessInsightsStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether insight summaries from Amazon Q Business are allowed in Dashboard Q&A.</p>"
+          }
+        },
+        "ExcludedDataSetArns": {
+          "target": "com.amazonaws.quicksight#DataSetArnsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of dataset ARNS to exclude from Dashboard Q&A.</p>"
+          }
+        },
+        "CustomActionDefaults": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionDefaults",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of visual custom actions for the analysis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An array of analysis level configurations.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BorderSettings": {
+      "type": "structure",
+      "members": {
+        "BorderVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Visibility setting for the border.</p>"
+          }
+        },
+        "BorderWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>Width of the border. Valid range is from 1px to 8px.</p>"
+          }
+        },
+        "BorderColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>Color of the border.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Border settings configuration for visual elements, including visibility, width, and color properties.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HexColor": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^#[A-F0-9]{6}$"
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElement": {
+      "type": "structure",
+      "members": {
+        "ElementId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for an element within a grid layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ElementType": {
+          "target": "com.amazonaws.quicksight#LayoutElementType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of element.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ColumnIndex": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementColumnIndex",
+          "traits": {
+            "smithy.api#documentation": "<p>The column index for the upper left corner of an element.</p>"
+          }
+        },
+        "ColumnSpan": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementColumnSpan",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of a grid element expressed as a number of grid columns.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RowIndex": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementRowIndex",
+          "traits": {
+            "smithy.api#documentation": "<p>The row index for the upper left corner of an element.</p>"
+          }
+        },
+        "RowSpan": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementRowSpan",
+          "traits": {
+            "smithy.api#documentation": "<p>The height of a grid element expressed as a number of grid rows.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BorderStyle": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The border style configuration of a grid layout element.</p>"
+          }
+        },
+        "SelectedBorderStyle": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The border style configuration of a grid layout element. This border style is used when the element is selected.</p>"
+          }
+        },
+        "BackgroundStyle": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementBackgroundStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The background style configuration of a grid layout element.</p>"
+          }
+        },
+        "LoadingAnimation": {
+          "target": "com.amazonaws.quicksight#LoadingAnimation"
+        },
+        "BorderRadius": {
+          "target": "com.amazonaws.quicksight#BorderRadius",
+          "traits": {
+            "smithy.api#documentation": "<p>The border radius of a grid layout element.</p>"
+          }
+        },
+        "Padding": {
+          "target": "com.amazonaws.quicksight#Padding",
+          "traits": {
+            "smithy.api#documentation": "<p>The padding of a grid layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An element within a grid layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PercentVisibleRange": {
+      "type": "structure",
+      "members": {
+        "From": {
+          "target": "com.amazonaws.quicksight#PercentNumber",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The lower bound of the range.</p>"
+          }
+        },
+        "To": {
+          "target": "com.amazonaws.quicksight#PercentNumber",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The top bound of the range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The percent range in the visible range.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TotalAggregationOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TotalAggregationOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DescribeAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.quicksight#DescribeAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.quicksight#DescribeAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.quicksight#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#UnsupportedUserEditionException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a summary of the metadata for an analysis.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/accounts/{AwsAccountId}/analyses/{AnalysisId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartLineStyleSettings": {
+      "type": "structure",
+      "members": {
+        "LineVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration option that determines whether to show the line for the series.</p>"
+          }
+        },
+        "LineInterpolation": {
+          "target": "com.amazonaws.quicksight#LineInterpolation",
+          "traits": {
+            "smithy.api#documentation": "<p>Interpolation style for line series.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>LINEAR</code>: Show as default, linear style.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SMOOTH</code>: Show as a smooth curve.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STEPPED</code>: Show steps in line.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "LineStyle": {
+          "target": "com.amazonaws.quicksight#LineChartLineStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Line style for line series.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SOLID</code>: Show as a solid line.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DOTTED</code>: Show as a dotted line.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DASHED</code>: Show as a dashed line.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "LineWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>Width that determines the line thickness.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Line styles options for a line series in <code>LineChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BaseMapStyleType": {
+      "type": "enum",
+      "members": {
+        "LIGHT_GRAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LIGHT_GRAY"
+          }
+        },
+        "DARK_GRAY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DARK_GRAY"
+          }
+        },
+        "STREET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STREET"
+          }
+        },
+        "IMAGERY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IMAGERY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisErrorType": {
+      "type": "enum",
+      "members": {
+        "ACCESS_DENIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCESS_DENIED"
+          }
+        },
+        "SOURCE_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_NOT_FOUND"
+          }
+        },
+        "DATA_SET_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_SET_NOT_FOUND"
+          }
+        },
+        "INTERNAL_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_FAILURE"
+          }
+        },
+        "PARAMETER_VALUE_INCOMPATIBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARAMETER_VALUE_INCOMPATIBLE"
+          }
+        },
+        "PARAMETER_TYPE_INVALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARAMETER_TYPE_INVALID"
+          }
+        },
+        "PARAMETER_NOT_FOUND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARAMETER_NOT_FOUND"
+          }
+        },
+        "COLUMN_TYPE_MISMATCH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLUMN_TYPE_MISMATCH"
+          }
+        },
+        "COLUMN_GEOGRAPHIC_ROLE_MISMATCH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLUMN_GEOGRAPHIC_ROLE_MISMATCH"
+          }
+        },
+        "COLUMN_REPLACEMENT_MISSING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLUMN_REPLACEMENT_MISSING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapFieldWells": {
+      "type": "structure",
+      "members": {
+        "GeospatialMapAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#GeospatialMapAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field well for a geospatial map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a <code>GeospatialMapVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionStyle": {
+      "type": "structure",
+      "members": {
+        "Height": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The height of a section.</p>\n         <p>Heights can only be defined for header and footer sections. The default height margin is 0.5 inches. </p>"
+          }
+        },
+        "Padding": {
+          "target": "com.amazonaws.quicksight#Spacing",
+          "traits": {
+            "smithy.api#documentation": "<p>The spacing between section content and its top, bottom, left, and right edges.</p>\n         <p>There is no padding by default.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that style a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapNavigation": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ArcThickness": {
+      "type": "enum",
+      "members": {
+        "SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMALL"
+          }
+        },
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LARGE"
+          }
+        },
+        "WHOLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WHOLE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MeasureField": {
+      "type": "structure",
+      "members": {
+        "NumericalMeasureField": {
+          "target": "com.amazonaws.quicksight#NumericalMeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The measure type field with numerical type columns.</p>"
+          }
+        },
+        "CategoricalMeasureField": {
+          "target": "com.amazonaws.quicksight#CategoricalMeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The measure type field with categorical type columns.</p>"
+          }
+        },
+        "DateMeasureField": {
+          "target": "com.amazonaws.quicksight#DateMeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The measure type field with date type columns.</p>"
+          }
+        },
+        "CalculatedMeasureField": {
+          "target": "com.amazonaws.quicksight#CalculatedMeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The calculated measure field only used in pivot tables.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The measure (metric) type field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementColumnIndex": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 35
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomActionColumnList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PercentileValue": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomActionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#LayerCustomAction"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MaximumMinimumComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#MaximumMinimumComputationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of computation. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>MAXIMUM: A maximum computation.</p>\n            </li>\n            <li>\n               <p>MINIMUM: A minimum computation.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The maximum and minimum computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UnlimitedPixelLength": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "String based length that is composed of value and unit in px with Integer.MAX_VALUE as maximum value"
+      }
+    },
+    "com.amazonaws.quicksight#InnerFilter": {
+      "type": "structure",
+      "members": {
+        "CategoryInnerFilter": {
+          "target": "com.amazonaws.quicksight#CategoryInnerFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>CategoryInnerFilter</code> filters text values for the <code>NestedFilter</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>InnerFilter</code> defines the subset of data to be used with the <code>NestedFilter</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#HistogramConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for a <code>HistogramVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A histogram.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/histogram-charts.html\">Using histograms</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartMarkerStyleSettings": {
+      "type": "structure",
+      "members": {
+        "MarkerVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration option that determines whether to show the markers in the series.</p>"
+          }
+        },
+        "MarkerShape": {
+          "target": "com.amazonaws.quicksight#LineChartMarkerShape",
+          "traits": {
+            "smithy.api#documentation": "<p>Shape option for markers in the series.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CIRCLE</code>: Show marker as a circle.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRIANGLE</code>: Show marker as a triangle.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SQUARE</code>: Show marker as a square.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND</code>: Show marker as a diamond.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ROUNDED_SQUARE</code>: Show marker as a rounded square.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "MarkerSize": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>Size of marker in the series.</p>"
+          }
+        },
+        "MarkerColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Color of marker in the series.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Marker styles options for a line series in <code>LineChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomActionSetParametersOperation": {
+      "type": "structure",
+      "members": {
+        "ParameterValueConfigurations": {
+          "target": "com.amazonaws.quicksight#SetParameterValueConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter that determines the value configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The set parameter operation that sets parameters in custom action.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomNarrativeOptions": {
+      "type": "structure",
+      "members": {
+        "Narrative": {
+          "target": "com.amazonaws.quicksight#NarrativeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The string input of custom narrative.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom narrative options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataLabelContent": {
+      "type": "enum",
+      "members": {
+        "VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE"
+          }
+        },
+        "PERCENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT"
+          }
+        },
+        "VALUE_AND_PERCENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE_AND_PERCENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoryFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Configuration": {
+          "target": "com.amazonaws.quicksight#CategoryFilterConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for a <code>CategoryFilter</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>CategoryFilter</code> filters text values.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/add-a-text-filter-data-prep.html\">Adding text filters</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TextFieldControlDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TitleOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to configure the title visibility, name, and font size.</p>"
+          }
+        },
+        "PlaceholderOptions": {
+          "target": "com.amazonaws.quicksight#TextControlPlaceholderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of the placeholder options in a text field control.</p>"
+          }
+        },
+        "InfoIconLabelOptions": {
+          "target": "com.amazonaws.quicksight#SheetControlInfoIconLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of info icon label options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options of a control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableStyleTarget": {
+      "type": "structure",
+      "members": {
+        "CellType": {
+          "target": "com.amazonaws.quicksight#StyledCellType",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell type of the table style target.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table style target.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Sheet"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultPaginatedLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "SectionBased": {
+          "target": "com.amazonaws.quicksight#DefaultSectionBasedLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default settings for a section-based layout configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default settings for a paginated layout configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlTitle": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#HistogramConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#HistogramFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a histogram.</p>"
+          }
+        },
+        "XAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the x-axis.</p>"
+          }
+        },
+        "XAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the x-axis label.</p>"
+          }
+        },
+        "YAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the y-axis.</p>"
+          }
+        },
+        "BinOptions": {
+          "target": "com.amazonaws.quicksight#HistogramBinOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of histogram bins.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data label configuration of a histogram.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip configuration of a histogram.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual palette configuration of a histogram.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a <code>HistogramVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "StringFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#StringFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for string fields.</p>"
+          }
+        },
+        "NumberFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumberFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for number fields.</p>"
+          }
+        },
+        "DateTimeFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#DateTimeFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for <code>DateTime</code> fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The formatting configuration for all types of field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultInteractiveLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "Grid": {
+          "target": "com.amazonaws.quicksight#DefaultGridLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default settings for a grid layout configuration.</p>"
+          }
+        },
+        "FreeForm": {
+          "target": "com.amazonaws.quicksight#DefaultFreeFormLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the default settings of a free-form layout configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default settings for interactive layout configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#RadarChartCategoryFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field well categories of a radar chart.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#RadarChartColorFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color that are assigned to the aggregated field wells of a radar chart.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#RadarChartValuesFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are assigned to the aggregated field wells of a radar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well configuration of a <code>RadarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#YAxisOptions": {
+      "type": "structure",
+      "members": {
+        "YAxis": {
+          "target": "com.amazonaws.quicksight#SingleYAxisOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The Y axis type to be used in the chart.</p>\n         <p>If you choose <code>PRIMARY_Y_AXIS</code>, the primary Y Axis is located on the leftmost vertical axis of the chart.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that are available for a single Y axis in a chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PeriodsBackward": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingCustomIconOptions": {
+      "type": "structure",
+      "members": {
+        "Icon": {
+          "target": "com.amazonaws.quicksight#Icon",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the type of icon.</p>"
+          }
+        },
+        "UnicodeIcon": {
+          "target": "com.amazonaws.quicksight#UnicodeIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the Unicode icon type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Custom icon options for an icon set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PredefinedHierarchy": {
+      "type": "structure",
+      "members": {
+        "HierarchyId": {
+          "target": "com.amazonaws.quicksight#HierarchyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The hierarchy ID of the predefined hierarchy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Columns": {
+          "target": "com.amazonaws.quicksight#PredefinedHierarchyColumnList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of columns that define the predefined hierarchy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DrillDownFilters": {
+          "target": "com.amazonaws.quicksight#DrillDownFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the drill down filters for the predefined hierarchy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that determines the hierarchy of the fields that are defined during data preparation. These fields are available to use in any analysis that uses the data source.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CalculatedFieldExpression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32000
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#PieChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "PieChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#PieChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a pie chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a pie chart.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ContributionAnalysisDefault": {
+      "type": "structure",
+      "members": {
+        "MeasureFieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The measure field that is used in the contribution analysis.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContributorDimensions": {
+          "target": "com.amazonaws.quicksight#ContributorDimensionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimensions columns that are used in the contribution analysis,\n            usually a list of <code>ColumnIdentifiers</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The contribution analysis visual display for a line, pie, or bar chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataPathValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataPathValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DecimalValueWhenUnsetConfiguration": {
+      "type": "structure",
+      "members": {
+        "ValueWhenUnsetOption": {
+          "target": "com.amazonaws.quicksight#ValueWhenUnsetOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The built-in options for default values. The value can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>RECOMMENDED</code>: The recommended value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code>: The <code>NULL</code> value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomValue": {
+          "target": "com.amazonaws.quicksight#SensitiveDouble",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>A custom value that's used when the value of a parameter isn't set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>Decimal</code> parameter when a value has not been set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormLayoutElement": {
+      "type": "structure",
+      "members": {
+        "ElementId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for an element within a free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ElementType": {
+          "target": "com.amazonaws.quicksight#LayoutElementType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of element.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "XAxisLocation": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The x-axis coordinate of the element.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "YAxisLocation": {
+          "target": "com.amazonaws.quicksight#UnlimitedPixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The y-axis coordinate of the element.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of an element within a free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Height": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The height of an element within a free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of an element within a free-form layout.</p>"
+          }
+        },
+        "RenderingRules": {
+          "target": "com.amazonaws.quicksight#SheetElementRenderingRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rendering rules that determine when an element should be displayed within a free-form layout.</p>"
+          }
+        },
+        "BorderStyle": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutElementBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The border style configuration of a free-form layout element.</p>"
+          }
+        },
+        "SelectedBorderStyle": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutElementBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The border style configuration of a free-form layout element. This border style is used when the element is selected.</p>"
+          }
+        },
+        "BackgroundStyle": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutElementBackgroundStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The background style configuration of a free-form layout element.</p>"
+          }
+        },
+        "LoadingAnimation": {
+          "target": "com.amazonaws.quicksight#LoadingAnimation",
+          "traits": {
+            "smithy.api#documentation": "<p>The loading animation configuration of a free-form layout element.</p>"
+          }
+        },
+        "BorderRadius": {
+          "target": "com.amazonaws.quicksight#BorderRadius",
+          "traits": {
+            "smithy.api#documentation": "<p>The border radius of a free-form layout element.</p>"
+          }
+        },
+        "Padding": {
+          "target": "com.amazonaws.quicksight#Padding",
+          "traits": {
+            "smithy.api#documentation": "<p>The padding of a free-form layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An element within a free-form layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StringDefaultValues": {
+      "type": "structure",
+      "members": {
+        "DynamicValue": {
+          "target": "com.amazonaws.quicksight#DynamicDefaultValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The dynamic value of the <code>StringDefaultValues</code>. Different defaults displayed according to users, groups, and values mapping.</p>"
+          }
+        },
+        "StaticValues": {
+          "target": "com.amazonaws.quicksight#StringDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The static values of the <code>DecimalDefaultValues</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default values of the <code>StringParameterDeclaration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeParameterDeclaration": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that is being declared.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultValues": {
+          "target": "com.amazonaws.quicksight#DateTimeDefaultValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The default values of a parameter. If the parameter is a single-value parameter, a maximum of one default value can be provided.</p>"
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>"
+          }
+        },
+        "ValueWhenUnset": {
+          "target": "com.amazonaws.quicksight#DateTimeValueWhenUnsetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>DateTime</code> parameter when a value has not been set.</p>"
+          }
+        },
+        "MappedDataSetParameters": {
+          "target": "com.amazonaws.quicksight#MappedDataSetParameters"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A parameter declaration for the <code>DateTime</code> data type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ShortRichText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ParameterSliderControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the <code>ParameterSliderControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#SliderControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "MaximumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The larger value that is displayed at the right of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MinimumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The smaller value that is displayed at the left of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepSize": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of increments that the slider bar is divided into.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a horizontal toggle bar. This is used to change a value by sliding the toggle.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterNullOption": {
+      "type": "enum",
+      "members": {
+        "ALL_VALUES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_VALUES"
+          }
+        },
+        "NULLS_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NULLS_ONLY"
+          }
+        },
+        "NON_NULLS_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NON_NULLS_ONLY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TextBoxMenuOption": {
+      "type": "structure",
+      "members": {
+        "AvailabilityStatus": {
+          "target": "com.amazonaws.quicksight#DashboardBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The availability status of the textbox menu. If the value of this property is set to <code>ENABLED</code>, dashboard readers can interact with the textbox menu.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The menu options for the interactions of a textbox.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#TreeMapFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#TreeMapSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a tree map.</p>"
+          }
+        },
+        "GroupLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility) of the groups that are displayed in a tree map.</p>"
+          }
+        },
+        "SizeLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility) of the sizes that are displayed in a tree map.</p>"
+          }
+        },
+        "ColorLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility) for the colors displayed in a tree map.</p>"
+          }
+        },
+        "ColorScale": {
+          "target": "com.amazonaws.quicksight#ColorScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The color options (gradient color, point of divergence) of a tree map.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a tree map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartShape": {
+      "type": "enum",
+      "members": {
+        "CIRCLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE"
+          }
+        },
+        "POLYGON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POLYGON"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisibleRangeOptions": {
+      "type": "structure",
+      "members": {
+        "PercentRange": {
+          "target": "com.amazonaws.quicksight#PercentVisibleRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The percent range in the visible range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The range options for the data zoom scroll bar.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CreateAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.quicksight#CreateAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.quicksight#CreateAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.quicksight#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceExistsException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#UnsupportedUserEditionException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an analysis in Amazon Quick Sight. Analyses can be created either from a template or from an <code>AnalysisDefinition</code>.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/accounts/{AwsAccountId}/analyses/{AnalysisId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BarChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#BarChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A bar chart.</p>\n         <p>The <code>BarChartVisual</code> structure describes a visual that is a member of the bar chart family. The following charts can be described using this structure:</p>\n         <ul>\n            <li>\n               <p>Horizontal bar chart</p>\n            </li>\n            <li>\n               <p>Vertical bar chart</p>\n            </li>\n            <li>\n               <p>Horizontal stacked bar chart</p>\n            </li>\n            <li>\n               <p>Vertical stacked bar chart</p>\n            </li>\n            <li>\n               <p>Horizontal stacked 100% bar chart</p>\n            </li>\n            <li>\n               <p>Vertical stacked 100% bar chart</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/bar-charts.html\">Using bar charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SelectedFieldOptions": {
+      "type": "enum",
+      "members": {
+        "ALL_FIELDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_FIELDS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BooleanObject": {
+      "type": "boolean"
+    },
+    "com.amazonaws.quicksight#AnalysisErrorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#AnalysisError"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultTextFieldControlOptions": {
+      "type": "structure",
+      "members": {
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextFieldControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>TextField</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "TickLabelOptions": {
+          "target": "com.amazonaws.quicksight#AxisTickLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tick label options of an axis.</p>"
+          }
+        },
+        "AxisLineVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the axis line is visible.</p>"
+          }
+        },
+        "GridLineVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the grid line is visible.</p>"
+          }
+        },
+        "DataOptions": {
+          "target": "com.amazonaws.quicksight#AxisDataOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data options for an axis.</p>"
+          }
+        },
+        "ScrollbarOptions": {
+          "target": "com.amazonaws.quicksight#ScrollBarOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The scroll bar options for an axis.</p>"
+          }
+        },
+        "AxisOffset": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The offset value that determines the starting placement of the axis within a visual's bounds.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display options for the axis label.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapState": {
+      "type": "structure",
+      "members": {
+        "Bounds": {
+          "target": "com.amazonaws.quicksight#GeospatialCoordinateBounds"
+        },
+        "MapNavigation": {
+          "target": "com.amazonaws.quicksight#GeospatialMapNavigation",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables or disables map navigation for a map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The map state properties for a map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RollingDateConfiguration": {
+      "type": "structure",
+      "members": {
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The data set that is used in the rolling date configuration.</p>"
+          }
+        },
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression of the rolling date configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The rolling date configuration of a date time filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementRowSpan": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 21
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ParameterTextFieldControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the <code>ParameterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextFieldControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a text box that is used to enter a single entry.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ExcludePeriodConfiguration": {
+      "type": "structure",
+      "members": {
+        "Amount": {
+          "target": "com.amazonaws.quicksight#Integer",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The amount or number of the exclude period.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Granularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The granularity or unit (day, month, year) of the exclude period.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the exclude period. Choose from the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The exclude period of <code>TimeRangeFilter</code> or <code>RelativeDatesFilter</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of category fields.</p>"
+          }
+        },
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of categories displayed in a bar chart.</p>"
+          }
+        },
+        "ColorSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of color fields in a bar chart.</p>"
+          }
+        },
+        "ColorItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of values displayed in a bar chart.</p>"
+          }
+        },
+        "SmallMultiplesSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the small multiples field.</p>"
+          }
+        },
+        "SmallMultiplesLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of small multiples panels that are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>sort-configuration-description</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Visual"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "GridLayout": {
+          "target": "com.amazonaws.quicksight#GridLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A type of layout that can be used on a sheet. In a grid layout, visuals snap to a grid with standard spacing and alignment. Dashboards are displayed as designed, with options to fit to screen or view at actual size. A grid layout can be configured to behave in one of two ways when the viewport is resized: <code>FIXED</code> or <code>RESPONSIVE</code>.</p>"
+          }
+        },
+        "FreeFormLayout": {
+          "target": "com.amazonaws.quicksight#FreeFormLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A free-form is optimized for a fixed width and has more control over the exact placement of layout elements.</p>"
+          }
+        },
+        "SectionBasedLayout": {
+          "target": "com.amazonaws.quicksight#SectionBasedLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A section based layout organizes visuals into multiple sections and has customized header, footer and page break.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that determines what the type of layout will be used on a sheet.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultSliderControlOptions": {
+      "type": "structure",
+      "members": {
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#SliderControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlSliderType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>DefaultSliderControlOptions</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SINGLE_POINT</code>: Filter against(equals) a single data point.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code>: Filter data that is in a specified range.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "MaximumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The larger value that is displayed at the right of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MinimumValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The smaller value that is displayed at the left of the slider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepSize": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of increments that the slider bar is divided into.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>Slider</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableStyleTargetList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TableStyleTarget"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SelectedSheetsFilterScopeConfiguration": {
+      "type": "structure",
+      "members": {
+        "SheetVisualScopingConfigurations": {
+          "target": "com.amazonaws.quicksight#SheetVisualScopingConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The sheet ID and visual IDs of the sheet and visuals that the filter is applied to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for applying a filter to specific sheets or visuals. You can apply this filter to multiple visuals that are on one sheet or to all visuals on a sheet.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StringParameterDeclaration": {
+      "type": "structure",
+      "members": {
+        "ParameterValueType": {
+          "target": "com.amazonaws.quicksight#ParameterValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The value type determines whether the parameter is a single-value or multi-value parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that is being declared.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultValues": {
+          "target": "com.amazonaws.quicksight#StringDefaultValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The default values of a parameter. If the parameter is a single-value parameter, a maximum of one default value can be provided.</p>"
+          }
+        },
+        "ValueWhenUnset": {
+          "target": "com.amazonaws.quicksight#StringValueWhenUnsetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>String</code> parameter when a value has not been set.</p>"
+          }
+        },
+        "MappedDataSetParameters": {
+          "target": "com.amazonaws.quicksight#MappedDataSetParameters"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A parameter declaration for the <code>String</code> data type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomComputationType": {
+      "type": "enum",
+      "members": {
+        "TOP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TOP"
+          }
+        },
+        "BOTTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOTTOM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialNullSymbolStyle": {
+      "type": "structure",
+      "members": {
+        "FillColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the fill color.</p>"
+          }
+        },
+        "StrokeColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the stroke color.</p>"
+          }
+        },
+        "StrokeWidth": {
+          "target": "com.amazonaws.quicksight#GeospatialWidth",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the border stroke.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The symbol style for null data.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualPalette": {
+      "type": "structure",
+      "members": {
+        "ChartColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The chart color options for the visual palette.</p>"
+          }
+        },
+        "ColorMap": {
+          "target": "com.amazonaws.quicksight#DataPathColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color map options for the visual palette.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The visual display options for the visual palette.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LayerCustomActionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field wells of a line chart. Values are grouped by category fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a line chart. Values are aggregated based on categories.</p>"
+          }
+        },
+        "Colors": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color field wells of a line chart. Values are grouped by category fields.</p>"
+          }
+        },
+        "SmallMultiples": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples field well of a line chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SetParameterValueConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SetParameterValueConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Double": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.quicksight#KPIProgressBarConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ForegroundColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the progress bar's foreground color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the progress bar of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#FunnelChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#FunnelChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options of the categories that are displayed in a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "ValueLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options for the values that are displayed in a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "DataLabelOptions": {
+          "target": "com.amazonaws.quicksight#FunnelChartDataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the data labels.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual palette configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>FunnelChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialStaticFileSource": {
+      "type": "structure",
+      "members": {
+        "StaticFileId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the static file.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source properties for a geospatial static file.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BorderRadius": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoryInnerFilter": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "Configuration": {
+          "target": "com.amazonaws.quicksight#CategoryFilterConfiguration",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>CategoryInnerFilter</code> filters text values for the <code>NestedFilter</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#MetricComparisonComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "FromValue": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The field that is used in a metric comparison from value setup.</p>"
+          }
+        },
+        "TargetValue": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The field that is used in a metric comparison to value setup.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The metric comparison computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveStringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveString"
+      }
+    },
+    "com.amazonaws.quicksight#KPISortConfiguration": {
+      "type": "structure",
+      "members": {
+        "TrendGroupSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the trend group fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterTextFieldControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterTextFieldControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextFieldControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a text box that is used to enter a single entry.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartColorFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterTextAreaControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Delimiter": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDelimiter",
+          "traits": {
+            "smithy.api#documentation": "<p>The delimiter that is used to separate the lines in text.</p>"
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a text box that is used to enter multiple entries.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldURLConfiguration": {
+      "type": "structure",
+      "members": {
+        "LinkConfiguration": {
+          "target": "com.amazonaws.quicksight#TableFieldLinkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The link configuration of a table field URL.</p>"
+          }
+        },
+        "ImageConfiguration": {
+          "target": "com.amazonaws.quicksight#TableFieldImageConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The image configuration of a table field URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The URL configuration for a table field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableOrientation": {
+      "type": "enum",
+      "members": {
+        "VERTICAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VERTICAL"
+          }
+        },
+        "HORIZONTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HORIZONTAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AnchorOption": {
+      "type": "enum",
+      "members": {
+        "NOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCoordinateBounds": {
+      "type": "structure",
+      "members": {
+        "North": {
+          "target": "com.amazonaws.quicksight#Latitude",
+          "traits": {
+            "smithy.api#documentation": "<p>The latitude of the north bound of the geospatial coordinate bounds.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "South": {
+          "target": "com.amazonaws.quicksight#Latitude",
+          "traits": {
+            "smithy.api#documentation": "<p>The latitude of the south bound of the geospatial coordinate bounds.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "West": {
+          "target": "com.amazonaws.quicksight#Longitude",
+          "traits": {
+            "smithy.api#documentation": "<p>The longitude of the west bound of the geospatial coordinate bounds.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "East": {
+          "target": "com.amazonaws.quicksight#Longitude",
+          "traits": {
+            "smithy.api#documentation": "<p>The longitude of the east bound of the geospatial coordinate bounds.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The bound\n            options (north, south, west, east) of the geospatial window options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualTitleLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the title label.</p>"
+          }
+        },
+        "FormatText": {
+          "target": "com.amazonaws.quicksight#ShortFormatText",
+          "traits": {
+            "smithy.api#documentation": "<p>The short text format of the title label, such as plain text or rich text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The title label options for a visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UpdateAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.quicksight#UpdateAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.quicksight#UpdateAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.quicksight#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceExistsException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.quicksight#UnsupportedUserEditionException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an analysis in Amazon Quick Sight</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/accounts/{AwsAccountId}/analyses/{AnalysisId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialDataSourceItem": {
+      "type": "structure",
+      "members": {
+        "StaticFileDataSource": {
+          "target": "com.amazonaws.quicksight#GeospatialStaticFileSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The static file data source properties for the geospatial data.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data source properties for the geospatial data.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SmallMultiplesAxisPlacement": {
+      "type": "enum",
+      "members": {
+        "OUTSIDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OUTSIDE"
+          }
+        },
+        "INSIDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSIDE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "ComboChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#ComboChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a combo chart. Combo charts only have aggregated field wells. Columns in a combo chart are aggregated by category.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of the visual.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TextConditionalFormat": {
+      "type": "structure",
+      "members": {
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the text background color.</p>"
+          }
+        },
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the text color.</p>"
+          }
+        },
+        "Icon": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for the icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the text.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ChartAxisLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of an axis label on a chart. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>VISIBLE</code>: Shows the axis.</p>\n            </li>\n            <li>\n               <p>\n                  <code>HIDDEN</code>: Hides the axis.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SortIconVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the sort icon on a chart's axis label.</p>"
+          }
+        },
+        "AxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#AxisLabelOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options for a chart axis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The label options for an axis on a chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionBasedLayoutPaperCanvasSizeOptions": {
+      "type": "structure",
+      "members": {
+        "PaperSize": {
+          "target": "com.amazonaws.quicksight#PaperSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The paper size that is used to define canvas dimensions.</p>"
+          }
+        },
+        "PaperOrientation": {
+          "target": "com.amazonaws.quicksight#PaperOrientation",
+          "traits": {
+            "smithy.api#documentation": "<p>The paper orientation that\n            is used to define canvas dimensions. Choose one of the following\n            options:</p>\n         <ul>\n            <li>\n               <p>PORTRAIT</p>\n            </li>\n            <li>\n               <p>LANDSCAPE</p>\n            </li>\n         </ul>"
+          }
+        },
+        "PaperMargin": {
+          "target": "com.amazonaws.quicksight#Spacing",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the spacing between the canvas content and the top, bottom, left, and right edges.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for a paper canvas of a section-based layout.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisLabelOptionsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#AxisLabelOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoryFilterConfiguration": {
+      "type": "structure",
+      "members": {
+        "FilterListConfiguration": {
+          "target": "com.amazonaws.quicksight#FilterListConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of filter configurations. In the Quick Sight console, this filter type is called a filter list.</p>"
+          }
+        },
+        "CustomFilterListConfiguration": {
+          "target": "com.amazonaws.quicksight#CustomFilterListConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of custom filter values. In the Quick Sight console, this filter type is called a custom filter list.</p>"
+          }
+        },
+        "CustomFilterConfiguration": {
+          "target": "com.amazonaws.quicksight#CustomFilterConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom filter that filters based on a single value. This filter can be partially matched.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a <code>CategoryFilter</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#KPIConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a KPI visual.</p>"
+          }
+        },
+        "ConditionalFormatting": {
+          "target": "com.amazonaws.quicksight#KPIConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of a KPI visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key performance indicator (KPI).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/kpi.html\">Using KPIs</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TableFieldOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 201
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableRowsLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the rows label.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#PivotTableRowsLabelText",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label string for the rows label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for the label thta is located above the row headers. This option is only applicable when <code>RowsLayout</code> is set to <code>HIERARCHY</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldSubtotalOptions": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the subtotal options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The optional configuration of subtotals cells.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterListControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterListControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#ListControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>FilterListControl</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MULTI_SELECT</code>: The user can select multiple entries from the list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_SELECT</code>: The user can select a single entry from the list.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#FilterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        },
+        "CascadingControlConfiguration": {
+          "target": "com.amazonaws.quicksight#CascadingControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a list of buttons or boxes. This is used to select either a single value or multiple values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageScalingType": {
+      "type": "enum",
+      "members": {
+        "SCALE_TO_WIDTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCALE_TO_WIDTH"
+          }
+        },
+        "SCALE_TO_HEIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCALE_TO_HEIGHT"
+          }
+        },
+        "SCALE_TO_CONTAINER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCALE_TO_CONTAINER"
+          }
+        },
+        "SCALE_NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCALE_NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartDefaultSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "LineStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartLineStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Line styles options for all line series in the visual.</p>"
+          }
+        },
+        "MarkerStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartMarkerStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Marker styles options for all line series in the visual.</p>"
+          }
+        },
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings for all series in the visual.</p>"
+          }
+        },
+        "BorderSettings": {
+          "target": "com.amazonaws.quicksight#BorderSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Border settings for all bar series in the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default presentation of all series in <code>ComboChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisTickLabelOptions": {
+      "type": "structure",
+      "members": {
+        "LabelOptions": {
+          "target": "com.amazonaws.quicksight#LabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not the axis ticks are visible.</p>"
+          }
+        },
+        "RotationAngle": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The rotation angle of the axis tick labels.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tick label options of an axis.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableOptions": {
+      "type": "structure",
+      "members": {
+        "Orientation": {
+          "target": "com.amazonaws.quicksight#TableOrientation",
+          "traits": {
+            "smithy.api#documentation": "<p>The orientation (vertical, horizontal) for a table.</p>"
+          }
+        },
+        "HeaderStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of a table header.</p>"
+          }
+        },
+        "CellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of table cells.</p>"
+          }
+        },
+        "RowAlternateColorOptions": {
+          "target": "com.amazonaws.quicksight#RowAlternateColorOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The row alternate color options (widget status, row alternate colors) for a table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table options for a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DimensionField": {
+      "type": "structure",
+      "members": {
+        "NumericalDimensionField": {
+          "target": "com.amazonaws.quicksight#NumericalDimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimension type field with numerical type columns.</p>"
+          }
+        },
+        "CategoricalDimensionField": {
+          "target": "com.amazonaws.quicksight#CategoricalDimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimension type field with categorical type columns.</p>"
+          }
+        },
+        "DateDimensionField": {
+          "target": "com.amazonaws.quicksight#DateDimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimension type field with date type columns.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dimension type field.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomMoversComputationMoverSize": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomContentVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#CustomContentConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a <code>CustomContentVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset that is used to create the custom content visual. You can't create a visual without a dataset.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A visual that contains custom content.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/custom-visual-content.html\">Using custom visual content</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LoadingAnimation": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of <code>LoadingAnimation</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of loading animation in free-form layout. </p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageSource": {
+      "type": "structure",
+      "members": {
+        "SheetImageStaticFileSource": {
+          "target": "com.amazonaws.quicksight#SheetImageStaticFileSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the static file that contains the image.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source of the image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "TreeMapSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of group by fields.</p>"
+          }
+        },
+        "TreeMapGroupItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of groups that are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a tree map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveLongObject": {
+      "type": "long",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#ParameterTextAreaControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the <code>ParameterTextAreaControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Delimiter": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDelimiter",
+          "traits": {
+            "smithy.api#documentation": "<p>The delimiter that is used to separate the lines in text.</p>"
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a text box that is used to enter multiple entries.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveDoubleObject": {
+      "type": "double",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#RadarChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a <code>RadarChartVisual</code>.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#RadarChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a <code>RadarChartVisual</code>.</p>"
+          }
+        },
+        "Shape": {
+          "target": "com.amazonaws.quicksight#RadarChartShape",
+          "traits": {
+            "smithy.api#documentation": "<p>The shape of the radar chart.</p>"
+          }
+        },
+        "BaseSeriesSettings": {
+          "target": "com.amazonaws.quicksight#RadarChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The base sreies settings of a radar chart.</p>"
+          }
+        },
+        "StartAngle": {
+          "target": "com.amazonaws.quicksight#RadarChartStartAngle",
+          "traits": {
+            "smithy.api#documentation": "<p>The start angle of a radar chart's axis.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "AlternateBandColorsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the colors of alternatign bands in a radar chart.</p>"
+          }
+        },
+        "AlternateBandEvenColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the even-numbered alternate bands of a radar chart.</p>"
+          }
+        },
+        "AlternateBandOddColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the odd-numbered alternate bands of a radar chart.</p>"
+          }
+        },
+        "CategoryAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The category axis of a radar chart.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The category label options of a radar chart.</p>"
+          }
+        },
+        "ColorAxis": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The color axis of a radar chart.</p>"
+          }
+        },
+        "ColorLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The color label options of a radar chart.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "AxesRangeScale": {
+          "target": "com.amazonaws.quicksight#RadarChartAxesRangeScale",
+          "traits": {
+            "smithy.api#documentation": "<p>The axis behavior options of a radar chart.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>RadarChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataFieldSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the field that you are setting the axis binding to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#SensitiveString",
+          "traits": {
+            "smithy.api#documentation": "<p>The field value of the field that you are setting the axis binding to.</p>"
+          }
+        },
+        "AxisBinding": {
+          "target": "com.amazonaws.quicksight#AxisBinding",
+          "traits": {
+            "smithy.api#documentation": "<p>The axis that you are binding the field to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.quicksight#LineChartSeriesSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of line series associated to the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data field series item configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchyCountryString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTablePaginatedReportOptions": {
+      "type": "structure",
+      "members": {
+        "VerticalOverflowVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the printing table overflow across pages.</p>"
+          }
+        },
+        "OverflowColumnHeaderVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the repeating header rows on each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The paginated report options for a pivot table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLineStyle": {
+      "type": "structure",
+      "members": {
+        "LineSymbolStyle": {
+          "target": "com.amazonaws.quicksight#GeospatialLineSymbolStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The symbol style for a line style.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The visualization style for a line layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionDynamicDimensionSortConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnSort"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DeleteAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "AwsAccountId": {
+          "target": "com.amazonaws.quicksight#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services account where you want to delete an analysis.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the analysis that you're deleting.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RecoveryWindowInDays": {
+          "target": "com.amazonaws.quicksight#RecoveryWindowInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>A value that specifies the number of days that Amazon Quick Sight waits before it deletes the\n            analysis. You can't use this parameter with the <code>ForceDeleteWithoutRecovery</code>\n            option in the same API call. The default value is 30.</p>",
+            "smithy.api#httpQuery": "recovery-window-in-days"
+          }
+        },
+        "ForceDeleteWithoutRecovery": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>This option defaults to the value <code>NoForceDeleteWithoutRecovery</code>. To\n            immediately delete the analysis, add the <code>ForceDeleteWithoutRecovery</code> option.\n            You can't restore an analysis after it's deleted. </p>",
+            "smithy.api#httpQuery": "force-delete-without-recovery"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.quicksight#GaugeChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#GaugeChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "ConditionalFormatting": {
+          "target": "com.amazonaws.quicksight#GaugeChartConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of a <code>GaugeChartVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A gauge chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/gauge-chart.html\">Using gauge charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TablePaginatedReportOptions": {
+      "type": "structure",
+      "members": {
+        "VerticalOverflowVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of printing table overflow across pages.</p>"
+          }
+        },
+        "OverflowColumnHeaderVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of repeating header rows on each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The paginated report options for a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#BoxPlotChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A box plot.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/box-plots.html\">Using box plots</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetTitle": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the visual that you want to use.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PluginArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that reflects the plugin and version.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions"
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions"
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#PluginVisualConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>\n       A description of the plugin field wells and their persisted properties.\n      </p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A flexible visualization type that allows engineers \n      to create new custom charts in Quick Sight.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomFilterListConfiguration": {
+      "type": "structure",
+      "members": {
+        "MatchOperator": {
+          "target": "com.amazonaws.quicksight#CategoryFilterMatchOperator",
+          "traits": {
+            "smithy.api#documentation": "<p>The match operator that is used to determine if a filter should be applied.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CategoryValues": {
+          "target": "com.amazonaws.quicksight#CategoryValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of category values for the filter.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#CategoryFilterSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Select all of the values. Null is not the assigned value of select all.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FILTER_ALL_VALUES</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of custom filter values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldCustomIconContent": {
+      "type": "structure",
+      "members": {
+        "Icon": {
+          "target": "com.amazonaws.quicksight#TableFieldIconSetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The icon set type (link) of the custom icon content for table URL link content.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom icon content for the table link content configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateAxisOptions": {
+      "type": "structure",
+      "members": {
+        "MissingDateVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not missing dates are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine how a date axis is displayed.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PieChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category (group/color) field wells of a pie chart.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field wells of a pie chart. Values are aggregated based on categories.</p>"
+          }
+        },
+        "SmallMultiples": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples field well of a pie chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a pie chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColumnTooltipItem": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The target column of the tooltip item.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Label": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The label of the tooltip item.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the tooltip item.</p>"
+          }
+        },
+        "Aggregation": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the column tooltip item.</p>"
+          }
+        },
+        "TooltipTarget": {
+          "target": "com.amazonaws.quicksight#TooltipTarget",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the target of the column tooltip item in a combo chart visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tooltip item for the columns that are not part of a field well.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomColor": {
+      "type": "structure",
+      "members": {
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#FieldValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The data value that the color is applied to.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color that is applied to the data value.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SpecialValue": {
+          "target": "com.amazonaws.quicksight#SpecialValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of a special data value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the color that's applied to a particular data value in a column.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RelativeDatesFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AnchorDateConfiguration": {
+          "target": "com.amazonaws.quicksight#AnchorDateConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The date configuration of the filter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MinimumGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum granularity (period granularity) of the relative dates filter.</p>"
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RelativeDateType": {
+          "target": "com.amazonaws.quicksight#RelativeDateType",
+          "traits": {
+            "smithy.api#documentation": "<p>The range date type of the filter. Choose one of the options below:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PREVIOUS</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>THIS</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>LAST</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>NOW</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>NEXT</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "RelativeDateValue": {
+          "target": "com.amazonaws.quicksight#Integer",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The date value of the filter.</p>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter whose value should be used for the filter value.</p>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExcludePeriodConfiguration": {
+          "target": "com.amazonaws.quicksight#ExcludePeriodConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for the exclude period of the filter.</p>"
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>RelativeDatesFilter</code> filters relative dates values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CustomValuesConfiguration": {
+      "type": "structure",
+      "members": {
+        "IncludeNullValue": {
+          "target": "com.amazonaws.quicksight#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Includes the null value in custom action parameter values.</p>"
+          }
+        },
+        "CustomValues": {
+          "target": "com.amazonaws.quicksight#CustomParameterValues",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of custom values for the destination parameter in <code>DestinationParameterValueConfiguration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ClusterMarker": {
+      "type": "structure",
+      "members": {
+        "SimpleClusterMarker": {
+          "target": "com.amazonaws.quicksight#SimpleClusterMarker",
+          "traits": {
+            "smithy.api#documentation": "<p>The simple cluster marker of the cluster marker.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The cluster marker that is a part of the cluster marker\n            configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotFieldSortOptions": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID for the field sort options.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SortBy": {
+          "target": "com.amazonaws.quicksight#PivotTableSortBy",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort by field for the field sort options.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field sort options for a pivot table sort configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StringFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "NullValueFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NullValueFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+          }
+        },
+        "NumericFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The formatting configuration for numeric strings.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Formatting configuration for string fields.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLineSymbolStyle": {
+      "type": "structure",
+      "members": {
+        "FillColor": {
+          "target": "com.amazonaws.quicksight#GeospatialColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the fill color.</p>"
+          }
+        },
+        "LineWidth": {
+          "target": "com.amazonaws.quicksight#GeospatialLineWidth",
+          "traits": {
+            "smithy.api#documentation": "<p>The width value for a line.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The symbol style for a line layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SubtotalOptions": {
+      "type": "structure",
+      "members": {
+        "TotalsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration for the subtotal cells.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label string for the subtotal cells.</p>"
+          }
+        },
+        "FieldLevel": {
+          "target": "com.amazonaws.quicksight#PivotTableSubtotalLevel",
+          "traits": {
+            "smithy.api#documentation": "<p>The field level (all, custom, last) for the subtotal cells.</p>"
+          }
+        },
+        "FieldLevelOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldSubtotalOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional configuration of subtotal cells.</p>"
+          }
+        },
+        "TotalCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the subtotal cells.</p>"
+          }
+        },
+        "ValueCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the subtotals of value cells.</p>"
+          }
+        },
+        "MetricHeaderCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the subtotals of header cells.</p>"
+          }
+        },
+        "StyleTargets": {
+          "target": "com.amazonaws.quicksight#TableStyleTargetList",
+          "traits": {
+            "smithy.api#documentation": "<p>The style targets options for subtotals.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The subtotal options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#StyledCellType": {
+      "type": "enum",
+      "members": {
+        "TOTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TOTAL"
+          }
+        },
+        "METRIC_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "METRIC_HEADER"
+          }
+        },
+        "VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LocalNavigationConfiguration": {
+      "type": "structure",
+      "members": {
+        "TargetSheetId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The sheet that is targeted for navigation in the same analysis.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The navigation configuration for <code>CustomActionNavigationOperation</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RowAlternateColorOptions": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the widget status.</p>"
+          }
+        },
+        "RowAlternateColors": {
+          "target": "com.amazonaws.quicksight#RowAlternateColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the list of row alternate colors.</p>"
+          }
+        },
+        "UsePrimaryBackgroundColor": {
+          "target": "com.amazonaws.quicksight#WidgetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The primary background color options for alternate rows.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the row alternate color options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableOptions": {
+      "type": "structure",
+      "members": {
+        "MetricPlacement": {
+          "target": "com.amazonaws.quicksight#PivotTableMetricPlacement",
+          "traits": {
+            "smithy.api#documentation": "<p>The metric placement (row, column) options.</p>"
+          }
+        },
+        "SingleMetricVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the single metric options.</p>"
+          }
+        },
+        "ColumnNamesVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the column names.</p>"
+          }
+        },
+        "ToggleButtonsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the pivot table.</p>"
+          }
+        },
+        "ColumnHeaderStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of the column header.</p>"
+          }
+        },
+        "RowHeaderStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of the row headers.</p>"
+          }
+        },
+        "CellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of cells.</p>"
+          }
+        },
+        "RowFieldNamesStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The table cell style of row field names.</p>"
+          }
+        },
+        "RowAlternateColorOptions": {
+          "target": "com.amazonaws.quicksight#RowAlternateColorOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The row alternate color options (widget status, row alternate colors).</p>"
+          }
+        },
+        "CollapsedRowDimensionsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility setting of a pivot table's collapsed row dimension fields. If the value of this structure is <code>HIDDEN</code>, all collapsed columns in a pivot table are automatically hidden. The default value is <code>VISIBLE</code>.</p>"
+          }
+        },
+        "RowsLayout": {
+          "target": "com.amazonaws.quicksight#PivotTableRowsLayout",
+          "traits": {
+            "smithy.api#documentation": "<p>The layout for the row dimension headers of a pivot table. Choose one of the following options.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TABULAR</code>: (Default) Each row field is displayed in a separate column.</p>\n            </li>\n            <li>\n               <p>\n                  <code>HIERARCHY</code>: All row fields are displayed in a single column. Indentation is used to differentiate row headers of different fields.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "RowsLabelOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableRowsLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for the label that is located above the row headers. This option is only applicable when <code>RowsLayout</code> is set to <code>HIERARCHY</code>.</p>"
+          }
+        },
+        "DefaultCellWidth": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The default cell width of the pivot table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table options for a pivot table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPolygonSymbolStyle": {
+      "type": "structure",
+      "members": {
+        "FillColor": {
+          "target": "com.amazonaws.quicksight#GeospatialColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the fill color.</p>"
+          }
+        },
+        "StrokeColor": {
+          "target": "com.amazonaws.quicksight#GeospatialColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the stroke color.</p>"
+          }
+        },
+        "StrokeWidth": {
+          "target": "com.amazonaws.quicksight#GeospatialLineWidth",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the border stroke.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The polygon symbol style for a polygon layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFromLayoutElementList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FreeFormLayoutElement"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 430
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SankeyDiagramFieldWells": {
+      "type": "structure",
+      "members": {
+        "SankeyDiagramAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#SankeyDiagramAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a sankey diagram.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a sankey diagram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Length": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "String based length that is composed of value and unit"
+      }
+    },
+    "com.amazonaws.quicksight#SheetName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionDynamicNumericDimensionConfiguration": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicDimensionLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of values to use from the column for repetition.</p>"
+          }
+        },
+        "SortByMetrics": {
+          "target": "com.amazonaws.quicksight#BodySectionDynamicDimensionSortConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Sort criteria on the column values that you use for repetition. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the <b>Numeric</b> dataset column and constraints for the dynamic values used to repeat the  contents of a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#MinimumLabelType": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the minimum label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The minimum label of a data path label.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SankeyDiagramSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "WeightSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the weight fields.</p>"
+          }
+        },
+        "SourceItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of source nodes that are displayed in a sankey diagram.</p>"
+          }
+        },
+        "DestinationItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of destination nodes that are displayed in a sankey diagram.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a sankey diagram.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DashboardCustomizationStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SmallMultiplesOptions": {
+      "type": "structure",
+      "members": {
+        "MaxVisibleRows": {
+          "target": "com.amazonaws.quicksight#VisiblePanelRows",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the maximum number of visible rows to display in the grid of small multiples panels.</p>\n         <p>The default value is <code>Auto</code>,\n            which automatically adjusts the rows in the grid\n            to fit the overall layout and size of the given chart.</p>"
+          }
+        },
+        "MaxVisibleColumns": {
+          "target": "com.amazonaws.quicksight#VisiblePanelColumns",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the maximum number of visible columns to display in the grid of small multiples panels.</p>\n         <p>The default is <code>Auto</code>, which automatically adjusts the columns in the grid to fit the overall layout and size of the given chart.</p>"
+          }
+        },
+        "PanelConfiguration": {
+          "target": "com.amazonaws.quicksight#PanelConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configures the display options for each small multiples panel.</p>"
+          }
+        },
+        "XAxis": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesAxisProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of a small multiples X axis.</p>"
+          }
+        },
+        "YAxis": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesAxisProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of a small multiples Y axis.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Options that determine the layout and display options of a chart's small multiples.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CascadingControlSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#CascadingControlSource"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#BodySectionConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 28
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BinWidthValue": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CategoryValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#CategoryValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AxisDisplayDataDrivenRange": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>The options that are saved for future extension.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SectionPageBreakStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialSelectedPointStyle": {
+      "type": "enum",
+      "members": {
+        "POINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POINT"
+          }
+        },
+        "CLUSTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTER"
+          }
+        },
+        "HEATMAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HEATMAP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PieChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#PieChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#PieChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a pie chart.</p>"
+          }
+        },
+        "DonutOptions": {
+          "target": "com.amazonaws.quicksight#DonutOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the shape of the chart. This option determines whether the chart is a pie chart or a donut chart.</p>"
+          }
+        },
+        "SmallMultiplesOptions": {
+          "target": "com.amazonaws.quicksight#SmallMultiplesOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The small multiples setup for the visual.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options of the group/color that is displayed in a pie chart.</p>"
+          }
+        },
+        "ValueLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options for the value that is displayed in a pie chart.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine if visual data labels are displayed.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The palette (chart color) display setup of the visual.</p>"
+          }
+        },
+        "ContributionAnalysisDefaults": {
+          "target": "com.amazonaws.quicksight#ContributionAnalysisDefaultList",
+          "traits": {
+            "smithy.api#documentation": "<p>The contribution analysis (anomaly configuration) setup of the visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a pie chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetVisualScopingConfiguration": {
+      "type": "structure",
+      "members": {
+        "SheetId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected sheet that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Scope": {
+          "target": "com.amazonaws.quicksight#FilterVisualScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The scope of the applied entities. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VISUALS</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SELECTED_VISUALS</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "VisualIds": {
+          "target": "com.amazonaws.quicksight#FilteredVisualsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected visuals that the filter is applied to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter that is applied to the options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LongPlainText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PanelConfiguration": {
+      "type": "structure",
+      "members": {
+        "Title": {
+          "target": "com.amazonaws.quicksight#PanelTitleOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Configures the title display within each small multiples panel.</p>"
+          }
+        },
+        "BorderVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not each panel displays a border.</p>"
+          }
+        },
+        "BorderThickness": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the line thickness of panel borders.</p>"
+          }
+        },
+        "BorderStyle": {
+          "target": "com.amazonaws.quicksight#PanelBorderStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the line style of panel borders.</p>"
+          }
+        },
+        "BorderColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the line color of panel borders.</p>"
+          }
+        },
+        "GutterVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not negative space between sibling panels is rendered.</p>"
+          }
+        },
+        "GutterSpacing": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the total amount of negative space to display between sibling panels.</p>"
+          }
+        },
+        "BackgroundVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether or not a background for each small multiples panel is rendered.</p>"
+          }
+        },
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the background color for each panel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A collection of options that configure how each panel displays in a small multiples chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FontWeightName": {
+      "type": "enum",
+      "members": {
+        "NORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NORMAL"
+          }
+        },
+        "BOLD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOLD"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ComparisonMethod": {
+      "type": "enum",
+      "members": {
+        "DIFFERENCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIFFERENCE"
+          }
+        },
+        "PERCENT_DIFFERENCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT_DIFFERENCE"
+          }
+        },
+        "PERCENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ShortFormatText": {
+      "type": "structure",
+      "members": {
+        "PlainText": {
+          "target": "com.amazonaws.quicksight#ShortPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>Plain text format.</p>"
+          }
+        },
+        "RichText": {
+          "target": "com.amazonaws.quicksight#ShortRichText",
+          "traits": {
+            "smithy.api#documentation": "<p>Rich text. Examples of rich text include bold, underline, and italics.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The text format for the title.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetArnsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Arn"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GlobalTableBorderOptions": {
+      "type": "structure",
+      "members": {
+        "UniformBorder": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the options for uniform border.</p>"
+          }
+        },
+        "SideSpecificBorder": {
+          "target": "com.amazonaws.quicksight#TableSideBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the options for side specific border.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the border options for a table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Layout": {
+      "type": "structure",
+      "members": {
+        "Configuration": {
+          "target": "com.amazonaws.quicksight#LayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that determines what the type of layout for a sheet.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>Layout</code> defines the placement of elements within a sheet.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/types-of-layout.html\">Types of layout</a> in the <i>Amazon Quick Suite User Guide</i>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "ConditionalFormattingOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableConditionalFormattingOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>Conditional formatting options for a <code>PivotTableVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#IntegerParameter": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the integer parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#SensitiveLongList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values for the integer parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An integer parameter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CategoricalAggregationFunction": {
+      "type": "enum",
+      "members": {
+        "COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT"
+          }
+        },
+        "DISTINCT_COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISTINCT_COUNT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisualInteractionOptions": {
+      "type": "structure",
+      "members": {
+        "VisualMenuOption": {
+          "target": "com.amazonaws.quicksight#VisualMenuOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The on-visual menu options for a visual.</p>"
+          }
+        },
+        "ContextMenuOption": {
+          "target": "com.amazonaws.quicksight#ContextMenuOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The context menu options for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The general visual interactions setup for visual publish options</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SectionPageBreakConfiguration": {
+      "type": "structure",
+      "members": {
+        "After": {
+          "target": "com.amazonaws.quicksight#SectionAfterPageBreak",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a page break after a section.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a page break for a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PageNumber": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudCloudLayout": {
+      "type": "enum",
+      "members": {
+        "FLUID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FLUID"
+          }
+        },
+        "NORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NORMAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DataBarsOptions": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID for the data bars options.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PositiveColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the positive data bar.</p>"
+          }
+        },
+        "NegativeColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the negative data bar.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for data bars.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineSeriesType": {
+      "type": "enum",
+      "members": {
+        "BAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BAR"
+          }
+        },
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#AnalysisDefaults": {
+      "type": "structure",
+      "members": {
+        "DefaultNewSheetConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultNewSheetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for default new sheet settings.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for default analysis settings.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NullString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisualHighlightOperation": {
+      "type": "structure",
+      "members": {
+        "Trigger": {
+          "target": "com.amazonaws.quicksight#VisualHighlightTrigger",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a highlight operation is initiated by a click or hover, or whether it's disabled.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines what initiates a highlight operation on a visual, such as a click or hover.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.quicksight#Integer",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The number of items to include in the top bottom filter results.</p>"
+          }
+        },
+        "AggregationSortConfigurations": {
+          "target": "com.amazonaws.quicksight#AggregationSortConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation and sort configuration of the top bottom filter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter whose value should be used for the filter value.</p>"
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>TopBottomFilter</code> filters values that are at the top or the bottom.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIPrimaryValueConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the  primary value's text color.</p>"
+          }
+        },
+        "Icon": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the primary value's icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the primary value of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColumnSort": {
+      "type": "structure",
+      "members": {
+        "SortBy": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "Direction": {
+          "target": "com.amazonaws.quicksight#SortDirection",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort direction.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function that is defined in the column sort.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration for a column that is not used in a field well.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericalAggregationFunction": {
+      "type": "structure",
+      "members": {
+        "SimpleNumericalAggregation": {
+          "target": "com.amazonaws.quicksight#SimpleNumericalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>Built-in aggregation functions for numerical values.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SUM</code>: The sum of a dimension or measure. </p>\n            </li>\n            <li>\n               <p>\n                  <code>AVERAGE</code>: The average of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MIN</code>: The minimum value of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MAX</code>: The maximum value of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COUNT</code>: The count of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISTINCT_COUNT</code>: The count of distinct values in a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>VAR</code>: The variance of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>VARP</code>: The partitioned variance of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STDEV</code>: The standard deviation of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STDEVP</code>: The partitioned standard deviation of a dimension or measure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MEDIAN</code>: The median value of a dimension or measure.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "PercentileAggregation": {
+          "target": "com.amazonaws.quicksight#PercentileAggregation",
+          "traits": {
+            "smithy.api#documentation": "<p>An aggregation based on the percentile of values in a dimension or measure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Aggregation for numerical values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartDataLabelOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility option that determines if data labels are displayed.</p>"
+          }
+        },
+        "CategoryLabelVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the category labels within the data labels.</p>"
+          }
+        },
+        "MeasureLabelVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the measure labels within the data labels.</p>"
+          }
+        },
+        "Position": {
+          "target": "com.amazonaws.quicksight#DataLabelPosition",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the positioning of the data label relative to a section of the funnel.</p>"
+          }
+        },
+        "LabelFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration for the data labels.</p>\n         <p>Only the <code>FontSize</code> attribute of the font configuration is used for data labels.</p>"
+          }
+        },
+        "LabelColor": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the data label text.</p>"
+          }
+        },
+        "MeasureDataLabelStyle": {
+          "target": "com.amazonaws.quicksight#FunnelChartMeasureDataLabelStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the style of the metric labels.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the data labels.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableDataPathOption": {
+      "type": "structure",
+      "members": {
+        "DataPathList": {
+          "target": "com.amazonaws.quicksight#DataPathValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of data path values for the data path options.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#PixelLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the data path option.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data path options for the pivot table field options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericSeparatorConfiguration": {
+      "type": "structure",
+      "members": {
+        "DecimalSeparator": {
+          "target": "com.amazonaws.quicksight#NumericSeparatorSymbol",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the decimal separator.</p>"
+          }
+        },
+        "ThousandsSeparator": {
+          "target": "com.amazonaws.quicksight#ThousandSeparatorOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the thousands separator configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the numeric separator configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CreateAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for the analysis.</p>"
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the analysis.</p>"
+          }
+        },
+        "CreationStatus": {
+          "target": "com.amazonaws.quicksight#ResourceStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the creation of the analysis. </p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#StatusCode",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The HTTP status of the request.</p>",
+            "smithy.api#httpResponseCode": {}
+          }
+        },
+        "RequestId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services request ID for this operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.quicksight#PaperSize": {
+      "type": "enum",
+      "members": {
+        "US_LETTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "US_LETTER"
+          }
+        },
+        "US_LEGAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "US_LEGAL"
+          }
+        },
+        "US_TABLOID_LEDGER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "US_TABLOID_LEDGER"
+          }
+        },
+        "A0": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A0"
+          }
+        },
+        "A1": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A1"
+          }
+        },
+        "A2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A2"
+          }
+        },
+        "A3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A3"
+          }
+        },
+        "A4": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A4"
+          }
+        },
+        "A5": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A5"
+          }
+        },
+        "JIS_B4": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JIS_B4"
+          }
+        },
+        "JIS_B5": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JIS_B5"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartCategoryFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPolygonLayer": {
+      "type": "structure",
+      "members": {
+        "Style": {
+          "target": "com.amazonaws.quicksight#GeospatialPolygonStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization style for a polygon layer.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The geospatial polygon layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AxisLabelOptions": {
+      "type": "structure",
+      "members": {
+        "FontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The font configuration of the axis label.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text for the axis label.</p>"
+          }
+        },
+        "ApplyTo": {
+          "target": "com.amazonaws.quicksight#AxisLabelReferenceOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that indicate which field the label belongs to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The label options for a chart axis. You must specify the field that the label is targeted to.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveLongList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveLong"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#GeospatialMapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        },
+        "GeocodingPreferences": {
+          "target": "com.amazonaws.quicksight#GeocodePreferenceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The geocoding prefences for geospatial map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A geospatial map or a points on map visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/point-maps.html\">Creating point maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTotalOptions": {
+      "type": "structure",
+      "members": {
+        "TotalsVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration for the total cells.</p>"
+          }
+        },
+        "Placement": {
+          "target": "com.amazonaws.quicksight#TableTotalsPlacement",
+          "traits": {
+            "smithy.api#documentation": "<p>The placement (start, end) for the total cells.</p>"
+          }
+        },
+        "ScrollStatus": {
+          "target": "com.amazonaws.quicksight#TableTotalsScrollStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The scroll status (pinned, scrolled) for the total cells.</p>"
+          }
+        },
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom label string for the total cells.</p>"
+          }
+        },
+        "TotalCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the total cells.</p>"
+          }
+        },
+        "ValueCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the totals of value cells.</p>"
+          }
+        },
+        "MetricHeaderCellStyle": {
+          "target": "com.amazonaws.quicksight#TableCellStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell styling options for the total of header cells.</p>"
+          }
+        },
+        "TotalAggregationOptions": {
+          "target": "com.amazonaws.quicksight#TotalAggregationOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The total aggregation options for each value field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The optional configuration of totals cells in a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ExplicitHierarchyColumnList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SingleYAxisOption": {
+      "type": "enum",
+      "members": {
+        "PRIMARY_Y_AXIS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRIMARY_Y_AXIS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FontDecoration": {
+      "type": "enum",
+      "members": {
+        "UNDERLINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNDERLINE"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialLayerMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PanelBorderStyle": {
+      "type": "enum",
+      "members": {
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        },
+        "DASHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DASHED"
+          }
+        },
+        "DOTTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOTTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BodySectionConfiguration": {
+      "type": "structure",
+      "members": {
+        "SectionId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a body section.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Content": {
+          "target": "com.amazonaws.quicksight#BodySectionContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of content in a body section.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Style": {
+          "target": "com.amazonaws.quicksight#SectionStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The style options of a body section.</p>"
+          }
+        },
+        "PageBreakConfiguration": {
+          "target": "com.amazonaws.quicksight#SectionPageBreakConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a page break for a section.</p>"
+          }
+        },
+        "RepeatConfiguration": {
+          "target": "com.amazonaws.quicksight#BodySectionRepeatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the configurations that are required to declare a section as repeating.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a body section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TooltipTitleType": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "PRIMARY_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRIMARY_VALUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SelectedFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FieldId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LongRichText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DonutCenterOptions": {
+      "type": "structure",
+      "members": {
+        "LabelVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the visibility of the label in a donut chart. In the Quick Sight console, this option is called <code>'Show total'</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The label options of the label that is displayed in the center of a donut chart. This option isn't available for pie charts.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldOrderList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FieldId"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of table field IDs.</p>",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 201
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterDropDownControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>FilterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DropDownControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of the <code>FilterDropDownControl</code>.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the <code>FilterDropDownControl</code>. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>MULTI_SELECT</code>: The user can select multiple entries from a dropdown menu.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SINGLE_SELECT</code>: The user can select a single entry from a dropdown menu.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#FilterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        },
+        "CascadingControlConfiguration": {
+          "target": "com.amazonaws.quicksight#CascadingControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>FilterDropDownControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a dropdown list with buttons that are used to select a single value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilledMapConditionalFormattingOption": {
+      "type": "structure",
+      "members": {
+        "Shape": {
+          "target": "com.amazonaws.quicksight#FilledMapShapeConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting that determines the shape of the filled map.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Conditional formatting options of a <code>FilledMapVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeParameter": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>A display name for the date-time parameter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#SensitiveTimestampList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values for the date-time parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A date-time parameter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldSortOptions": {
+      "type": "structure",
+      "members": {
+        "FieldSort": {
+          "target": "com.amazonaws.quicksight#FieldSort",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration for a field in a field well.</p>"
+          }
+        },
+        "ColumnSort": {
+          "target": "com.amazonaws.quicksight#ColumnSort",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration for a column that is not used in a field well.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field sort options in a chart configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionDefaults": {
+      "type": "structure",
+      "members": {
+        "highlightOperation": {
+          "target": "com.amazonaws.quicksight#VisualHighlightOperation",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of highlight operations available for visuals in an analysis or sheet.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of custom actions applied to visuals in an analysis or sheet.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumberScale": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "THOUSANDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THOUSANDS"
+          }
+        },
+        "MILLIONS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MILLIONS"
+          }
+        },
+        "BILLIONS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BILLIONS"
+          }
+        },
+        "TRILLIONS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRILLIONS"
+          }
+        },
+        "LAKHS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAKHS"
+          }
+        },
+        "CRORES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CRORES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableUnaggregatedFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#UnaggregatedField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 201
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudDimensionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DimensionField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TableConditionalFormattingOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TableConditionalFormattingOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 500
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapLayerList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GeospatialLayerItem"
+      }
+    },
+    "com.amazonaws.quicksight#GeocodePreference": {
+      "type": "structure",
+      "members": {
+        "RequestKey": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchy",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique request key for the geocode preference.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Preference": {
+          "target": "com.amazonaws.quicksight#GeocodePreferenceValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The preference definition for the geocode preference.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The geocode preference.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HeatMapAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Rows": {
+          "target": "com.amazonaws.quicksight#HeatMapDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rows field well of a heat map.</p>"
+          }
+        },
+        "Columns": {
+          "target": "com.amazonaws.quicksight#HeatMapDimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The columns field well of a heat map.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#HeatMapMeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values field well of a heat map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field wells of a heat map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecalSettings": {
+      "type": "structure",
+      "members": {
+        "ElementValue": {
+          "target": "com.amazonaws.quicksight#ElementValue",
+          "traits": {
+            "smithy.api#documentation": "<p>Field value of the field that you are setting the decal pattern to. Applicable only for field level settings.</p>"
+          }
+        },
+        "DecalVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Visibility setting for the decal pattern.</p>"
+          }
+        },
+        "DecalColor": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>Color configuration for the decal pattern.</p>"
+          }
+        },
+        "DecalPatternType": {
+          "target": "com.amazonaws.quicksight#DecalPatternType",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of pattern used for the decal, such as solid, diagonal, or circular patterns in various sizes.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SOLID</code>: Solid fill pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_SMALL</code>: Small diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_MEDIUM</code>: Medium diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_LARGE</code>: Large diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_OPPOSITE_SMALL</code>: Small cross-diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_OPPOSITE_MEDIUM</code>: Medium cross-diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAGONAL_OPPOSITE_LARGE</code>: Large cross-diagonal stripes pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CIRCLE_SMALL</code>: Small circle pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CIRCLE_MEDIUM</code>: Medium circle pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CIRCLE_LARGE</code>: Large circle pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_SMALL</code>: Small diamonds pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_MEDIUM</code>: Medium diamonds pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_LARGE</code>: Large diamonds pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_GRID_SMALL</code>: Small diamond grid pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_GRID_MEDIUM</code>: Medium diamond grid pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DIAMOND_GRID_LARGE</code>: Large diamond grid pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CHECKERBOARD_SMALL</code>: Small checkerboard pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CHECKERBOARD_MEDIUM</code>: Medium checkerboard pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CHECKERBOARD_LARGE</code>: Large checkerboard pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRIANGLE_SMALL</code>: Small triangles pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRIANGLE_MEDIUM</code>: Medium triangles pattern.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TRIANGLE_LARGE</code>: Large triangles pattern.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DecalStyleType": {
+          "target": "com.amazonaws.quicksight#DecalStyleType",
+          "traits": {
+            "smithy.api#documentation": "<p>Style type for the decal, which can be either manual or automatic. This field is only applicable for line series.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Manual</code>: Apply manual line and marker configuration for line series.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Auto</code>: Apply automatic line and marker configuration for line series.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Decal settings for accessibility features that define visual patterns and styling for data elements.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the category fields.</p>"
+          }
+        },
+        "CategoryItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of categories that are displayed in a line chart.</p>"
+          }
+        },
+        "ColorItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of lines that are displayed in a line chart.</p>"
+          }
+        },
+        "SmallMultiplesSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the small multiples field.</p>"
+          }
+        },
+        "SmallMultiplesLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of small multiples panels that are displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeocodePreferenceValue": {
+      "type": "union",
+      "members": {
+        "GeocoderHierarchy": {
+          "target": "com.amazonaws.quicksight#GeocoderHierarchy",
+          "traits": {
+            "smithy.api#documentation": "<p>The preference hierarchy for the geocode preference.</p>"
+          }
+        },
+        "Coordinate": {
+          "target": "com.amazonaws.quicksight#Coordinate",
+          "traits": {
+            "smithy.api#documentation": "<p>The preference coordinate for the geocode preference.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The preference value for the geocode preference.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineDataConfiguration": {
+      "type": "structure",
+      "members": {
+        "StaticConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineStaticDataConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The static data configuration of the reference line data configuration.</p>"
+          }
+        },
+        "DynamicConfiguration": {
+          "target": "com.amazonaws.quicksight#ReferenceLineDynamicDataConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The dynamic configuration of the reference line data configuration.</p>"
+          }
+        },
+        "AxisBinding": {
+          "target": "com.amazonaws.quicksight#AxisBinding",
+          "traits": {
+            "smithy.api#documentation": "<p>The axis binding type of the reference line. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PrimaryY</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SecondaryY</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "SeriesType": {
+          "target": "com.amazonaws.quicksight#ReferenceLineSeriesType",
+          "traits": {
+            "smithy.api#documentation": "<p>The series type of the reference line data configuration. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>BAR</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>LINE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data configuration of the reference line.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Visual": {
+      "type": "structure",
+      "members": {
+        "TableVisual": {
+          "target": "com.amazonaws.quicksight#TableVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A table visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/tabular.html\">Using tables as visuals</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "PivotTableVisual": {
+          "target": "com.amazonaws.quicksight#PivotTableVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A pivot table.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/pivot-table.html\">Using pivot tables</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "BarChartVisual": {
+          "target": "com.amazonaws.quicksight#BarChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A bar chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/bar-charts.html\">Using bar charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "KPIVisual": {
+          "target": "com.amazonaws.quicksight#KPIVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A key performance indicator (KPI).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/kpi.html\">Using KPIs</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "PieChartVisual": {
+          "target": "com.amazonaws.quicksight#PieChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A pie or donut chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/pie-chart.html\">Using pie charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "GaugeChartVisual": {
+          "target": "com.amazonaws.quicksight#GaugeChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A gauge chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/gauge-chart.html\">Using gauge charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "LineChartVisual": {
+          "target": "com.amazonaws.quicksight#LineChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A line chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/line-charts.html\">Using line charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "HeatMapVisual": {
+          "target": "com.amazonaws.quicksight#HeatMapVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A heat map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/heat-map.html\">Using heat maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "TreeMapVisual": {
+          "target": "com.amazonaws.quicksight#TreeMapVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A tree map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/tree-map.html\">Using tree maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "GeospatialMapVisual": {
+          "target": "com.amazonaws.quicksight#GeospatialMapVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A geospatial map or a points on map visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/point-maps.html\">Creating point maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "FilledMapVisual": {
+          "target": "com.amazonaws.quicksight#FilledMapVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A filled map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/filled-maps.html\">Creating filled maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "LayerMapVisual": {
+          "target": "com.amazonaws.quicksight#LayerMapVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties for a layer map visual</p>"
+          }
+        },
+        "FunnelChartVisual": {
+          "target": "com.amazonaws.quicksight#FunnelChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A funnel chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/funnel-visual-content.html\">Using funnel charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "ScatterPlotVisual": {
+          "target": "com.amazonaws.quicksight#ScatterPlotVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A scatter plot.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/scatter-plot.html\">Using scatter plots</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "ComboChartVisual": {
+          "target": "com.amazonaws.quicksight#ComboChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A combo chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/combo-charts.html\">Using combo charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "BoxPlotVisual": {
+          "target": "com.amazonaws.quicksight#BoxPlotVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A box plot.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/box-plots.html\">Using box plots</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "WaterfallVisual": {
+          "target": "com.amazonaws.quicksight#WaterfallVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A waterfall chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/waterfall-chart.html\">Using waterfall charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "HistogramVisual": {
+          "target": "com.amazonaws.quicksight#HistogramVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A histogram.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/histogram-charts.html\">Using histograms</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "WordCloudVisual": {
+          "target": "com.amazonaws.quicksight#WordCloudVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A word cloud.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/word-cloud.html\">Using word clouds</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "InsightVisual": {
+          "target": "com.amazonaws.quicksight#InsightVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>An insight visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/computational-insights.html\">Working with insights</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "SankeyDiagramVisual": {
+          "target": "com.amazonaws.quicksight#SankeyDiagramVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A sankey diagram.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/sankey-diagram.html\">Using Sankey diagrams</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "CustomContentVisual": {
+          "target": "com.amazonaws.quicksight#CustomContentVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A visual that contains custom content.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/custom-visual-content.html\">Using custom visual content</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "EmptyVisual": {
+          "target": "com.amazonaws.quicksight#EmptyVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>An empty visual.</p>"
+          }
+        },
+        "RadarChartVisual": {
+          "target": "com.amazonaws.quicksight#RadarChartVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>A radar chart visual.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/radar-chart.html\">Using radar charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+          }
+        },
+        "PluginVisual": {
+          "target": "com.amazonaws.quicksight#PluginVisual",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom plugin visual type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A visual displayed on a sheet in an analysis, dashboard, or template.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DecimalDefaultValues": {
+      "type": "structure",
+      "members": {
+        "DynamicValue": {
+          "target": "com.amazonaws.quicksight#DynamicDefaultValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The dynamic value of the <code>DecimalDefaultValues</code>. Different defaults are displayed according to users, groups, and values mapping.</p>"
+          }
+        },
+        "StaticValues": {
+          "target": "com.amazonaws.quicksight#DecimalDefaultValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The static values of the <code>DecimalDefaultValues</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default values of the <code>DecimalParameterDeclaration</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "LineStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartLineStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Line styles options for a line series in <code>LineChartVisual</code>.</p>"
+          }
+        },
+        "MarkerStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartMarkerStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Marker styles options for a line series in <code>LineChartVisual</code>.</p>"
+          }
+        },
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings for a line series in <code>LineChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of a line series in the visual</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotStyleOptions": {
+      "type": "structure",
+      "members": {
+        "FillStyle": {
+          "target": "com.amazonaws.quicksight#BoxPlotFillStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The fill styles (solid, transparent) of the box plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The style options of the box plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCategoricalDataColor": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the category data color.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataValue": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The data value for the category data color.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The categorical data color for a single category.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StringValueWhenUnsetConfiguration": {
+      "type": "structure",
+      "members": {
+        "ValueWhenUnsetOption": {
+          "target": "com.amazonaws.quicksight#ValueWhenUnsetOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The built-in options for default values. The value can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>RECOMMENDED</code>: The recommended value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code>: The <code>NULL</code> value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomValue": {
+          "target": "com.amazonaws.quicksight#SensitiveString",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom value that's used when the value of a parameter isn't set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that defines the default value of a <code>String</code> parameter when a value has not been set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated category field wells of a combo chart.</p>"
+          }
+        },
+        "BarValues": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated <code>BarValues</code> field well of a combo chart.</p>"
+          }
+        },
+        "Colors": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated colors field well of a combo chart.</p>"
+          }
+        },
+        "LineValues": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated <code>LineValues</code> field well of a combo chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field wells of a combo chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RelativeFontSize": {
+      "type": "enum",
+      "members": {
+        "EXTRA_SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXTRA_SMALL"
+          }
+        },
+        "SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMALL"
+          }
+        },
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LARGE"
+          }
+        },
+        "EXTRA_LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXTRA_LARGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterVisualScope": {
+      "type": "enum",
+      "members": {
+        "ALL_VISUALS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_VISUALS"
+          }
+        },
+        "SELECTED_VISUALS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SELECTED_VISUALS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableSubtotalLevel": {
+      "type": "enum",
+      "members": {
+        "ALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL"
+          }
+        },
+        "CUSTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOM"
+          }
+        },
+        "LAST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CurrencyDisplayFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "Prefix": {
+          "target": "com.amazonaws.quicksight#Prefix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the prefix value of the currency format.</p>"
+          }
+        },
+        "Suffix": {
+          "target": "com.amazonaws.quicksight#Suffix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the suffix value of the currency format.</p>"
+          }
+        },
+        "SeparatorConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericSeparatorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the numeric separator configuration.</p>"
+          }
+        },
+        "Symbol": {
+          "target": "com.amazonaws.quicksight#CurrencyCode",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the symbol for the currency format.</p>"
+          }
+        },
+        "DecimalPlacesConfiguration": {
+          "target": "com.amazonaws.quicksight#DecimalPlacesConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the decimal places configuration.</p>"
+          }
+        },
+        "NumberScale": {
+          "target": "com.amazonaws.quicksight#NumberScale",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the number scale value for the currency format.</p>"
+          }
+        },
+        "NegativeValueConfiguration": {
+          "target": "com.amazonaws.quicksight#NegativeValueConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the negative value configuration.</p>"
+          }
+        },
+        "NullValueFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NullValueFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the currency display format configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldOptions": {
+      "type": "structure",
+      "members": {
+        "SelectedFieldOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The selected field options for the pivot table field options.</p>"
+          }
+        },
+        "DataPathOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableDataPathOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The data path options for the pivot table field options.</p>"
+          }
+        },
+        "CollapseStateOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldCollapseStateOptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The collapse state options for the pivot table field options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field options for a pivot table visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataPathLabelType": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the field that the data label needs to be applied to.</p>"
+          }
+        },
+        "FieldValue": {
+          "target": "com.amazonaws.quicksight#FieldValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The actual value of the field that is labeled.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the data label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The option that specifies individual data values for labels.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DefaultTextAreaControlOptions": {
+      "type": "structure",
+      "members": {
+        "Delimiter": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDelimiter",
+          "traits": {
+            "smithy.api#documentation": "<p>The delimiter that is used to separate the lines in text.</p>"
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#TextAreaControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default options that correspond to the <code>TextArea</code> filter control type.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColorScale": {
+      "type": "structure",
+      "members": {
+        "Colors": {
+          "target": "com.amazonaws.quicksight#ColorScaleColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the list of colors that are applied to the visual.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ColorFillType": {
+          "target": "com.amazonaws.quicksight#ColorFillType",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color fill type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NullValueColor": {
+          "target": "com.amazonaws.quicksight#DataColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color that is applied to null values.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the color scale that is applied to the visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableRowConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "BackgroundColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting color (solid, gradient) of the background for a table row.</p>"
+          }
+        },
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting color (solid, gradient) of the text for a table row.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting of a table row.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageStaticFile": {
+      "type": "structure",
+      "members": {
+        "StaticFileId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the static file that contains an image.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.quicksight#StaticFileSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the image static file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A static file that contains an image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CalculatedFields": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#CalculatedField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FilterControl": {
+      "type": "structure",
+      "members": {
+        "DateTimePicker": {
+          "target": "com.amazonaws.quicksight#FilterDateTimePickerControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control from a date filter that is used to specify date and time.</p>"
+          }
+        },
+        "List": {
+          "target": "com.amazonaws.quicksight#FilterListControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a list of buttons or boxes. This is used to select either a single value or multiple values.</p>"
+          }
+        },
+        "Dropdown": {
+          "target": "com.amazonaws.quicksight#FilterDropDownControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a dropdown list with buttons that are used to select a single value.</p>"
+          }
+        },
+        "TextField": {
+          "target": "com.amazonaws.quicksight#FilterTextFieldControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a text box that is used to enter a single entry.</p>"
+          }
+        },
+        "TextArea": {
+          "target": "com.amazonaws.quicksight#FilterTextAreaControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a text box that is used to enter multiple entries.</p>"
+          }
+        },
+        "Slider": {
+          "target": "com.amazonaws.quicksight#FilterSliderControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control to display a horizontal toggle bar. This is used to change a value by sliding the toggle.</p>"
+          }
+        },
+        "RelativeDateTime": {
+          "target": "com.amazonaws.quicksight#FilterRelativeDateTimeControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control from a date filter that is used to specify the relative date.</p>"
+          }
+        },
+        "CrossSheet": {
+          "target": "com.amazonaws.quicksight#FilterCrossSheetControl",
+          "traits": {
+            "smithy.api#documentation": "<p>A control from a filter that is scoped across more than one sheet. This represents your filter control on a sheet</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The control of a filter that is used to interact with a dashboard or an analysis.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StaticFileUrlSourceOptions": {
+      "type": "structure",
+      "members": {
+        "Url": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL to download the static file from.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The structure that contains the URL to download the static file from.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the category field well in a combo chart.</p>"
+          }
+        },
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The item limit configuration for the category field well of a combo chart.</p>"
+          }
+        },
+        "ColorSort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the color field well in a combo chart.</p>"
+          }
+        },
+        "ColorItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The item limit configuration of the color field well in a combo chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a <code>ComboChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#StringParameterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#StringParameter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ForecastComputationSeasonality": {
+      "type": "enum",
+      "members": {
+        "AUTOMATIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTOMATIC"
+          }
+        },
+        "CUSTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#HorizontalTextAlignment": {
+      "type": "enum",
+      "members": {
+        "LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEFT"
+          }
+        },
+        "CENTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CENTER"
+          }
+        },
+        "RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RIGHT"
+          }
+        },
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#IntegerValueWhenUnsetConfiguration": {
+      "type": "structure",
+      "members": {
+        "ValueWhenUnsetOption": {
+          "target": "com.amazonaws.quicksight#ValueWhenUnsetOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The built-in options for default values. The value can be one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>RECOMMENDED</code>: The recommended value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code>: The <code>NULL</code> value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomValue": {
+          "target": "com.amazonaws.quicksight#SensitiveLong",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>A custom value that's used when the value of a parameter isn't set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A parameter declaration for the <code>Integer</code> data type.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "FunnelChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#FunnelChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field well configuration of a <code>FunnelChartVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#QueryExecutionOptions": {
+      "type": "structure",
+      "members": {
+        "QueryExecutionMode": {
+          "target": "com.amazonaws.quicksight#QueryExecutionMode",
+          "traits": {
+            "smithy.api#documentation": "<p>A structure that describes the query execution mode.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that describes the query execution options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldCollapseStateOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableFieldCollapseStateOption"
+      }
+    },
+    "com.amazonaws.quicksight#RecoveryWindowInDays": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 7,
+          "max": 30
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ProgressBarOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the progress bar.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of the progress bar of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineSeriesAxisDisplayOptions": {
+      "type": "structure",
+      "members": {
+        "AxisOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the line series axis.</p>"
+          }
+        },
+        "MissingDataConfigurations": {
+          "target": "com.amazonaws.quicksight#MissingDataConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration options that determine how missing data is treated during the rendering of a line chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The series axis configuration of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DonutOptions": {
+      "type": "structure",
+      "members": {
+        "ArcOptions": {
+          "target": "com.amazonaws.quicksight#ArcOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The option for define the arc of the chart shape. Valid values are as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>WHOLE</code> - A pie chart</p>\n            </li>\n            <li>\n               <p>\n                  <code>SMALL</code>- A small-sized donut chart</p>\n            </li>\n            <li>\n               <p>\n                  <code>MEDIUM</code>- A medium-sized donut chart</p>\n            </li>\n            <li>\n               <p>\n                  <code>LARGE</code>- A large-sized donut chart</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DonutCenterOptions": {
+          "target": "com.amazonaws.quicksight#DonutCenterOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options of the label that is displayed in the center of a donut chart. This option isn't available for pie charts.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options for configuring a donut chart or pie chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CategoryFilterSelectAllOptions": {
+      "type": "enum",
+      "members": {
+        "FILTER_ALL_VALUES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FILTER_ALL_VALUES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldCollapseStateTarget": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The field ID of the pivot table that the collapse state needs to be set to.</p>"
+          }
+        },
+        "FieldDataPathValues": {
+          "target": "com.amazonaws.quicksight#DataPathValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The data path of the pivot table's header. Used to set the collapse state.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The target of a pivot table field collapse state.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SimpleClusterMarker": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color of the simple cluster marker.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The simple cluster marker of the cluster marker.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SensitiveStringObject": {
+      "type": "string",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.quicksight#TotalAggregationFunction": {
+      "type": "structure",
+      "members": {
+        "SimpleTotalAggregationFunction": {
+          "target": "com.amazonaws.quicksight#SimpleTotalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>A built in aggregation function for total values.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An aggregation function that aggregates the total values of a measure.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineValueLabelRelativePosition": {
+      "type": "enum",
+      "members": {
+        "BEFORE_CUSTOM_LABEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEFORE_CUSTOM_LABEL"
+          }
+        },
+        "AFTER_CUSTOM_LABEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AFTER_CUSTOM_LABEL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RowAlternateColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#HexColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DefaultFilterControlConfiguration": {
+      "type": "structure",
+      "members": {
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>DefaultFilterControlConfiguration</code>. This title is shared by all controls that are tied to this filter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ControlOptions": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The control option for the <code>DefaultFilterControlConfiguration</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The default configuration for all dependent controls of the filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterControlList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FilterControl"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Entity": {
+      "type": "structure",
+      "members": {
+        "Path": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The hierarchical path of the entity within the analysis, template, or dashboard definition tree.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object, structure, or sub-structure of an analysis, template, or dashboard.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIOptions": {
+      "type": "structure",
+      "members": {
+        "ProgressBar": {
+          "target": "com.amazonaws.quicksight#ProgressBarOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the progress bar of a KPI visual.</p>"
+          }
+        },
+        "TrendArrows": {
+          "target": "com.amazonaws.quicksight#TrendArrowOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of trend arrows in a KPI visual.</p>"
+          }
+        },
+        "SecondaryValue": {
+          "target": "com.amazonaws.quicksight#SecondaryValueOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the secondary value of a KPI visual.</p>"
+          }
+        },
+        "Comparison": {
+          "target": "com.amazonaws.quicksight#ComparisonConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The comparison configuration of a KPI visual.</p>"
+          }
+        },
+        "PrimaryValueDisplayType": {
+          "target": "com.amazonaws.quicksight#PrimaryValueDisplayType",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the primary value display type.</p>"
+          }
+        },
+        "PrimaryValueFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the primary value font configuration.</p>"
+          }
+        },
+        "SecondaryValueFontConfiguration": {
+          "target": "com.amazonaws.quicksight#FontConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the secondary value font configuration.</p>"
+          }
+        },
+        "Sparkline": {
+          "target": "com.amazonaws.quicksight#KPISparklineOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the visibility, color, type, and tooltip visibility of the sparkline of a KPI visual.</p>"
+          }
+        },
+        "VisualLayoutOptions": {
+          "target": "com.amazonaws.quicksight#KPIVisualLayoutOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the layout a KPI visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialGradientStepColor": {
+      "type": "structure",
+      "members": {
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the gradient step color.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The data value for the gradient step color.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The gradient step color for a single step.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GradientColor": {
+      "type": "structure",
+      "members": {
+        "Stops": {
+          "target": "com.amazonaws.quicksight#GradientStopList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of gradient color stops.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the gradient color settings.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPIConditionalFormattingOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#KPIConditionalFormattingOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "AreaStyleSettings": {
+          "target": "com.amazonaws.quicksight#RadarChartAreaStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The area style settings of a radar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The series settings of a radar chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColumnIdentifier": {
+      "type": "structure",
+      "members": {
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The data set that the column belongs to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ColumnName": {
+          "target": "com.amazonaws.quicksight#ColumnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the column.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A column of a data set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableDataPathType": {
+      "type": "enum",
+      "members": {
+        "HIERARCHY_ROWS_LAYOUT_COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIERARCHY_ROWS_LAYOUT_COLUMN"
+          }
+        },
+        "MULTIPLE_ROW_METRICS_COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTIPLE_ROW_METRICS_COLUMN"
+          }
+        },
+        "EMPTY_COLUMN_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMPTY_COLUMN_HEADER"
+          }
+        },
+        "COUNT_METRIC_COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT_METRIC_COLUMN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldSortOptions": {
+          "target": "com.amazonaws.quicksight#PivotFieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The field sort options for a pivot table sort configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotUnaggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "XAxis": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The x-axis field well of a scatter plot.</p>\n         <p>The x-axis is a dimension field and cannot be aggregated.</p>"
+          }
+        },
+        "YAxis": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The y-axis field well of a scatter plot.</p>\n         <p>The y-axis is a dimension field and cannot be aggregated.</p>"
+          }
+        },
+        "Size": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The size field well of a scatter plot.</p>"
+          }
+        },
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field well of a scatter plot.</p>"
+          }
+        },
+        "Label": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The label field well of a scatter plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The unaggregated field wells of a scatter plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LineChartDefaultSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "AxisBinding": {
+          "target": "com.amazonaws.quicksight#AxisBinding",
+          "traits": {
+            "smithy.api#documentation": "<p>The axis to which you are binding all line series to.</p>"
+          }
+        },
+        "LineStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartLineStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Line styles options for all line series in the visual.</p>"
+          }
+        },
+        "MarkerStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartMarkerStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Marker styles options for all line series in the visual.</p>"
+          }
+        },
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings options for all line series in the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the default presentation of all line series in <code>LineChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CommitMode": {
+      "type": "enum",
+      "members": {
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "MANUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SeriesItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SeriesItem"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericalMeasureField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>NumericalMeasureField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#NumericalAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the measure field.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NumberFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The measure type field with numerical type columns.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#PluginVisualFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells configuration of the plugin visual.</p>"
+          }
+        },
+        "VisualOptions": {
+          "target": "com.amazonaws.quicksight#PluginVisualOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The persisted properties of the plugin visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#PluginVisualSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the plugin visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The plugin visual configuration. This includes the field wells, sorting options, and persisted options of the plugin visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColorsConfiguration": {
+      "type": "structure",
+      "members": {
+        "CustomColors": {
+          "target": "com.amazonaws.quicksight#CustomColorsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 50 custom colors.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The color configurations for a column.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ArcThicknessOptions": {
+      "type": "enum",
+      "members": {
+        "SMALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMALL"
+          }
+        },
+        "MEDIUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEDIUM"
+          }
+        },
+        "LARGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LARGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MapZoomMode": {
+      "type": "enum",
+      "members": {
+        "AUTO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO"
+          }
+        },
+        "MANUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TreeMapVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#TreeMapConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A tree map.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/tree-map.html\">Using tree maps</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FontStyle": {
+      "type": "enum",
+      "members": {
+        "NORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NORMAL"
+          }
+        },
+        "ITALIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ITALIC"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ScatterPlotCategoricallyAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "XAxis": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The x-axis field well of a scatter plot.</p>\n         <p>The x-axis is aggregated by category.</p>"
+          }
+        },
+        "YAxis": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The y-axis field well of a scatter plot.</p>\n         <p>The y-axis is aggregated by category.</p>"
+          }
+        },
+        "Category": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The category field well of a scatter plot.</p>"
+          }
+        },
+        "Size": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The size field well of a scatter plot.</p>"
+          }
+        },
+        "Label": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The label field well of a scatter plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field well of a scatter plot.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Latitude": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": -90,
+          "max": 90
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ParameterSelectableValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#String"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of the category fields.</p>"
+          }
+        },
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of categories displayed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a <code>FunnelChartVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineStyleConfiguration": {
+      "type": "structure",
+      "members": {
+        "Pattern": {
+          "target": "com.amazonaws.quicksight#ReferenceLinePatternType",
+          "traits": {
+            "smithy.api#documentation": "<p>The pattern type of the line style. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SOLID</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DASHED</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DOTTED</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The hex color of the reference line.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The style configuration of the reference\n            line.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageStaticFileSource": {
+      "type": "structure",
+      "members": {
+        "StaticFileId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the static file that contains the image.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source of the static file that contains the image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TransposedTableOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#TransposedTableOption"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of <code>TransposedTableOption</code> configurations.</p>",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10001
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudWordScaling": {
+      "type": "enum",
+      "members": {
+        "EMPHASIZE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMPHASIZE"
+          }
+        },
+        "NORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NORMAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#StringDefaultValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveStringObject"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DateMeasureField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>DateMeasureField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#DateAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the measure field.</p>"
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#DateTimeFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The measure type field with date type columns.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LongFormatText": {
+      "type": "structure",
+      "members": {
+        "PlainText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>Plain text format.</p>"
+          }
+        },
+        "RichText": {
+          "target": "com.amazonaws.quicksight#LongRichText",
+          "traits": {
+            "smithy.api#documentation": "<p>Rich text. Examples of rich text include bold, underline, and italics.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The text format for a subtitle.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a group by fields.</p>"
+          }
+        },
+        "PaginationConfiguration": {
+          "target": "com.amazonaws.quicksight#PaginationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination configuration of a table visual or box plot.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a <code>BoxPlotVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualTableQuerySort": {
+      "type": "structure",
+      "members": {
+        "RowSort": {
+          "target": "com.amazonaws.quicksight#RowSortList",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines how data is sorted in the response.</p>"
+          }
+        },
+        "ItemsLimitConfiguration": {
+          "target": "com.amazonaws.quicksight#PluginVisualItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of data to be returned by a query.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table query sorting options for the plugin visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetIdentifierDeclaration": {
+      "type": "structure",
+      "members": {
+        "Identifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the data set, typically the data set's name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataSetArn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the data set.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A data set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetIdentifier": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomContentType": {
+      "type": "enum",
+      "members": {
+        "IMAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IMAGE"
+          }
+        },
+        "OTHER_EMBEDDED_CONTENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OTHER_EMBEDDED_CONTENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Icon": {
+      "type": "enum",
+      "members": {
+        "CARET_UP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CARET_UP"
+          }
+        },
+        "CARET_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CARET_DOWN"
+          }
+        },
+        "PLUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PLUS"
+          }
+        },
+        "MINUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MINUS"
+          }
+        },
+        "ARROW_UP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_UP"
+          }
+        },
+        "ARROW_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_DOWN"
+          }
+        },
+        "ARROW_LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_LEFT"
+          }
+        },
+        "ARROW_UP_LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_UP_LEFT"
+          }
+        },
+        "ARROW_DOWN_LEFT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_DOWN_LEFT"
+          }
+        },
+        "ARROW_RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_RIGHT"
+          }
+        },
+        "ARROW_UP_RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_UP_RIGHT"
+          }
+        },
+        "ARROW_DOWN_RIGHT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARROW_DOWN_RIGHT"
+          }
+        },
+        "FACE_UP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FACE_UP"
+          }
+        },
+        "FACE_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FACE_DOWN"
+          }
+        },
+        "FACE_FLAT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FACE_FLAT"
+          }
+        },
+        "ONE_BAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ONE_BAR"
+          }
+        },
+        "TWO_BAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TWO_BAR"
+          }
+        },
+        "THREE_BAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THREE_BAR"
+          }
+        },
+        "CIRCLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CIRCLE"
+          }
+        },
+        "TRIANGLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRIANGLE"
+          }
+        },
+        "SQUARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SQUARE"
+          }
+        },
+        "FLAG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FLAG"
+          }
+        },
+        "THUMBS_UP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THUMBS_UP"
+          }
+        },
+        "THUMBS_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THUMBS_DOWN"
+          }
+        },
+        "CHECKMARK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHECKMARK"
+          }
+        },
+        "X": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "X"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#LineChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#LineChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a line chart.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A line chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/line-charts.html\">Using line charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TimeRangeFilterValue": {
+      "type": "structure",
+      "members": {
+        "StaticValue": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The static input value.</p>"
+          }
+        },
+        "RollingDate": {
+          "target": "com.amazonaws.quicksight#RollingDateConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The rolling date input value.</p>"
+          }
+        },
+        "Parameter": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter type input value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The value of a time range filter.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableFieldLinkContentConfiguration": {
+      "type": "structure",
+      "members": {
+        "CustomTextContent": {
+          "target": "com.amazonaws.quicksight#TableFieldCustomTextContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom text content (value, font configuration) for the table link content configuration.</p>"
+          }
+        },
+        "CustomIconContent": {
+          "target": "com.amazonaws.quicksight#TableFieldCustomIconContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom icon content for the table link content configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The URL content (text, icon) for the table link configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapAggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Geospatial": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The geospatial field wells of a geospatial map. Values are grouped by geospatial fields.</p>"
+          }
+        },
+        "Values": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The size field wells of a geospatial map. Values are aggregated based on geospatial fields.</p>"
+          }
+        },
+        "Colors": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The color field wells of a geospatial map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The aggregated field wells for a geospatial map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#IntegerDefaultValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SensitiveLongObject"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldSubtotalOptionsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableFieldSubtotalOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#KPIVisualStandardLayout": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.quicksight#KPIVisualStandardLayoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The standard layout type.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The standard layout of the KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DataSetReferenceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DataSetReference"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Spacing": {
+      "type": "structure",
+      "members": {
+        "Top": {
+          "target": "com.amazonaws.quicksight#Length",
+          "traits": {
+            "smithy.api#documentation": "<p>Define the top spacing.</p>"
+          }
+        },
+        "Bottom": {
+          "target": "com.amazonaws.quicksight#Length",
+          "traits": {
+            "smithy.api#documentation": "<p>Define the bottom spacing.</p>"
+          }
+        },
+        "Left": {
+          "target": "com.amazonaws.quicksight#Length",
+          "traits": {
+            "smithy.api#documentation": "<p>Define the left spacing.</p>"
+          }
+        },
+        "Right": {
+          "target": "com.amazonaws.quicksight#Length",
+          "traits": {
+            "smithy.api#documentation": "<p>Define the right spacing.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of spacing (often a margin or padding).</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UpdateAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.quicksight#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the analysis that you're updating.</p>"
+          }
+        },
+        "AnalysisId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the analysis.</p>"
+          }
+        },
+        "UpdateStatus": {
+          "target": "com.amazonaws.quicksight#ResourceStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The update status of the last update that was made to the analysis.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#StatusCode",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The HTTP status of the request.</p>",
+            "smithy.api#httpResponseCode": {}
+          }
+        },
+        "RequestId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services request ID for this operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.quicksight#DataPathType": {
+      "type": "structure",
+      "members": {
+        "PivotTableDataPathType": {
+          "target": "com.amazonaws.quicksight#PivotTableDataPathType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of data path value utilized in a pivot table. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HIERARCHY_ROWS_LAYOUT_COLUMN</code> - The type of data path for the rows layout column, when <code>RowsLayout</code> is set to <code>HIERARCHY</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MULTIPLE_ROW_METRICS_COLUMN</code> - The type of data path for the metric column when the row is set to Metric Placement.</p>\n            </li>\n            <li>\n               <p>\n                  <code>EMPTY_COLUMN_HEADER</code> - The type of data path for the column with empty column header, when there is no field in <code>ColumnsFieldWell</code> and the row is set to Metric Placement.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COUNT_METRIC_COLUMN</code> - The type of data path for the column with <code>COUNT</code> as the metric, when there is no field in the <code>ValuesFieldWell</code>.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of the data path value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DescribeAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "Analysis": {
+          "target": "com.amazonaws.quicksight#Analysis",
+          "traits": {
+            "smithy.api#documentation": "<p>A metadata structure that contains summary information for the analysis that you're\n            describing.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.quicksight#StatusCode",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The HTTP status of the request.</p>",
+            "smithy.api#httpResponseCode": {}
+          }
+        },
+        "RequestId": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services request ID for this operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.quicksight#ShortPlainText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapStyleOptions": {
+      "type": "structure",
+      "members": {
+        "BaseMapStyle": {
+          "target": "com.amazonaws.quicksight#BaseMapStyleType",
+          "traits": {
+            "smithy.api#documentation": "<p>The base map style of the geospatial map.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The map style options of the geospatial map.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TopBottomSortOrder": {
+      "type": "enum",
+      "members": {
+        "PERCENT_DIFFERENCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT_DIFFERENCE"
+          }
+        },
+        "ABSOLUTE_DIFFERENCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ABSOLUTE_DIFFERENCE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialGradientStepColorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GeospatialGradientStepColor"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudWordCasing": {
+      "type": "enum",
+      "members": {
+        "LOWER_CASE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOWER_CASE"
+          }
+        },
+        "EXISTING_CASE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXISTING_CASE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#WordCloudChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A word cloud.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/word-cloud.html\">Using word clouds</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GrowthRateComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "PeriodSize": {
+          "target": "com.amazonaws.quicksight#GrowthRatePeriodSize",
+          "traits": {
+            "smithy.api#documentation": "<p>The period size setup of a growth rate computation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The growth rate computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FunnelChartVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#FunnelChartConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of a <code>FunnelChartVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "ColumnHierarchies": {
+          "target": "com.amazonaws.quicksight#ColumnHierarchyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column hierarchy that is used during drill-downs and drill-ups.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A funnel chart.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/funnel-visual-content.html\">Using funnel charts</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FieldSortOptionsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#FieldSortOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#Coordinate": {
+      "type": "structure",
+      "members": {
+        "Latitude": {
+          "target": "com.amazonaws.quicksight#CoordinateLatitudeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The latitude coordinate value for the geocode preference.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Longitude": {
+          "target": "com.amazonaws.quicksight#CoordinateLongitudeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The longitude coordinate value for the geocode preference.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The preference coordinate for the geocode preference.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ColumnConfiguration": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#FormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of a column.</p>"
+          }
+        },
+        "Role": {
+          "target": "com.amazonaws.quicksight#ColumnRole",
+          "traits": {
+            "smithy.api#documentation": "<p>The role of the column.</p>"
+          }
+        },
+        "ColorsConfiguration": {
+          "target": "com.amazonaws.quicksight#ColorsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The color configurations of the column.</p>"
+          }
+        },
+        "DecalSettingsConfiguration": {
+          "target": "com.amazonaws.quicksight#DecalSettingsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal configuration of the column.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The general configuration of a column.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumberDisplayFormatConfiguration": {
+      "type": "structure",
+      "members": {
+        "Prefix": {
+          "target": "com.amazonaws.quicksight#Prefix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the prefix value of the number format.</p>"
+          }
+        },
+        "Suffix": {
+          "target": "com.amazonaws.quicksight#Suffix",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the suffix value of the number format.</p>"
+          }
+        },
+        "SeparatorConfiguration": {
+          "target": "com.amazonaws.quicksight#NumericSeparatorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the numeric separator configuration.</p>"
+          }
+        },
+        "DecimalPlacesConfiguration": {
+          "target": "com.amazonaws.quicksight#DecimalPlacesConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The option that determines the decimal places configuration.</p>"
+          }
+        },
+        "NumberScale": {
+          "target": "com.amazonaws.quicksight#NumberScale",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the number scale value of the number format.</p>"
+          }
+        },
+        "NegativeValueConfiguration": {
+          "target": "com.amazonaws.quicksight#NegativeValueConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the negative value configuration.</p>"
+          }
+        },
+        "NullValueFormatConfiguration": {
+          "target": "com.amazonaws.quicksight#NullValueFormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the null value format configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the number display format configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingIcon": {
+      "type": "structure",
+      "members": {
+        "IconSet": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIconSet",
+          "traits": {
+            "smithy.api#documentation": "<p>Formatting configuration for icon set.</p>"
+          }
+        },
+        "CustomCondition": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingCustomIconCondition",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the custom condition for an icon set.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The formatting configuration for the icon.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeFormat": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableMetricPlacement": {
+      "type": "enum",
+      "members": {
+        "ROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROW"
+          }
+        },
+        "COLUMN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLUMN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#FieldSort": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration target field.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Direction": {
+          "target": "com.amazonaws.quicksight#SortDirection",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort direction. Choose one of the following\n            options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ASC</code>: Ascending</p>\n            </li>\n            <li>\n               <p>\n                  <code>DESC</code>: Descending</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration for a field in a\n            field well.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCircleSymbolStyle": {
+      "type": "structure",
+      "members": {
+        "FillColor": {
+          "target": "com.amazonaws.quicksight#GeospatialColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the fill color.</p>"
+          }
+        },
+        "StrokeColor": {
+          "target": "com.amazonaws.quicksight#GeospatialColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The color and opacity values for the stroke color.</p>"
+          }
+        },
+        "StrokeWidth": {
+          "target": "com.amazonaws.quicksight#GeospatialLineWidth",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the stroke (border).</p>"
+          }
+        },
+        "CircleRadius": {
+          "target": "com.amazonaws.quicksight#GeospatialCircleRadius",
+          "traits": {
+            "smithy.api#documentation": "<p>The radius of the circle.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties for a circle symbol style.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramBinOptions": {
+      "type": "structure",
+      "members": {
+        "SelectedBinType": {
+          "target": "com.amazonaws.quicksight#HistogramBinType",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the selected bin type.</p>"
+          }
+        },
+        "BinCount": {
+          "target": "com.amazonaws.quicksight#BinCountOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the bin count of a histogram.</p>"
+          }
+        },
+        "BinWidth": {
+          "target": "com.amazonaws.quicksight#BinWidthOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the bin width of a histogram.</p>"
+          }
+        },
+        "StartValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The options that determine the bin start value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the presentation of histogram bins.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ForecastConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ForecastConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ConditionalFormattingCustomIconCondition": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression that determines the condition of the icon set.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IconOptions": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingCustomIconOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom icon options for an icon set.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColor",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the color of the icon.</p>"
+          }
+        },
+        "DisplayConfiguration": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIconDisplayConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the icon display configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the custom condition for an icon set.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetTextBox": {
+      "type": "structure",
+      "members": {
+        "SheetTextBoxId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for a text box. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have text boxes that share identifiers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Content": {
+          "target": "com.amazonaws.quicksight#SheetTextBoxContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content that is displayed in the text box.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#TextBoxInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general textbox interactions setup for a textbox.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A text box.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RelativeDateType": {
+      "type": "enum",
+      "members": {
+        "PREVIOUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PREVIOUS"
+          }
+        },
+        "THIS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THIS"
+          }
+        },
+        "LAST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAST"
+          }
+        },
+        "NOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOW"
+          }
+        },
+        "NEXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEXT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialWindowOptions": {
+      "type": "structure",
+      "members": {
+        "Bounds": {
+          "target": "com.amazonaws.quicksight#GeospatialCoordinateBounds",
+          "traits": {
+            "smithy.api#documentation": "<p>The bounds options (north, south, west, east) of the geospatial window options.</p>"
+          }
+        },
+        "MapZoomMode": {
+          "target": "com.amazonaws.quicksight#MapZoomMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The map zoom modes (manual, auto) of the geospatial window options.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The window options of the geospatial map visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ForecastComputation": {
+      "type": "structure",
+      "members": {
+        "ComputationId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for a computation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a computation.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.quicksight#DimensionField",
+          "traits": {
+            "smithy.api#documentation": "<p>The time field that is used in a computation.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#MeasureField",
+          "traits": {
+            "smithy.api#documentation": "<p>The value field that is used in a computation.</p>"
+          }
+        },
+        "PeriodsForward": {
+          "target": "com.amazonaws.quicksight#PeriodsForward",
+          "traits": {
+            "smithy.api#documentation": "<p>The periods forward setup of a forecast computation.</p>"
+          }
+        },
+        "PeriodsBackward": {
+          "target": "com.amazonaws.quicksight#PeriodsBackward",
+          "traits": {
+            "smithy.api#documentation": "<p>The periods backward setup of a forecast computation.</p>"
+          }
+        },
+        "UpperBoundary": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The upper boundary setup of a forecast computation.</p>"
+          }
+        },
+        "LowerBoundary": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The lower boundary setup of a forecast computation.</p>"
+          }
+        },
+        "PredictionInterval": {
+          "target": "com.amazonaws.quicksight#PredictionInterval",
+          "traits": {
+            "smithy.api#documentation": "<p>The prediction interval setup of a forecast computation.</p>"
+          }
+        },
+        "Seasonality": {
+          "target": "com.amazonaws.quicksight#ForecastComputationSeasonality",
+          "traits": {
+            "smithy.api#documentation": "<p>The seasonality setup of a forecast computation. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AUTOMATIC</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>CUSTOM</code>: Checks the custom seasonality value.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CustomSeasonalityValue": {
+          "target": "com.amazonaws.quicksight#ForecastComputationCustomSeasonalityValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom seasonality value setup of a forecast computation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The forecast computation configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CalculatedMeasureField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Expression": {
+          "target": "com.amazonaws.quicksight#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression in the table calculation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The table calculation measure field for pivot tables.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FreeFormSectionLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "Elements": {
+          "target": "com.amazonaws.quicksight#FreeFromLayoutElementList",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements that are included in the free-form layout.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The free-form layout configuration of a section.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetDefinitionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetDefinition"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#RadarChartAreaStyleSettings": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility settings of a radar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configured style settings of a radar chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TimeRangeFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IncludeMinimum": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines whether the minimum value in the filter value range should be included in the filtered results.</p>"
+          }
+        },
+        "IncludeMaximum": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Determines whether the maximum value in the filter value range should be included in the filtered results.</p>"
+          }
+        },
+        "RangeMinimumValue": {
+          "target": "com.amazonaws.quicksight#TimeRangeFilterValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum value for the filter value range.</p>"
+          }
+        },
+        "RangeMaximumValue": {
+          "target": "com.amazonaws.quicksight#TimeRangeFilterValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum value for the filter value range.</p>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExcludePeriodConfiguration": {
+          "target": "com.amazonaws.quicksight#ExcludePeriodConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The exclude period of the time range filter.</p>"
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>"
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>TimeRangeFilter</code> filters values that are between two specified values.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableUnaggregatedFieldWells": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.quicksight#TableUnaggregatedFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The values field well for a pivot table. Values are unaggregated for an unaggregated table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The unaggregated field well for the table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudOptions": {
+      "type": "structure",
+      "members": {
+        "WordOrientation": {
+          "target": "com.amazonaws.quicksight#WordCloudWordOrientation",
+          "traits": {
+            "smithy.api#documentation": "<p>The word orientation options (horizontal, horizontal_and_vertical) for the words in a word cloud.</p>"
+          }
+        },
+        "WordScaling": {
+          "target": "com.amazonaws.quicksight#WordCloudWordScaling",
+          "traits": {
+            "smithy.api#documentation": "<p>The word scaling options (emphasize, normal) for the words in a word cloud.</p>"
+          }
+        },
+        "CloudLayout": {
+          "target": "com.amazonaws.quicksight#WordCloudCloudLayout",
+          "traits": {
+            "smithy.api#documentation": "<p>The cloud layout options (fluid, normal) of a word cloud.</p>"
+          }
+        },
+        "WordCasing": {
+          "target": "com.amazonaws.quicksight#WordCloudWordCasing",
+          "traits": {
+            "smithy.api#documentation": "<p>The word casing options (lower_case, existing_case) for the words in a word cloud.</p>"
+          }
+        },
+        "WordPadding": {
+          "target": "com.amazonaws.quicksight#WordCloudWordPadding",
+          "traits": {
+            "smithy.api#documentation": "<p>The word padding options (none, small, medium, large) for the words in a word cloud.</p>"
+          }
+        },
+        "MaximumStringLength": {
+          "target": "com.amazonaws.quicksight#WordCloudMaximumStringLength",
+          "traits": {
+            "smithy.api#documentation": "<p>The length limit of each word from 1-100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The word cloud options for a word cloud visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboChartSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "LineStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartLineStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Line styles options for the line series in the visual.</p>"
+          }
+        },
+        "MarkerStyleSettings": {
+          "target": "com.amazonaws.quicksight#LineChartMarkerStyleSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Marker styles options for the line series in the visual.</p>"
+          }
+        },
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings for the series in the visual.</p>"
+          }
+        },
+        "BorderSettings": {
+          "target": "com.amazonaws.quicksight#BorderSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Border settings for the bar series in the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Options that determine the presentation of a series in the visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeocoderHierarchyCityString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SheetControlLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "GridLayout": {
+          "target": "com.amazonaws.quicksight#GridLayoutConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that determines the elements and canvas size options of sheet control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that determines the elements and canvas size options of sheet control.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#CategoryFilterMatchOperator": {
+      "type": "enum",
+      "members": {
+        "EQUALS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EQUALS"
+          }
+        },
+        "DOES_NOT_EQUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOES_NOT_EQUAL"
+          }
+        },
+        "CONTAINS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTAINS"
+          }
+        },
+        "DOES_NOT_CONTAIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOES_NOT_CONTAIN"
+          }
+        },
+        "STARTS_WITH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTS_WITH"
+          }
+        },
+        "ENDS_WITH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENDS_WITH"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableDataPathOptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#PivotTableDataPathOption"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#WhatIfPointScenario": {
+      "type": "structure",
+      "members": {
+        "Date": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date that you need the forecast results for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The target value that you want to meet for the provided date.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the forecast to meet the target for a particular date.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterScopeConfiguration": {
+      "type": "structure",
+      "members": {
+        "SelectedSheets": {
+          "target": "com.amazonaws.quicksight#SelectedSheetsFilterScopeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for applying a filter to specific sheets.</p>"
+          }
+        },
+        "AllSheets": {
+          "target": "com.amazonaws.quicksight#AllSheetsFilterScopeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration that applies a filter to all sheets. When you choose <code>AllSheets</code> as the value for a <code>FilterScopeConfiguration</code>, this filter is applied to all visuals of all sheets in an Analysis, Dashboard, or Template. The <code>AllSheetsFilterScopeConfiguration</code> is chosen.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The scope configuration for a <code>FilterGroup</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterDateTimePickerControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the <code>ParameterDateTimePickerControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DateTimePickerControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control from a date parameter that specifies date and time.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#HistogramBinType": {
+      "type": "enum",
+      "members": {
+        "BIN_COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIN_COUNT"
+          }
+        },
+        "BIN_WIDTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIN_WIDTH"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutElementBorderStyle": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The border visibility of a grid layout element.</p>"
+          }
+        },
+        "Color": {
+          "target": "com.amazonaws.quicksight#HexColorWithTransparency",
+          "traits": {
+            "smithy.api#documentation": "<p>The border color of a grid layout element.</p>"
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.quicksight#Width",
+          "traits": {
+            "smithy.api#documentation": "<p>The border width of a grid layout element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The border style configuration of a grid layout element.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConditionalFormattingScopeRole": {
+      "type": "enum",
+      "members": {
+        "FIELD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIELD"
+          }
+        },
+        "FIELD_TOTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIELD_TOTAL"
+          }
+        },
+        "GRAND_TOTAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GRAND_TOTAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#SortDirection": {
+      "type": "enum",
+      "members": {
+        "ASC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASC"
+          }
+        },
+        "DESC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESC"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PredictionInterval": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 50,
+          "max": 95
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GeocodePreferenceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#GeocodePreference"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#PivotTableSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration for a <code>PivotTableVisual</code>.</p>"
+          }
+        },
+        "TableOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table options for a pivot table visual.</p>"
+          }
+        },
+        "TotalOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableTotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The total options for a pivot table visual.</p>"
+          }
+        },
+        "FieldOptions": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The field options for a pivot table visual.</p>"
+          }
+        },
+        "PaginatedReportOptions": {
+          "target": "com.amazonaws.quicksight#PivotTablePaginatedReportOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The paginated report options for a pivot table visual.</p>"
+          }
+        },
+        "DashboardCustomizationVisualOptions": {
+          "target": "com.amazonaws.quicksight#DashboardCustomizationVisualOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that define customizations available to dashboard readers for a specific visual</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a <code>PivotTableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#FilterCrossSheetControl": {
+      "type": "structure",
+      "members": {
+        "FilterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>FilterCrossSheetControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceFilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The source filter ID of the <code>FilterCrossSheetControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CascadingControlConfiguration": {
+          "target": "com.amazonaws.quicksight#CascadingControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control from a filter that is scoped across more than one sheet. This represents your filter control on a sheet</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PrimaryValueDisplayType": {
+      "type": "enum",
+      "members": {
+        "HIDDEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HIDDEN"
+          }
+        },
+        "COMPARISON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPARISON"
+          }
+        },
+        "ACTUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TargetVisualOptions": {
+      "type": "enum",
+      "members": {
+        "ALL_VISUALS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_VISUALS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#TimeRangeDrillDownFilter": {
+      "type": "structure",
+      "members": {
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RangeMinimum": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum value for the filter value range.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RangeMaximum": {
+          "target": "com.amazonaws.quicksight#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum value for the filter value range.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TimeGranularity": {
+          "target": "com.amazonaws.quicksight#TimeGranularity",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of time precision that is used to aggregate <code>DateTime</code> values.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The time range drill down filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartSeriesSettings": {
+      "type": "structure",
+      "members": {
+        "DecalSettings": {
+          "target": "com.amazonaws.quicksight#DecalSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Decal settings for the bar series.</p>"
+          }
+        },
+        "BorderSettings": {
+          "target": "com.amazonaws.quicksight#BorderSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Border settings for the bar series.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Options that determine the presentation of a bar series in the visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudSortConfiguration": {
+      "type": "structure",
+      "members": {
+        "CategoryItemsLimit": {
+          "target": "com.amazonaws.quicksight#ItemsLimitConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit on the number of groups that are displayed in a word cloud.</p>"
+          }
+        },
+        "CategorySort": {
+          "target": "com.amazonaws.quicksight#FieldSortOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of group by fields.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sort configuration of a word cloud visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#AttributeAggregationFunction": {
+      "type": "structure",
+      "members": {
+        "SimpleAttributeAggregation": {
+          "target": "com.amazonaws.quicksight#SimpleAttributeAggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The built-in aggregation functions for attributes.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>UNIQUE_VALUE</code>: Returns the unique value for a field, aggregated by the dimension fields.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "ValueForMultipleValues": {
+          "target": "com.amazonaws.quicksight#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Used by the <code>UNIQUE_VALUE</code> aggregation function. If there are multiple values for the field used by the aggregation, the value for this property will be returned instead. Defaults to '*'.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Aggregation for attributes.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboSeriesItem": {
+      "type": "structure",
+      "members": {
+        "FieldComboSeriesItem": {
+          "target": "com.amazonaws.quicksight#FieldComboSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The field series item configuration of a <code>ComboChartVisual</code>.</p>"
+          }
+        },
+        "DataFieldComboSeriesItem": {
+          "target": "com.amazonaws.quicksight#DataFieldComboSeriesItem",
+          "traits": {
+            "smithy.api#documentation": "<p>The data field series item configuration of a <code>ComboChartVisual</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The series item configuration of a <code>ComboChartVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableSideBorderOptions": {
+      "type": "structure",
+      "members": {
+        "InnerVertical": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the inner vertical border.</p>"
+          }
+        },
+        "InnerHorizontal": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the inner horizontal border.</p>"
+          }
+        },
+        "Left": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the left border.</p>"
+          }
+        },
+        "Right": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the right border.</p>"
+          }
+        },
+        "Top": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the top border.</p>"
+          }
+        },
+        "Bottom": {
+          "target": "com.amazonaws.quicksight#TableBorderOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table border options of the bottom border.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The side border options for a table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BarChartFieldWells": {
+      "type": "structure",
+      "members": {
+        "BarChartAggregatedFieldWells": {
+          "target": "com.amazonaws.quicksight#BarChartAggregatedFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregated field wells of a bar chart.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The field wells of a <code>BarChartVisual</code>.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TextWrap": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "WRAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WRAP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#VisualCustomActionOperation": {
+      "type": "structure",
+      "members": {
+        "FilterOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionFilterOperation",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter operation that filters data included in a visual or in an entire sheet.</p>"
+          }
+        },
+        "NavigationOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionNavigationOperation",
+          "traits": {
+            "smithy.api#documentation": "<p>The navigation operation that navigates between different sheets in the same analysis.</p>"
+          }
+        },
+        "URLOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionURLOperation",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL operation that opens a link to another webpage.</p>"
+          }
+        },
+        "SetParametersOperation": {
+          "target": "com.amazonaws.quicksight#CustomActionSetParametersOperation",
+          "traits": {
+            "smithy.api#documentation": "<p>The set parameter operation that sets parameters in custom action.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The operation that is defined by the custom action.</p>\n         <p>This is a union type structure. For this structure to be valid, only one of the attributes can be defined.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#KPISparklineType": {
+      "type": "enum",
+      "members": {
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        },
+        "AREA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AREA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#MaximumLabelType": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the maximum label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The maximum label of a data path label.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetImageTooltipConfiguration": {
+      "type": "structure",
+      "members": {
+        "TooltipText": {
+          "target": "com.amazonaws.quicksight#SheetImageTooltipText",
+          "traits": {
+            "smithy.api#documentation": "<p>The text that appears in the tooltip.</p>"
+          }
+        },
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the tooltip.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tooltip configuration for a sheet image.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WaterfallChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#WaterfallChartFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field well configuration of a waterfall visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#WaterfallChartSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a waterfall visual.</p>"
+          }
+        },
+        "WaterfallChartOptions": {
+          "target": "com.amazonaws.quicksight#WaterfallChartOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of a waterfall visual.</p>"
+          }
+        },
+        "CategoryAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the category axis label.</p>"
+          }
+        },
+        "CategoryAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the category axis.</p>"
+          }
+        },
+        "PrimaryYAxisLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the y-axis label.</p>"
+          }
+        },
+        "PrimaryYAxisDisplayOptions": {
+          "target": "com.amazonaws.quicksight#AxisDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that determine the presentation of the y-axis.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend configuration of a waterfall visual.</p>"
+          }
+        },
+        "DataLabels": {
+          "target": "com.amazonaws.quicksight#DataLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The data label configuration of a waterfall visual.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual palette configuration of a waterfall visual.</p>"
+          }
+        },
+        "ColorConfiguration": {
+          "target": "com.amazonaws.quicksight#WaterfallChartColorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The color configuration of a waterfall visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a waterfall visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialCategoricalColor": {
+      "type": "structure",
+      "members": {
+        "CategoryDataColors": {
+          "target": "com.amazonaws.quicksight#GeospatialCategoricalDataColorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of categorical data colors for each category.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NullDataVisibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of visibility for null data.</p>"
+          }
+        },
+        "NullDataSettings": {
+          "target": "com.amazonaws.quicksight#GeospatialNullDataSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The null data visualization settings.</p>"
+          }
+        },
+        "DefaultOpacity": {
+          "target": "com.amazonaws.quicksight#Opacity",
+          "traits": {
+            "smithy.api#documentation": "<p>The default opacity of a categorical color.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition for a categorical color.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ContributionAnalysisDefaultList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ContributionAnalysisDefault"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.quicksight#CustomActionURLOperation": {
+      "type": "structure",
+      "members": {
+        "URLTemplate": {
+          "target": "com.amazonaws.quicksight#URLOperationTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>THe URL link of the <code>CustomActionURLOperation</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "URLTarget": {
+          "target": "com.amazonaws.quicksight#URLTargetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The target of the <code>CustomActionURLOperation</code>.</p>\n         <p>Valid values are defined as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NEW_TAB</code>: Opens the target URL in a new browser tab.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NEW_WINDOW</code>: Opens the target URL in a new browser window.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SAME_TAB</code>: Opens the target URL in the same browser tab.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The URL operation that opens a link to another webpage.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#RangeEndsLabelType": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the range ends label.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The range ends label type of a data path label.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ParameterDropDownControl": {
+      "type": "structure",
+      "members": {
+        "ParameterControlId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the <code>ParameterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#SheetControlTitle",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the <code>ParameterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The source parameter name of the <code>ParameterDropDownControl</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayOptions": {
+          "target": "com.amazonaws.quicksight#DropDownControlDisplayOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The display options of a control.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.quicksight#SheetControlListType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type parameter name of the <code>ParameterDropDownControl</code>.</p>"
+          }
+        },
+        "SelectableValues": {
+          "target": "com.amazonaws.quicksight#ParameterSelectableValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of selectable values that are used in a control.</p>"
+          }
+        },
+        "CascadingControlConfiguration": {
+          "target": "com.amazonaws.quicksight#CascadingControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The values that are displayed in a control can be configured to only show values that are valid based on what's selected in other controls.</p>"
+          }
+        },
+        "CommitMode": {
+          "target": "com.amazonaws.quicksight#CommitMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility configuration of the Apply button on a <code>ParameterDropDownControl</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A control to display a dropdown list with buttons that are used to select a single value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#MissingDataConfiguration": {
+      "type": "structure",
+      "members": {
+        "TreatmentOption": {
+          "target": "com.amazonaws.quicksight#MissingDataTreatmentOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The treatment option that determines how missing data should be rendered. Choose\n            from the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INTERPOLATE</code>: Interpolate missing values between the prior and the next known value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SHOW_AS_ZERO</code>: Show missing values as the value <code>0</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SHOW_AS_BLANK</code>: Display a blank space when rendering missing data.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration options that determine how missing data is treated during the rendering of a line chart.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ContributorDimensionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PredefinedHierarchyColumnList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ColumnIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableVisual": {
+      "type": "structure",
+      "members": {
+        "VisualId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a visual. This identifier must be unique within the context of a dashboard, template, or analysis. Two dashboards, analyses, or templates can have visuals with the same identifiers..</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.quicksight#VisualTitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The title that is displayed on the visual.</p>"
+          }
+        },
+        "Subtitle": {
+          "target": "com.amazonaws.quicksight#VisualSubtitleLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The subtitle that is displayed on the visual.</p>"
+          }
+        },
+        "ChartConfiguration": {
+          "target": "com.amazonaws.quicksight#PivotTableConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings of the visual.</p>"
+          }
+        },
+        "ConditionalFormatting": {
+          "target": "com.amazonaws.quicksight#PivotTableConditionalFormatting",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting for a <code>PivotTableVisual</code>.</p>"
+          }
+        },
+        "Actions": {
+          "target": "com.amazonaws.quicksight#VisualCustomActionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of custom actions that are configured for a visual.</p>"
+          }
+        },
+        "VisualContentAltText": {
+          "target": "com.amazonaws.quicksight#LongPlainText",
+          "traits": {
+            "smithy.api#documentation": "<p>The alt text for the visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A pivot table.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/quicksight/latest/user/pivot-table.html\">Using pivot tables</a> in the <i>Amazon Quick Suite User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#InsightConfiguration": {
+      "type": "structure",
+      "members": {
+        "Computations": {
+          "target": "com.amazonaws.quicksight#ComputationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The computations configurations of the insight visual</p>"
+          }
+        },
+        "CustomNarrative": {
+          "target": "com.amazonaws.quicksight#CustomNarrativeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom narrative of the insight visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of an insight visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialMapConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#GeospatialMapFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "Legend": {
+          "target": "com.amazonaws.quicksight#LegendOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The legend display setup of the visual.</p>"
+          }
+        },
+        "Tooltip": {
+          "target": "com.amazonaws.quicksight#TooltipOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The tooltip display setup of the visual.</p>"
+          }
+        },
+        "WindowOptions": {
+          "target": "com.amazonaws.quicksight#GeospatialWindowOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The window options of the geospatial map.</p>"
+          }
+        },
+        "MapStyleOptions": {
+          "target": "com.amazonaws.quicksight#GeospatialMapStyleOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The map style options of the geospatial map.</p>"
+          }
+        },
+        "PointStyleOptions": {
+          "target": "com.amazonaws.quicksight#GeospatialPointStyleOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The point style options of the geospatial map.</p>"
+          }
+        },
+        "VisualPalette": {
+          "target": "com.amazonaws.quicksight#VisualPalette"
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a <code>GeospatialMapVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#WordCloudChartConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#WordCloudFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#WordCloudSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration of a word cloud visual.</p>"
+          }
+        },
+        "CategoryLabelOptions": {
+          "target": "com.amazonaws.quicksight#ChartAxisLabelOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The label options (label text, label visibility, and sort icon visibility) for the word cloud category.</p>"
+          }
+        },
+        "WordCloudOptions": {
+          "target": "com.amazonaws.quicksight#WordCloudOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for a word cloud visual.</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration of a word cloud visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetTextBoxList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#SheetTextBox"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DynamicDefaultValue": {
+      "type": "structure",
+      "members": {
+        "UserNameColumn": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that contains the username.</p>"
+          }
+        },
+        "GroupNameColumn": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that contains the group name.</p>"
+          }
+        },
+        "DefaultValueColumn": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that contains the default value of each user or group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines different defaults to the users or groups based on mapping.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ComboSeriesItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ComboSeriesItem"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.quicksight#KPIVisualLayoutOptions": {
+      "type": "structure",
+      "members": {
+        "StandardLayout": {
+          "target": "com.amazonaws.quicksight#KPIVisualStandardLayout",
+          "traits": {
+            "smithy.api#documentation": "<p>The standard layout of the KPI visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The options that determine the layout a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ImageCustomActionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ImageCustomAction"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.quicksight#HierarchyId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.quicksight#NumericRangeFilterValue": {
+      "type": "structure",
+      "members": {
+        "StaticValue": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The static value of the numeric range filter.</p>"
+          }
+        },
+        "Parameter": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter that is used in the numeric range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The value input pf the numeric range filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#Width": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "String to encapsulate the most generic way Width can be formatted with whatever units (px, em etc)",
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#ReferenceLine"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.quicksight#KPIComparisonValueConditionalFormatting": {
+      "type": "structure",
+      "members": {
+        "TextColor": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingColor",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the comparison value's text color.</p>"
+          }
+        },
+        "Icon": {
+          "target": "com.amazonaws.quicksight#ConditionalFormattingIcon",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditional formatting of the comparison value's icon.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditional formatting for the comparison value of a KPI visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#LayoutList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#Layout"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.quicksight#PivotTableFieldCollapseStateOption": {
+      "type": "structure",
+      "members": {
+        "Target": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldCollapseStateTarget",
+          "traits": {
+            "smithy.api#documentation": "<p>A tagged-union object that sets the collapse state.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.quicksight#PivotTableFieldCollapseState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the field target of a pivot table. Choose one of the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COLLAPSED</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>EXPANDED</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The collapse state options for the pivot table field options.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ScrollBarOptions": {
+      "type": "structure",
+      "members": {
+        "Visibility": {
+          "target": "com.amazonaws.quicksight#Visibility",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility of the data zoom scroll bar.</p>"
+          }
+        },
+        "VisibleRange": {
+          "target": "com.amazonaws.quicksight#VisibleRangeOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The visibility range for the data zoom scroll bar.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The visual display options for a data zoom scroll bar.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#UnaggregatedField": {
+      "type": "structure",
+      "members": {
+        "FieldId": {
+          "target": "com.amazonaws.quicksight#FieldId",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom field ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that is used in the <code>UnaggregatedField</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FormatConfiguration": {
+          "target": "com.amazonaws.quicksight#FormatConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The format configuration of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The unaggregated field for a table.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#GeospatialPointLayer": {
+      "type": "structure",
+      "members": {
+        "Style": {
+          "target": "com.amazonaws.quicksight#GeospatialPointStyle",
+          "traits": {
+            "smithy.api#documentation": "<p>The visualization style for a point layer.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The geospatial Point layer.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#ReferenceLineCustomLabelConfiguration": {
+      "type": "structure",
+      "members": {
+        "CustomLabel": {
+          "target": "com.amazonaws.quicksight#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The string text of the custom label.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a custom label on a <code>ReferenceLine</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NestedFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IncludeInnerSet": {
+          "target": "com.amazonaws.quicksight#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>A boolean condition to include or exclude the subset that is defined by the values of the nested inner filter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InnerFilter": {
+          "target": "com.amazonaws.quicksight#InnerFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>InnerFilter</code> defines the subset of data to be used with the <code>NestedFilter</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>NestedFilter</code> filters data with a subset of data that is defined by the nested inner filter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#NumericEqualityFilter": {
+      "type": "structure",
+      "members": {
+        "FilterId": {
+          "target": "com.amazonaws.quicksight#ShortRestrictiveResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that uniquely identifies a filter within a dashboard, analysis, or template.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Column": {
+          "target": "com.amazonaws.quicksight#ColumnIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The column that the filter is applied to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.quicksight#Double",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The input value.</p>"
+          }
+        },
+        "SelectAllOptions": {
+          "target": "com.amazonaws.quicksight#NumericFilterSelectAllOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Select all of the values. Null is not the assigned value of select all.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>FILTER_ALL_VALUES</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "MatchOperator": {
+          "target": "com.amazonaws.quicksight#NumericEqualityMatchOperator",
+          "traits": {
+            "smithy.api#documentation": "<p>The match operator that is used to determine if a filter should be applied.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AggregationFunction": {
+          "target": "com.amazonaws.quicksight#AggregationFunction",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation function of the filter.</p>"
+          }
+        },
+        "ParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameter whose value should be used for the filter value.</p>"
+          }
+        },
+        "NullOption": {
+          "target": "com.amazonaws.quicksight#FilterNullOption",
+          "traits": {
+            "smithy.api#documentation": "<p>This option determines how null values should be treated when filtering data.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_VALUES</code>: Include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NULLS_ONLY</code>: Only include null values in filtered results.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_NULLS_ONLY</code>: Exclude null values from filtered results.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultFilterControlConfiguration": {
+          "target": "com.amazonaws.quicksight#DefaultFilterControlConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The default configurations for the associated controls. This applies only for filters that are scoped to multiple sheets.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>NumericEqualityFilter</code> filters values that are equal to the specified value.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#MappedDataSetParameter": {
+      "type": "structure",
+      "members": {
+        "DataSetIdentifier": {
+          "target": "com.amazonaws.quicksight#DataSetIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name that identifies a dataset within the analysis or dashboard.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataSetParameterName": {
+          "target": "com.amazonaws.quicksight#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dataset parameter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A dataset parameter that is mapped to an analysis parameter.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableConfiguration": {
+      "type": "structure",
+      "members": {
+        "FieldWells": {
+          "target": "com.amazonaws.quicksight#TableFieldWells",
+          "traits": {
+            "smithy.api#documentation": "<p>The field wells of the visual.</p>"
+          }
+        },
+        "SortConfiguration": {
+          "target": "com.amazonaws.quicksight#TableSortConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The sort configuration for a <code>TableVisual</code>.</p>"
+          }
+        },
+        "TableOptions": {
+          "target": "com.amazonaws.quicksight#TableOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The table options for a table visual.</p>"
+          }
+        },
+        "TotalOptions": {
+          "target": "com.amazonaws.quicksight#TotalOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The total options for a table visual.</p>"
+          }
+        },
+        "FieldOptions": {
+          "target": "com.amazonaws.quicksight#TableFieldOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The field options for a table visual.</p>"
+          }
+        },
+        "PaginatedReportOptions": {
+          "target": "com.amazonaws.quicksight#TablePaginatedReportOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The paginated report options for a table visual.</p>"
+          }
+        },
+        "TableInlineVisualizations": {
+          "target": "com.amazonaws.quicksight#TableInlineVisualizationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of inline visualizations to display within a chart.</p>"
+          }
+        },
+        "DashboardCustomizationVisualOptions": {
+          "target": "com.amazonaws.quicksight#DashboardCustomizationVisualOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The options that define customizations available to dashboard readers for a specific visual</p>"
+          }
+        },
+        "Interactions": {
+          "target": "com.amazonaws.quicksight#VisualInteractionOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The general visual interactions setup for a visual.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a <code>TableVisual</code>.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PluginVisualFieldWell": {
+      "type": "structure",
+      "members": {
+        "AxisName": {
+          "target": "com.amazonaws.quicksight#PluginVisualAxisName",
+          "traits": {
+            "smithy.api#documentation": "<p>The semantic axis name for the field well.</p>"
+          }
+        },
+        "Dimensions": {
+          "target": "com.amazonaws.quicksight#DimensionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of dimensions for the field well.</p>"
+          }
+        },
+        "Measures": {
+          "target": "com.amazonaws.quicksight#MeasureFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of measures that exist in the field well.</p>"
+          }
+        },
+        "Unaggregated": {
+          "target": "com.amazonaws.quicksight#UnaggregatedFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of unaggregated fields that exist in the field well.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A collection of field wells for a plugin visual.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#PivotMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 40
+        }
+      }
+    },
+    "com.amazonaws.quicksight#StaticFileSource": {
+      "type": "structure",
+      "members": {
+        "UrlOptions": {
+          "target": "com.amazonaws.quicksight#StaticFileUrlSourceOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The structure that contains the URL to download the static file from.</p>"
+          }
+        },
+        "S3Options": {
+          "target": "com.amazonaws.quicksight#StaticFileS3SourceOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The structure that contains the Amazon S3 location to download the static file from.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The source of the static file.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#TableCellImageSizingConfiguration": {
+      "type": "structure",
+      "members": {
+        "TableCellImageScalingConfiguration": {
+          "target": "com.amazonaws.quicksight#TableCellImageScalingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The cell scaling configuration of the sizing options for the table image configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The sizing options for the table image configuration.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotFillStyle": {
+      "type": "enum",
+      "members": {
+        "SOLID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOLID"
+          }
+        },
+        "TRANSPARENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRANSPARENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.quicksight#DateTimeParameterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#DateTimeParameter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.quicksight#BoxPlotMeasureFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.quicksight#MeasureField"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.quicksight#GridLayoutConfiguration": {
+      "type": "structure",
+      "members": {
+        "Elements": {
+          "target": "com.amazonaws.quicksight#GridLayoutElementList",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements that are included in a grid layout.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CanvasSizeOptions": {
+          "target": "com.amazonaws.quicksight#GridLayoutCanvasSizeOptions"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for a grid layout. Also called a tiled layout.</p>\n         <p>Visuals snap to a grid with standard spacing and alignment. Dashboards are displayed as designed, with options to fit to screen or view at actual size.</p>"
+      }
+    },
+    "com.amazonaws.quicksight#SheetContentType": {
+      "type": "enum",
+      "members": {
+        "PAGINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAGINATED"
+          }
+        },
+        "INTERACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERACTIVE"
+          }
+        }
+      }
     }
   }
 }

--- a/pkg/testdata/models/apis/quicksight/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/quicksight/0000-00-00/generator.yaml
@@ -3,7 +3,34 @@ ignore:
   field_paths:
     - CreateDataSetOutput.RequestId
     - CreateDataSetOutput.Status
+    - CreateAnalysisOutput.RequestId
+    - CreateAnalysisOutput.Status
+    - UpdateAnalysisOutput.RequestId
+    - UpdateAnalysisOutput.Status
+    - DeleteAnalysisOutput.RequestId
+    - DeleteAnalysisOutput.Status
+    - DescribeAnalysisOutput.RequestId
+    - DescribeAnalysisOutput.Status
+
+operations:
+  DescribeAnalysis:
+    output_wrapper_field_path: Analysis
+
+empty_shapes:
+  - AxisDisplayDataDrivenRange
+  - AllSheetsFilterScopeConfiguration
+
 resources:
+  Analysis:
+    exceptions:
+      errors:
+        404:
+          code: ResourceNotFoundException
+    fields:
+      AnalysisId:
+        is_primary_key: true
+    tags:
+      ignore: true
   DataSet:
     exceptions:
       errors:


### PR DESCRIPTION
## Fix: handle `double` and `long` shape types in `setSDKForScalar` for list members

### Issue

The QuickSight controller analysis resource fails to compile with errors like:

```
pkg/resource/analysis/sdk.go:6223:30: cannot use f2f6elemf1f0f1iter
  (variable of type *float64) as float64 value in assignment
```

This affects all `[]float64` list fields in the CRD-to-SDK conversion path, producing 10+ compile errors across the Analysis resource's `sdk.go`.

### Root Cause

`setSDKForScalar` in `pkg/generate/code/set_sdk.go` has an `intOrFloat` map that handles narrowing conversions for `"integer"` (int64→int32) and `"float"` (float64→float32) shape types. These types need range checks and casts because the CRD uses 64-bit types while the SDK uses 32-bit types.

However, `"double"` (float64) and `"long"` (int64) shape types were not handled. When these appear as list members:

- CRD type: `[]*float64` — loop iterator is `*float64`
- SDK type: `[]float64` — target element is `float64`

The code fell through to the default `else` branch which strips the `*` dereference via `strings.TrimPrefix(setTo, "*")`, generating `elem = iter` instead of `elem = *iter`.

### Fix

Added an explicit branch for `"double"` and `"long"` types in `setSDKForScalar`. Unlike `"integer"`/`"float"`, these are already native 64-bit Go types, so no range check or narrowing cast is needed — just correct pointer dereference in list context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
