### PR TITLE
feat: add new_resource_manager_client_options hook to manager template

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -32,7 +32,7 @@ var (
 		"helm/templates/_helpers.tpl.tpl",
 		"helm/Chart.yaml.tpl",
 		"helm/values.yaml.tpl",
-		"helm/values.schema.json",
+		"helm/values.schema.json.tpl",
 		"helm/templates/NOTES.txt.tpl",
 		"helm/templates/role-reader.yaml.tpl",
 		"helm/templates/role-writer.yaml.tpl",

--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -58,6 +58,11 @@ spec:
 {{ "{{- if .Values.aws.allow_unsafe_aws_endpoint_urls }}" }}
         - --allow-unsafe-aws-endpoint-urls
 {{ "{{- end }}" }}
+{{- if eq .ControllerName "s3" }}
+{{ "{{- if .Values.aws.endpoint_use_path_style }}" }}
+        - --aws-endpoint-use-path-style
+{{ "{{- end }}" }}
+{{- end }}
 {{ "{{- if .Values.log.enable_development_logging }}" }}
         - --enable-development-logging
 {{ "{{- end }}" }}

--- a/templates/helm/values.schema.json
+++ b/templates/helm/values.schema.json
@@ -181,6 +181,10 @@
           "type": "boolean",
           "default": false
         },
+        "endpoint_use_path_style": {
+          "type": "boolean",
+          "default": false
+        },
         "credentials": {
           "description": "AWS credentials information",
           "properties": {

--- a/templates/helm/values.schema.json.tpl
+++ b/templates/helm/values.schema.json.tpl
@@ -181,10 +181,12 @@
           "type": "boolean",
           "default": false
         },
+        {{- if eq .ControllerName "s3" }}
         "endpoint_use_path_style": {
           "type": "boolean",
           "default": false
         },
+        {{- end }}
         "credentials": {
           "description": "AWS credentials information",
           "properties": {

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -92,6 +92,9 @@ aws:
   endpoint_url: ""
   identity_endpoint_url: ""
   allow_unsafe_aws_endpoint_urls: false
+{{- if eq .ControllerName "s3" }}
+  endpoint_use_path_style: false
+{{- end }}
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -435,7 +435,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
-		sdkapi:	      svcsdk.NewFromConfig(clientcfg),
+		sdkapi:	      svcsdk.NewFromConfig(clientcfg{{- if $hookCode := Hook .CRD "new_resource_manager_client_options" }}, {{ $hookCode }}{{ end }}),
 	}, nil
 }
 


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2237

Description of changes:

In order to support some S3-compatible APIs (e.g. LocalStack on a local dev cluster) it may be necessary to force the S3 client to use "path-style" URLs (e.g. http://host/bucket/key).

This PR adds a hook injection point in `newResourceManager` to allow service controllers to pass custom options to the AWS SDK client constructor.

This will let the S3 controller set `UsePathStyle` based on the value set in its controller config.

I've also added changes to the Helm chart to support configuring this option in the S3 controller.

Associated PRs:
- [s3-controller#214](https://github.com/aws-controllers-k8s/s3-controller/pull/214) uses this hook to control `UsePathStyle`.
- [runtime#233](https://github.com/aws-controllers-k8s/runtime/pull/233) adds a new config option used by the `s3-controller` to set `UsePathStyle`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
