### PR TITLE
feat: add CompareResourceForPreDelete and DeltaForPreDelete support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,6 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
+
+
+

--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -270,6 +270,9 @@ type CompareFieldConfig struct {
 	// NilEqualsZeroValue indicates a nil pointer and zero-value pointed-to
 	// value should be considered equal for the purposes of comparison
 	NilEqualsZeroValue bool `json:"nil_equals_zero_value"`
+	// PreDeleteInclude indicates the field should be included in the
+	// pre-delete delta comparison even if IsIgnored is true
+	PreDeleteInclude bool `json:"pre_delete_include"`
 }
 
 // PrintFieldConfig instructs the code generator how to handle kubebuilder:printcolumn

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -81,6 +81,9 @@ type ResourceConfig struct {
 	// Reconcile describes options for controlling the reconciliation
 	// logic for a particular resource.
 	Reconcile *ReconcileConfig `json:"reconcile,omitempty"`
+	// PreDeleteSync contains instructions for the code generator about
+	// how to handle pre-delete sync delta comparison for a resource.
+	PreDeleteSync *PreDeleteSyncConfig `json:"pre_delete_sync,omitempty"`
 	// UpdateConditionsCustomMethodName provides the name of the custom method on the
 	// `resourceManager` struct that will set Conditions on a `resource` struct
 	// depending on the status of the resource.
@@ -423,6 +426,16 @@ type ReconcileConfig struct {
 	// causing ACK controllers to refresh the status views of all watched resources, but this
 	// behaviour is expensive and may be turned off in future ACK runtime options.
 	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
+}
+
+// PreDeleteSyncConfig contains instructions for the code generator about
+// how to handle pre-delete sync delta comparison for a resource.
+type PreDeleteSyncConfig struct {
+	// CompareAll indicates that ALL spec fields (including those with
+	// compare.is_ignored: true) should be included in the pre-delete delta
+	// comparison. When false (the default), only fields with
+	// compare.pre_delete_include: true are included.
+	CompareAll bool `json:"compare_all"`
 }
 
 // ResourceIsIgnored returns true if resource name is configured to be ignored

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -91,6 +91,9 @@ type ResourceConfig struct {
 	// Reconcile describes options for controlling the reconciliation
 	// logic for a particular resource.
 	Reconcile *ReconcileConfig `json:"reconcile,omitempty"`
+	// PreDeleteSync contains instructions for the code generator about
+	// how to handle pre-delete sync delta comparison for a resource.
+	PreDeleteSync *PreDeleteSyncConfig `json:"pre_delete_sync,omitempty"`
 	// UpdateConditionsCustomMethodName provides the name of the custom method on the
 	// `resourceManager` struct that will set Conditions on a `resource` struct
 	// depending on the status of the resource.
@@ -469,6 +472,16 @@ type ReconcileConfig struct {
 	// causing ACK controllers to refresh the status views of all watched resources, but this
 	// behaviour is expensive and may be turned off in future ACK runtime options.
 	RequeueOnSuccessSeconds int `json:"requeue_on_success_seconds,omitempty"`
+}
+
+// PreDeleteSyncConfig contains instructions for the code generator about
+// how to handle pre-delete sync delta comparison for a resource.
+type PreDeleteSyncConfig struct {
+	// CompareAll indicates that ALL spec fields (including those with
+	// compare.is_ignored: true) should be included in the pre-delete delta
+	// comparison. When false (the default), only fields with
+	// compare.pre_delete_include: true are included.
+	CompareAll bool `json:"compare_all"`
 }
 
 // ResourceIsIgnored returns true if resource name is configured to be ignored

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -145,6 +145,9 @@ var (
 		"GoCodeCompare": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) (string, error) {
 			return code.CompareResource(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeCompareForPreDelete": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) (string, error) {
+			return code.CompareResourceForPreDelete(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
+		},
 		"GoCodeIsSynced": func(r *ackmodel.CRD, resVarName string, indentLevel int) (string, error) {
 			return code.ResourceIsSynced(r.Config(), r, resVarName, indentLevel)
 		},

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -148,6 +148,12 @@ var (
 		"GoCodeCompareForPreDelete": func(r *ackmodel.CRD, deltaVarName string, sourceVarName string, targetVarName string, indentLevel int) (string, error) {
 			return code.CompareResourceForPreDelete(r.Config(), r, deltaVarName, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeMergeForPreDelete": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) (string, error) {
+			return code.MergeResourceForPreDelete(r.Config(), r, sourceVarName, targetVarName, indentLevel)
+		},
+		"HasPreDeleteSync": func(r *ackmodel.CRD) bool {
+			return code.HasPreDeleteSync(r.Config(), r)
+		},
 		"GoCodeIsSynced": func(r *ackmodel.CRD, resVarName string, indentLevel int) (string, error) {
 			return code.ResourceIsSynced(r.Config(), r, resVarName, indentLevel)
 		},

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -988,3 +988,212 @@ func fastCompareTypes(
 	}
 	return out, needToCloseBlock, nil
 }
+
+// CompareResourceForPreDelete returns the Go code that traverses a set of two
+// Resources, adding differences between the two Resources to an
+// `ackcompare.Delta`.
+//
+// When the resource has `pre_delete_sync.compare_all: true` set, ALL fields
+// are included (even those with `compare.is_ignored: true`), mirroring
+// CompareResource without the is_ignored skip.
+//
+// Otherwise (the default), only fields explicitly opted in via
+// `compare.pre_delete_include: true` are included; all other fields are
+// skipped. This opt-in approach reduces blast radius so controllers only get
+// pre-delete comparison on fields they've deliberately configured.
+func CompareResourceForPreDelete(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like "a.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like "b.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	out := "\n"
+
+	resConfig := cfg.GetResourceConfig(r.Names.Camel)
+
+	// Determine whether to include all fields in the pre-delete delta.
+	// If compare_all is set at the resource level, include all fields
+	// (even is_ignored ones). Otherwise, only include fields explicitly
+	// opted in via compare.pre_delete_include: true.
+	compareAll := false
+	if resConfig != nil && resConfig.PreDeleteSync != nil {
+		compareAll = resConfig.PreDeleteSync.CompareAll
+	}
+
+	tagField, err := r.GetTagField()
+	if err != nil {
+		return "", err
+	}
+
+	// We need a deterministic order to traverse our top-level fields...
+	specFieldNames := []string{}
+	for fieldName := range r.SpecFields {
+		specFieldNames = append(specFieldNames, fieldName)
+	}
+	sort.Strings(specFieldNames)
+
+	for _, fieldName := range specFieldNames {
+		specField := r.SpecFields[fieldName]
+		indent := strings.Repeat("\t", indentLevel)
+		firstResAdaptedVarName := firstResVarName + cfg.PrefixConfig.SpecField
+		firstResAdaptedVarName += "." + specField.Names.Camel
+		secondResAdaptedVarName := secondResVarName + cfg.PrefixConfig.SpecField
+		secondResAdaptedVarName += "." + specField.Names.Camel
+
+		var fieldConfig *ackgenconfig.FieldConfig
+		var compareConfig *ackgenconfig.CompareFieldConfig
+
+		if resConfig != nil {
+			fieldConfig = resConfig.GetFieldConfig(fieldName)
+		}
+		if fieldConfig != nil {
+			compareConfig = fieldConfig.Compare
+		}
+
+		if !compareAll {
+			// Default opt-in behavior: only include fields with pre_delete_include
+			if compareConfig == nil || !compareConfig.PreDeleteInclude {
+				continue
+			}
+		}
+
+		// this is the "path" to the field within the structs being compared.
+		// This is passed down into the compareXXX functions recursively and
+		// appended to with each level of nested structs we recurse into.
+		fieldPath := strings.TrimPrefix(
+			cfg.PrefixConfig.SpecField+"."+specField.Names.Camel, ".",
+		)
+
+		// Use equality.Semantic.Equalities.DeepEqual for comparing Reference fields because
+		// some of reference fields are list of pointer to structs and
+		// DeepEqual is easy way to compare them
+		if specField.IsReference() {
+			out += fmt.Sprintf("%sif !equality.Semantic.Equalities.DeepEqual(%s, %s) {\n",
+				indent, firstResAdaptedVarName, secondResAdaptedVarName)
+			out += fmt.Sprintf("%s\t%s.Add(\"%s\", %s, %s)\n", indent,
+				deltaVarName, fieldPath, firstResAdaptedVarName,
+				secondResAdaptedVarName)
+			out += fmt.Sprintf("%s}\n", indent)
+			continue
+		}
+
+		// Use a special comparison model for tags, since they need to be
+		// converted into the common ACK tag type before doing a map delta
+		if tagField != nil && specField == tagField {
+			out += compareTags(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
+			continue
+		}
+
+		// Use semantic IAM policy comparison for fields marked as IAM policies
+		if fieldConfig != nil && fieldConfig.IsIAMPolicy {
+			out += compareIAMPolicy(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
+			continue
+		}
+
+		memberShapeRef := specField.ShapeRef
+		memberShape := memberShapeRef.Shape
+
+		// Use len, bytes.Equal and HasNilDifference to fast compare types, and
+		// try to avoid deep comparison as much as possible.
+		fastComparisonOutput, needToCloseBlock, err := fastCompareTypes(
+			compareConfig,
+			memberShape,
+			deltaVarName,
+			fieldPath,
+			firstResAdaptedVarName,
+			secondResAdaptedVarName,
+			indentLevel,
+		)
+		if err != nil {
+			return "", err
+		}
+		out += fastComparisonOutput
+
+		switch memberShape.Type {
+		case "blob":
+			// We already handled the case of blobs above, so we can skip it here.
+		case "structure":
+			// Recurse through all the struct's fields and subfields, building
+			// nested conditionals and calls to `delta.Add()`...
+			structOut, err := CompareStruct(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += structOut
+		case "list":
+			// Returns Go code that compares all the elements of the slice fields...
+			sliceOut, err := compareSlice(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += sliceOut
+		case "map":
+			// Returns Go code that compares all the elements of the map fields...
+			mapOut, err := compareMap(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += mapOut
+		default:
+			scalarOut, err := compareScalar(
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += scalarOut
+		}
+		if needToCloseBlock {
+			// }
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
+		}
+	}
+	return out, nil
+}

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -1079,3 +1079,212 @@ func fastCompareTypes(
 	}
 	return out, needToCloseBlock, nil
 }
+
+// CompareResourceForPreDelete returns the Go code that traverses a set of two
+// Resources, adding differences between the two Resources to an
+// `ackcompare.Delta`.
+//
+// When the resource has `pre_delete_sync.compare_all: true` set, ALL fields
+// are included (even those with `compare.is_ignored: true`), mirroring
+// CompareResource without the is_ignored skip.
+//
+// Otherwise (the default), only fields explicitly opted in via
+// `compare.pre_delete_include: true` are included; all other fields are
+// skipped. This opt-in approach reduces blast radius so controllers only get
+// pre-delete comparison on fields they've deliberately configured.
+func CompareResourceForPreDelete(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like "a.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like "b.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	out := "\n"
+
+	resConfig := cfg.GetResourceConfig(r.Names.Camel)
+
+	// Determine whether to include all fields in the pre-delete delta.
+	// If compare_all is set at the resource level, include all fields
+	// (even is_ignored ones). Otherwise, only include fields explicitly
+	// opted in via compare.pre_delete_include: true.
+	compareAll := false
+	if resConfig != nil && resConfig.PreDeleteSync != nil {
+		compareAll = resConfig.PreDeleteSync.CompareAll
+	}
+
+	tagField, err := r.GetTagField()
+	if err != nil {
+		return "", err
+	}
+
+	// We need a deterministic order to traverse our top-level fields...
+	specFieldNames := []string{}
+	for fieldName := range r.SpecFields {
+		specFieldNames = append(specFieldNames, fieldName)
+	}
+	sort.Strings(specFieldNames)
+
+	for _, fieldName := range specFieldNames {
+		specField := r.SpecFields[fieldName]
+		indent := strings.Repeat("\t", indentLevel)
+		firstResAdaptedVarName := firstResVarName + cfg.PrefixConfig.SpecField
+		firstResAdaptedVarName += "." + specField.Names.Camel
+		secondResAdaptedVarName := secondResVarName + cfg.PrefixConfig.SpecField
+		secondResAdaptedVarName += "." + specField.Names.Camel
+
+		var fieldConfig *ackgenconfig.FieldConfig
+		var compareConfig *ackgenconfig.CompareFieldConfig
+
+		if resConfig != nil {
+			fieldConfig = resConfig.GetFieldConfig(fieldName)
+		}
+		if fieldConfig != nil {
+			compareConfig = fieldConfig.Compare
+		}
+
+		if !compareAll {
+			// Default opt-in behavior: only include fields with pre_delete_include
+			if compareConfig == nil || !compareConfig.PreDeleteInclude {
+				continue
+			}
+		}
+
+		// this is the "path" to the field within the structs being compared.
+		// This is passed down into the compareXXX functions recursively and
+		// appended to with each level of nested structs we recurse into.
+		fieldPath := strings.TrimPrefix(
+			cfg.PrefixConfig.SpecField+"."+specField.Names.Camel, ".",
+		)
+
+		// Use equality.Semantic.Equalities.DeepEqual for comparing Reference fields because
+		// some of reference fields are list of pointer to structs and
+		// DeepEqual is easy way to compare them
+		if specField.IsReference() {
+			out += fmt.Sprintf("%sif !equality.Semantic.Equalities.DeepEqual(%s, %s) {\n",
+				indent, firstResAdaptedVarName, secondResAdaptedVarName)
+			out += fmt.Sprintf("%s\t%s.Add(\"%s\", %s, %s)\n", indent,
+				deltaVarName, fieldPath, firstResAdaptedVarName,
+				secondResAdaptedVarName)
+			out += fmt.Sprintf("%s}\n", indent)
+			continue
+		}
+
+		// Use a special comparison model for tags, since they need to be
+		// converted into the common ACK tag type before doing a map delta
+		if tagField != nil && specField == tagField {
+			out += compareTags(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
+			continue
+		}
+
+		// Use semantic IAM policy comparison for fields marked as IAM policies
+		if fieldConfig != nil && fieldConfig.IsIAMPolicy {
+			out += compareIAMPolicy(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
+			continue
+		}
+
+		memberShapeRef := specField.ShapeRef
+		memberShape := memberShapeRef.Shape
+
+		// Use len, bytes.Equal and HasNilDifference to fast compare types, and
+		// try to avoid deep comparison as much as possible.
+		fastComparisonOutput, needToCloseBlock, err := fastCompareTypes(
+			compareConfig,
+			memberShape,
+			deltaVarName,
+			fieldPath,
+			firstResAdaptedVarName,
+			secondResAdaptedVarName,
+			indentLevel,
+		)
+		if err != nil {
+			return "", err
+		}
+		out += fastComparisonOutput
+
+		switch memberShape.Type {
+		case "blob":
+			// We already handled the case of blobs above, so we can skip it here.
+		case "structure":
+			// Recurse through all the struct's fields and subfields, building
+			// nested conditionals and calls to `delta.Add()`...
+			structOut, err := CompareStruct(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += structOut
+		case "list":
+			// Returns Go code that compares all the elements of the slice fields...
+			sliceOut, err := compareSlice(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += sliceOut
+		case "map":
+			// Returns Go code that compares all the elements of the map fields...
+			mapOut, err := compareMap(
+				cfg, r,
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += mapOut
+		default:
+			scalarOut, err := compareScalar(
+				compareConfig,
+				memberShape,
+				deltaVarName,
+				firstResAdaptedVarName,
+				secondResAdaptedVarName,
+				fieldPath,
+				indentLevel+1,
+			)
+			if err != nil {
+				return "", err
+			}
+			out += scalarOut
+		}
+		if needToCloseBlock {
+			// }
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
+		}
+	}
+	return out, nil
+}

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -25,75 +25,56 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
-// CompareResource returns the Go code that traverses a set of two Resources,
-// adding differences between the two Resources to an `ackcompare.Delta`
-//
-// By default, we produce Go code that only looks at the fields in a resource's
-// Spec, since those are the fields that represent the desired state of a
-// resource. When we make a ReadOne/ReadMany/GetAttributes call to a backend
-// AWS API, we construct a Resource and set the Spec fields to values contained
-// in the ReadOne/ReadMany/GetAttributes Output shape. This Resource,
-// constructed from the Read operation, is compared to the Resource we got from
-// the Kubernetes API server's event bus. The code that is returned from this
-// function is the code that compares those two Resources.
-//
-// The Go code we return depends on the Go type of the various fields for the
-// resource being compared.
-//
-// For *scalar* Go types, the output Go code looks like this:
-//
-//	if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
-//	    delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
-//	} else if a.ko.Spec.GrantFullControl != nil && b.ko.Spec.GrantFullControl != nil {
-//
-//	    if *a.ko.Spec.GrantFullControl != *b.ko.Spec.GrantFullControl {
-//	        delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
-//	    }
-//	}
-//
-// For *struct* Go types, the output Go code looks like this (note that it is a
-// simple recursive-descent output of all the struct's fields...):
-//
-//	if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
-//	    delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
-//	} else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
-//
-//	    if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
-//	        delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
-//	    } else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil {
-//	        if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
-//	            delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
-//	        }
-//	    }
-//	}
-//
-// For *slice of strings* Go types, the output Go code looks like this:
-//
-//	if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
-//	    delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
-//	} else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
-//
-//	    if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
-//	        delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
-//	    }
-//	}
-func CompareResource(
+// HasPreDeleteSync returns true if the CRD has any pre-delete sync
+// configuration — either pre_delete_sync.compare_all is true, or at least
+// one field has compare.pre_delete_include: true.
+func HasPreDeleteSync(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
-	// String representing the name of the variable that is of type
-	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
-	// method of this variable when differences between fields are detected.
+) bool {
+	resConfig := cfg.GetResourceConfig(r.Names.Camel)
+	if resConfig == nil {
+		return false
+	}
+	if resConfig.PreDeleteSync != nil && resConfig.PreDeleteSync.CompareAll {
+		return true
+	}
+	for fieldName := range r.SpecFields {
+		fieldConfig := resConfig.GetFieldConfig(fieldName)
+		if fieldConfig != nil && fieldConfig.Compare != nil && fieldConfig.Compare.PreDeleteInclude {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedSpecFieldNames returns the spec field names for a CRD in
+// deterministic sorted order.
+func sortedSpecFieldNames(r *model.CRD) []string {
+	fieldNames := make([]string, 0, len(r.SpecFields))
+	for fieldName := range r.SpecFields {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+	return fieldNames
+}
+
+// fieldFilter is a function that determines whether a spec field should be
+// included in the comparison output. It receives the field's compare config
+// (which may be nil) and returns true if the field should be included.
+type fieldFilter func(compareConfig *ackgenconfig.CompareFieldConfig) bool
+
+// compareResourceFields is the shared implementation for generating Go code
+// that compares spec fields between two resources. The includeField callback
+// controls which fields are included in the output.
+func compareResourceFields(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
 	deltaVarName string,
-	// String representing the name of the variable that represents the first
-	// CR under comparison. This will typically be something like "a.ko". See
-	// `templates/pkg/resource/delta.go.tpl`.
 	firstResVarName string,
-	// String representing the name of the variable that represents the second
-	// CR under comparison. This will typically be something like "b.ko". See
-	// `templates/pkg/resource/delta.go.tpl`.
 	secondResVarName string,
-	// Number of levels of indentation to use
 	indentLevel int,
+	includeField fieldFilter,
 ) (string, error) {
 	out := "\n"
 
@@ -105,13 +86,7 @@ func CompareResource(
 	}
 
 	// We need a deterministic order to traverse our top-level fields...
-	specFieldNames := []string{}
-	for fieldName := range r.SpecFields {
-		specFieldNames = append(specFieldNames, fieldName)
-	}
-	sort.Strings(specFieldNames)
-
-	for _, fieldName := range specFieldNames {
+	for _, fieldName := range sortedSpecFieldNames(r) {
 		specField := r.SpecFields[fieldName]
 		indent := strings.Repeat("\t", indentLevel)
 		firstResAdaptedVarName := firstResVarName + cfg.PrefixConfig.SpecField
@@ -129,7 +104,7 @@ func CompareResource(
 			compareConfig = fieldConfig.Compare
 		}
 
-		if compareConfig != nil && compareConfig.IsIgnored {
+		if !includeField(compareConfig) {
 			continue
 		}
 
@@ -269,6 +244,84 @@ func CompareResource(
 		}
 	}
 	return out, nil
+}
+
+// CompareResource returns the Go code that traverses a set of two Resources,
+// adding differences between the two Resources to an `ackcompare.Delta`
+//
+// By default, we produce Go code that only looks at the fields in a resource's
+// Spec, since those are the fields that represent the desired state of a
+// resource. When we make a ReadOne/ReadMany/GetAttributes call to a backend
+// AWS API, we construct a Resource and set the Spec fields to values contained
+// in the ReadOne/ReadMany/GetAttributes Output shape. This Resource,
+// constructed from the Read operation, is compared to the Resource we got from
+// the Kubernetes API server's event bus. The code that is returned from this
+// function is the code that compares those two Resources.
+//
+// The Go code we return depends on the Go type of the various fields for the
+// resource being compared.
+//
+// For *scalar* Go types, the output Go code looks like this:
+//
+//	if ackcompare.HasNilDifference(a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl) {
+//	    delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+//	} else if a.ko.Spec.GrantFullControl != nil && b.ko.Spec.GrantFullControl != nil {
+//
+//	    if *a.ko.Spec.GrantFullControl != *b.ko.Spec.GrantFullControl {
+//	        delta.Add("Spec.GrantFullControl", a.ko.Spec.GrantFullControl, b.ko.Spec.GrantFullControl)
+//	    }
+//	}
+//
+// For *struct* Go types, the output Go code looks like this (note that it is a
+// simple recursive-descent output of all the struct's fields...):
+//
+//	if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration) {
+//	    delta.Add("Spec.CreateBucketConfiguration", a.ko.Spec.CreateBucketConfiguration, b.ko.Spec.CreateBucketConfiguration)
+//	} else if a.ko.Spec.CreateBucketConfiguration != nil && b.ko.Spec.CreateBucketConfiguration != nil {
+//
+//	    if ackcompare.HasNilDifference(a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint) {
+//	        delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+//	    } else if a.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil && b.ko.Spec.CreateBucketConfiguration.LocationConstraint != nil {
+//	        if *a.ko.Spec.CreateBucketConfiguration.LocationConstraint != *b.ko.Spec.CreateBucketConfiguration.LocationConstraint {
+//	            delta.Add("Spec.CreateBucketConfiguration.LocationConstraint", a.ko.Spec.CreateBucketConfiguration.LocationConstraint, b.ko.Spec.CreateBucketConfiguration.LocationConstraint)
+//	        }
+//	    }
+//	}
+//
+// For *slice of strings* Go types, the output Go code looks like this:
+//
+//	if ackcompare.HasNilDifference(a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers) {
+//	    delta.Add("Spec.AllowedPublishers", a.ko.Spec.AllowedPublishers, b.ko.Spec.AllowedPublishers)
+//	} else if a.ko.Spec.AllowedPublishers != nil && b.ko.Spec.AllowedPublishers != nil {
+//
+//	    if !ackcompare.SliceStringPEqual(a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs) {
+//	        delta.Add("Spec.AllowedPublishers.SigningProfileVersionARNs", a.ko.Spec.AllowedPublishers.SigningProfileVersionARNs, b.ko.Spec.AllowedPublishers.SigningProfileVersionARNs)
+//	    }
+//	}
+func CompareResource(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the first
+	// CR under comparison. This will typically be something like "a.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	firstResVarName string,
+	// String representing the name of the variable that represents the second
+	// CR under comparison. This will typically be something like "b.ko". See
+	// `templates/pkg/resource/delta.go.tpl`.
+	secondResVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	return compareResourceFields(cfg, r, deltaVarName, firstResVarName, secondResVarName, indentLevel,
+		func(compareConfig *ackgenconfig.CompareFieldConfig) bool {
+			// Skip fields marked as ignored in normal reconciliation
+			return compareConfig == nil || !compareConfig.IsIgnored
+		},
+	)
 }
 
 // compareNil outputs Go code that compares two field values for nullability
@@ -1091,7 +1144,7 @@ func fastCompareTypes(
 // Otherwise (the default), only fields explicitly opted in via
 // `compare.pre_delete_include: true` are included; all other fields are
 // skipped. This opt-in approach reduces blast radius so controllers only get
-// pre-delete comparison on fields they've deliberately configured.
+// pre-delete sync comparison on fields they've deliberately configured.
 func CompareResourceForPreDelete(
 	cfg *ackgenconfig.Config,
 	r *model.CRD,
@@ -1110,38 +1163,55 @@ func CompareResourceForPreDelete(
 	// Number of levels of indentation to use
 	indentLevel int,
 ) (string, error) {
-	out := "\n"
-
 	resConfig := cfg.GetResourceConfig(r.Names.Camel)
 
-	// Determine whether to include all fields in the pre-delete delta.
-	// If compare_all is set at the resource level, include all fields
-	// (even is_ignored ones). Otherwise, only include fields explicitly
-	// opted in via compare.pre_delete_include: true.
+	// Determine whether to include all fields in the pre-delete sync delta.
 	compareAll := false
 	if resConfig != nil && resConfig.PreDeleteSync != nil {
 		compareAll = resConfig.PreDeleteSync.CompareAll
 	}
 
-	tagField, err := r.GetTagField()
-	if err != nil {
-		return "", err
+	return compareResourceFields(cfg, r, deltaVarName, firstResVarName, secondResVarName, indentLevel,
+		func(compareConfig *ackgenconfig.CompareFieldConfig) bool {
+			if compareAll {
+				return true
+			}
+			// Default opt-in behavior: only include fields with pre_delete_include
+			return compareConfig != nil && compareConfig.PreDeleteInclude
+		},
+	)
+}
+
+// MergeResourceForPreDelete outputs Go code that copies only the pre-delete sync
+// configured fields from the source variable onto the target variable. This is
+// used to build a merged resource that starts as a deep copy of observed and
+// has only the pre-delete sync fields overwritten from desired.
+//
+// The generated code is a series of simple field assignments for each field
+// that has `compare.pre_delete_include: true` (or all fields when
+// `pre_delete_sync.compare_all: true`).
+func MergeResourceForPreDelete(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// String representing the variable to copy fields FROM (e.g. "a.ko")
+	sourceVarName string,
+	// String representing the variable to copy fields TO (e.g. "merged.ko")
+	targetVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	out := ""
+
+	resConfig := cfg.GetResourceConfig(r.Names.Camel)
+
+	compareAll := false
+	if resConfig != nil && resConfig.PreDeleteSync != nil {
+		compareAll = resConfig.PreDeleteSync.CompareAll
 	}
 
-	// We need a deterministic order to traverse our top-level fields...
-	specFieldNames := []string{}
-	for fieldName := range r.SpecFields {
-		specFieldNames = append(specFieldNames, fieldName)
-	}
-	sort.Strings(specFieldNames)
-
-	for _, fieldName := range specFieldNames {
+	for _, fieldName := range sortedSpecFieldNames(r) {
 		specField := r.SpecFields[fieldName]
 		indent := strings.Repeat("\t", indentLevel)
-		firstResAdaptedVarName := firstResVarName + cfg.PrefixConfig.SpecField
-		firstResAdaptedVarName += "." + specField.Names.Camel
-		secondResAdaptedVarName := secondResVarName + cfg.PrefixConfig.SpecField
-		secondResAdaptedVarName += "." + specField.Names.Camel
 
 		var fieldConfig *ackgenconfig.FieldConfig
 		var compareConfig *ackgenconfig.CompareFieldConfig
@@ -1154,137 +1224,15 @@ func CompareResourceForPreDelete(
 		}
 
 		if !compareAll {
-			// Default opt-in behavior: only include fields with pre_delete_include
 			if compareConfig == nil || !compareConfig.PreDeleteInclude {
 				continue
 			}
 		}
 
-		// this is the "path" to the field within the structs being compared.
-		// This is passed down into the compareXXX functions recursively and
-		// appended to with each level of nested structs we recurse into.
-		fieldPath := strings.TrimPrefix(
-			cfg.PrefixConfig.SpecField+"."+specField.Names.Camel, ".",
-		)
+		sourceField := sourceVarName + cfg.PrefixConfig.SpecField + "." + specField.Names.Camel
+		targetField := targetVarName + cfg.PrefixConfig.SpecField + "." + specField.Names.Camel
 
-		// Use equality.Semantic.Equalities.DeepEqual for comparing Reference fields because
-		// some of reference fields are list of pointer to structs and
-		// DeepEqual is easy way to compare them
-		if specField.IsReference() {
-			out += fmt.Sprintf("%sif !equality.Semantic.Equalities.DeepEqual(%s, %s) {\n",
-				indent, firstResAdaptedVarName, secondResAdaptedVarName)
-			out += fmt.Sprintf("%s\t%s.Add(\"%s\", %s, %s)\n", indent,
-				deltaVarName, fieldPath, firstResAdaptedVarName,
-				secondResAdaptedVarName)
-			out += fmt.Sprintf("%s}\n", indent)
-			continue
-		}
-
-		// Use a special comparison model for tags, since they need to be
-		// converted into the common ACK tag type before doing a map delta
-		if tagField != nil && specField == tagField {
-			out += compareTags(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
-			continue
-		}
-
-		// Use semantic IAM policy comparison for fields marked as IAM policies
-		if fieldConfig != nil && fieldConfig.IsIAMPolicy {
-			out += compareIAMPolicy(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
-			continue
-		}
-
-		memberShapeRef := specField.ShapeRef
-		memberShape := memberShapeRef.Shape
-
-		// Use len, bytes.Equal and HasNilDifference to fast compare types, and
-		// try to avoid deep comparison as much as possible.
-		fastComparisonOutput, needToCloseBlock, err := fastCompareTypes(
-			compareConfig,
-			memberShape,
-			deltaVarName,
-			fieldPath,
-			firstResAdaptedVarName,
-			secondResAdaptedVarName,
-			indentLevel,
-		)
-		if err != nil {
-			return "", err
-		}
-		out += fastComparisonOutput
-
-		switch memberShape.Type {
-		case "blob":
-			// We already handled the case of blobs above, so we can skip it here.
-		case "structure":
-			// Recurse through all the struct's fields and subfields, building
-			// nested conditionals and calls to `delta.Add()`...
-			structOut, err := CompareStruct(
-				cfg, r,
-				compareConfig,
-				memberShape,
-				deltaVarName,
-				firstResAdaptedVarName,
-				secondResAdaptedVarName,
-				fieldPath,
-				indentLevel+1,
-			)
-			if err != nil {
-				return "", err
-			}
-			out += structOut
-		case "list":
-			// Returns Go code that compares all the elements of the slice fields...
-			sliceOut, err := compareSlice(
-				cfg, r,
-				compareConfig,
-				memberShape,
-				deltaVarName,
-				firstResAdaptedVarName,
-				secondResAdaptedVarName,
-				fieldPath,
-				indentLevel+1,
-			)
-			if err != nil {
-				return "", err
-			}
-			out += sliceOut
-		case "map":
-			// Returns Go code that compares all the elements of the map fields...
-			mapOut, err := compareMap(
-				cfg, r,
-				compareConfig,
-				memberShape,
-				deltaVarName,
-				firstResAdaptedVarName,
-				secondResAdaptedVarName,
-				fieldPath,
-				indentLevel+1,
-			)
-			if err != nil {
-				return "", err
-			}
-			out += mapOut
-		default:
-			scalarOut, err := compareScalar(
-				compareConfig,
-				memberShape,
-				deltaVarName,
-				firstResAdaptedVarName,
-				secondResAdaptedVarName,
-				fieldPath,
-				indentLevel+1,
-			)
-			if err != nil {
-				return "", err
-			}
-			out += scalarOut
-		}
-		if needToCloseBlock {
-			// }
-			out += fmt.Sprintf(
-				"%s}\n", indent,
-			)
-		}
+		out += fmt.Sprintf("%s%s = %s\n", indent, targetField, sourceField)
 	}
 	return out, nil
 }

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -669,6 +669,130 @@ func TestCompareResource_IAM_Role_IAMPolicy(t *testing.T) {
 	assert.Equal(expected, got)
 }
 
+func TestCompareResourceForPreDelete_S3_Bucket_NoPreDeleteInclude(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With the default S3 generator config, no fields have
+	// compare.pre_delete_include: true, so the pre-delete delta should be
+	// empty (only opted-in fields are included by default).
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal("\n", got)
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_WithPreDeleteInclude(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-include.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With pre_delete_include: true on ACL, only ACL should appear in the
+	// pre-delete delta output (other fields are not opted in).
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.ACL, b.ko.Spec.ACL) {
+		delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+	} else if a.ko.Spec.ACL != nil && b.ko.Spec.ACL != nil {
+		if *a.ko.Spec.ACL != *b.ko.Spec.ACL {
+			delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+		}
+	}
+`
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+
+	// Verify that CompareResource does NOT contain ACL (it's is_ignored)
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.NotContains(compareOut, "Spec.ACL")
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_CompareAll(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-compare-all.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With pre_delete_sync.compare_all: true, ALL fields should be included
+	// in the pre-delete delta, including ACL (which has is_ignored: true).
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+
+	// ACL (is_ignored) should be included
+	assert.Contains(got, "Spec.ACL")
+	// All non-ignored fields should also be included
+	assert.Contains(got, "Spec.CreateBucketConfiguration")
+	assert.Contains(got, "Spec.GrantFullControl")
+	assert.Contains(got, "Spec.GrantRead")
+	assert.Contains(got, "Spec.GrantReadACP")
+	assert.Contains(got, "Spec.GrantWrite")
+	assert.Contains(got, "Spec.GrantWriteACP")
+	assert.Contains(got, "Spec.Logging")
+	assert.Contains(got, "Spec.Name")
+	assert.Contains(got, "Spec.ObjectLockEnabledForBucket")
+	assert.Contains(got, "Spec.Tagging")
+
+	// CompareResource should NOT contain ACL
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.NotContains(compareOut, "Spec.ACL")
+
+	// The pre-delete output should be a superset of CompareResource
+	assert.Contains(got, compareOut)
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_EmptyWithoutOptIn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// Pre-delete delta should be empty when no fields are opted in
+	preDeleteOut, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal("\n", preDeleteOut)
+
+	// But CompareResource should still work normally (non-ignored fields present)
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Contains(compareOut, "Spec.CreateBucketConfiguration")
+	assert.Contains(compareOut, "Spec.Name")
+	assert.NotContains(compareOut, "Spec.ACL")
+}
+
 // TestCompareResource_QuickSight_DataSet tests that the delta code generation
 // correctly handles the QuickSight DataSet resource, specifically the
 // RowLevelPermissionTagConfiguration.TagRuleConfigurations field which is a

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -754,6 +754,130 @@ func TestCompareResource_SNS_Subscription_Document(t *testing.T) {
 	assert.Equal(expected, got)
 }
 
+func TestCompareResourceForPreDelete_S3_Bucket_NoPreDeleteInclude(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With the default S3 generator config, no fields have
+	// compare.pre_delete_include: true, so the pre-delete delta should be
+	// empty (only opted-in fields are included by default).
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal("\n", got)
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_WithPreDeleteInclude(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-include.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With pre_delete_include: true on ACL, only ACL should appear in the
+	// pre-delete delta output (other fields are not opted in).
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.ACL, b.ko.Spec.ACL) {
+		delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+	} else if a.ko.Spec.ACL != nil && b.ko.Spec.ACL != nil {
+		if *a.ko.Spec.ACL != *b.ko.Spec.ACL {
+			delta.Add("Spec.ACL", a.ko.Spec.ACL, b.ko.Spec.ACL)
+		}
+	}
+`
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+
+	// Verify that CompareResource does NOT contain ACL (it's is_ignored)
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.NotContains(compareOut, "Spec.ACL")
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_CompareAll(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-compare-all.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With pre_delete_sync.compare_all: true, ALL fields should be included
+	// in the pre-delete delta, including ACL (which has is_ignored: true).
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+
+	// ACL (is_ignored) should be included
+	assert.Contains(got, "Spec.ACL")
+	// All non-ignored fields should also be included
+	assert.Contains(got, "Spec.CreateBucketConfiguration")
+	assert.Contains(got, "Spec.GrantFullControl")
+	assert.Contains(got, "Spec.GrantRead")
+	assert.Contains(got, "Spec.GrantReadACP")
+	assert.Contains(got, "Spec.GrantWrite")
+	assert.Contains(got, "Spec.GrantWriteACP")
+	assert.Contains(got, "Spec.Logging")
+	assert.Contains(got, "Spec.Name")
+	assert.Contains(got, "Spec.ObjectLockEnabledForBucket")
+	assert.Contains(got, "Spec.Tagging")
+
+	// CompareResource should NOT contain ACL
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.NotContains(compareOut, "Spec.ACL")
+
+	// The pre-delete output should be a superset of CompareResource
+	assert.Contains(got, compareOut)
+}
+
+func TestCompareResourceForPreDelete_S3_Bucket_EmptyWithoutOptIn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// Pre-delete delta should be empty when no fields are opted in
+	preDeleteOut, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal("\n", preDeleteOut)
+
+	// But CompareResource should still work normally (non-ignored fields present)
+	compareOut, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Contains(compareOut, "Spec.CreateBucketConfiguration")
+	assert.Contains(compareOut, "Spec.Name")
+	assert.NotContains(compareOut, "Spec.ACL")
+}
+
 // TestCompareResource_QuickSight_DataSet tests that the delta code generation
 // correctly handles the QuickSight DataSet resource, specifically the
 // RowLevelPermissionTagConfiguration.TagRuleConfigurations field which is a

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -809,6 +809,43 @@ func TestCompareResourceForPreDelete_S3_Bucket_WithPreDeleteInclude(t *testing.T
 	assert.NotContains(compareOut, "Spec.ACL")
 }
 
+func TestCompareResourceForPreDelete_S3_Bucket_WithPreDeleteIncludeNested(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-include-nested.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	got, err := code.CompareResourceForPreDelete(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+
+	// ACL (scalar with pre_delete_include) should be included
+	assert.Contains(got, "Spec.ACL")
+	// Logging (struct with pre_delete_include) should be included with
+	// nested field comparisons
+	assert.Contains(got, "Spec.Logging")
+	assert.Contains(got, "Spec.Logging.LoggingEnabled")
+	// Other fields should NOT be included
+	assert.NotContains(got, "Spec.Name")
+	assert.NotContains(got, "Spec.CreateBucketConfiguration")
+	assert.NotContains(got, "Spec.GrantFullControl")
+
+	// Merge should also include both ACL and Logging
+	mergeOut, err := code.MergeResourceForPreDelete(
+		crd.Config(), crd, "a.ko", "merged.ko", 1,
+	)
+	require.NoError(err)
+	assert.Contains(mergeOut, "merged.ko.Spec.ACL = a.ko.Spec.ACL")
+	assert.Contains(mergeOut, "merged.ko.Spec.Logging = a.ko.Spec.Logging")
+	assert.NotContains(mergeOut, "merged.ko.Spec.Name")
+}
+
 func TestCompareResourceForPreDelete_S3_Bucket_CompareAll(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -876,6 +913,67 @@ func TestCompareResourceForPreDelete_S3_Bucket_EmptyWithoutOptIn(t *testing.T) {
 	assert.Contains(compareOut, "Spec.CreateBucketConfiguration")
 	assert.Contains(compareOut, "Spec.Name")
 	assert.NotContains(compareOut, "Spec.ACL")
+}
+
+func TestMergeResourceForPreDelete_S3_Bucket_WithPreDeleteInclude(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-include.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// Only ACL has pre_delete_include: true, so only ACL should be merged
+	got, err := code.MergeResourceForPreDelete(
+		crd.Config(), crd, "a.ko", "merged.ko", 1,
+	)
+	require.NoError(err)
+	assert.Contains(got, "merged.ko.Spec.ACL = a.ko.Spec.ACL")
+	// Other fields should NOT be merged
+	assert.NotContains(got, "merged.ko.Spec.Name")
+	assert.NotContains(got, "merged.ko.Spec.CreateBucketConfiguration")
+	assert.NotContains(got, "merged.ko.Spec.GrantFullControl")
+}
+
+func TestMergeResourceForPreDelete_S3_Bucket_CompareAll(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "s3", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-pre-delete-compare-all.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// With compare_all: true, all fields should be merged
+	got, err := code.MergeResourceForPreDelete(
+		crd.Config(), crd, "a.ko", "merged.ko", 1,
+	)
+	require.NoError(err)
+	assert.Contains(got, "merged.ko.Spec.ACL = a.ko.Spec.ACL")
+	assert.Contains(got, "merged.ko.Spec.Name = a.ko.Spec.Name")
+	assert.Contains(got, "merged.ko.Spec.CreateBucketConfiguration = a.ko.Spec.CreateBucketConfiguration")
+}
+
+func TestMergeResourceForPreDelete_S3_Bucket_NoOptIn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3")
+
+	crd := testutil.GetCRDByName(t, g, "Bucket")
+	require.NotNil(crd)
+
+	// No pre_delete_include fields, so merge output should be empty
+	got, err := code.MergeResourceForPreDelete(
+		crd.Config(), crd, "a.ko", "merged.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal("", got)
 }
 
 // TestCompareResource_QuickSight_DataSet tests that the delta code generation

--- a/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-compare-all.yaml
+++ b/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-compare-all.yaml
@@ -1,0 +1,41 @@
+ignore:
+  resource_names:
+    - Object
+    - MultipartUpload
+  shape_names:
+    # These shapes are structs with no members...
+    - SSES3
+  field_paths:
+    - CreateBucketInput.ObjectOwnership
+    - CreateBucketConfiguration.Bucket
+    - CreateBucketConfiguration.Location
+    - BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat
+resources:
+  Bucket:
+    renames:
+      operations:
+        CreateBucket:
+          input_fields:
+            Bucket: Name
+        DeleteBucket:
+          input_fields:
+            Bucket: Name
+    list_operation:
+      match_fields:
+        - Name
+    tags:
+      path: Tagging.TagSet
+    pre_delete_sync:
+      compare_all: true
+    fields:
+      ACL:
+        compare:
+          is_ignored: true
+      Logging:
+        from:
+          operation: PutBucketLogging
+          path: BucketLoggingStatus
+      Tagging:
+        from:
+          operation: PutBucketTagging
+          path: Tagging

--- a/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-include-nested.yaml
+++ b/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-include-nested.yaml
@@ -1,0 +1,42 @@
+ignore:
+  resource_names:
+    - Object
+    - MultipartUpload
+  shape_names:
+    # These shapes are structs with no members...
+    - SSES3
+  field_paths:
+    - CreateBucketInput.ObjectOwnership
+    - CreateBucketConfiguration.Bucket
+    - CreateBucketConfiguration.Location
+    - BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat
+resources:
+  Bucket:
+    renames:
+      operations:
+        CreateBucket:
+          input_fields:
+            Bucket: Name
+        DeleteBucket:
+          input_fields:
+            Bucket: Name
+    list_operation:
+      match_fields:
+        - Name
+    tags:
+      path: Tagging.TagSet
+    fields:
+      ACL:
+        compare:
+          is_ignored: true
+          pre_delete_include: true
+      Logging:
+        from:
+          operation: PutBucketLogging
+          path: BucketLoggingStatus
+        compare:
+          pre_delete_include: true
+      Tagging:
+        from:
+          operation: PutBucketTagging
+          path: Tagging

--- a/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-include.yaml
+++ b/pkg/testdata/models/apis/s3/0000-00-00/generator-with-pre-delete-include.yaml
@@ -1,0 +1,40 @@
+ignore:
+  resource_names:
+    - Object
+    - MultipartUpload
+  shape_names:
+    # These shapes are structs with no members...
+    - SSES3
+  field_paths:
+    - CreateBucketInput.ObjectOwnership
+    - CreateBucketConfiguration.Bucket
+    - CreateBucketConfiguration.Location
+    - BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat
+resources:
+  Bucket:
+    renames:
+      operations:
+        CreateBucket:
+          input_fields:
+            Bucket: Name
+        DeleteBucket:
+          input_fields:
+            Bucket: Name
+    list_operation:
+      match_fields:
+        - Name
+    tags:
+      path: Tagging.TagSet
+    fields:
+      ACL:
+        compare:
+          is_ignored: true
+          pre_delete_include: true
+      Logging:
+        from:
+          operation: PutBucketLogging
+          path: BucketLoggingStatus
+      Tagging:
+        from:
+          operation: PutBucketTagging
+          path: Tagging

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -39,19 +39,28 @@ func newResourceDelta(
 	return delta
 }
 
+{{ if HasPreDeleteSync .CRD }}
 // newResourceDeltaForPreDelete returns a new `ackcompare.Delta` that includes
-// fields normally excluded by compare.is_ignored. Used for pre-delete sync.
+// only fields configured for pre-delete comparison, and a merged resource that
+// is a deep copy of b (observed) with only those differing fields overwritten
+// from a (desired). Used for pre-delete sync.
 func newResourceDeltaForPreDelete(
 	a *resource,
 	b *resource,
-) *ackcompare.Delta {
+) (*ackcompare.Delta, *resource) {
 	delta := ackcompare.NewDelta()
 	if ((a == nil && b != nil) ||
 			(a != nil && b == nil)) {
 		delta.Add("", a, b)
-		return delta
+		return delta, nil
 	}
 
 {{ GoCodeCompareForPreDelete .CRD "delta" "a.ko" "b.ko" 1}}
-	return delta
+
+	// Build merged resource: start from observed (b) and overlay only the
+	// pre-delete fields from desired (a).
+	merged := b.DeepCopy().(*resource)
+{{ GoCodeMergeForPreDelete .CRD "a.ko" "merged.ko" 1}}
+	return delta, merged
 }
+{{ end }}

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -38,3 +38,20 @@ func newResourceDelta(
 {{- end }}
 	return delta
 }
+
+// newResourceDeltaForPreDelete returns a new `ackcompare.Delta` that includes
+// fields normally excluded by compare.is_ignored. Used for pre-delete sync.
+func newResourceDeltaForPreDelete(
+	a *resource,
+	b *resource,
+) *ackcompare.Delta {
+	delta := ackcompare.NewDelta()
+	if ((a == nil && b != nil) ||
+			(a != nil && b == nil)) {
+		delta.Add("", a, b)
+		return delta
+	}
+
+{{ GoCodeCompareForPreDelete .CRD "delta" "a.ko" "b.ko" 1}}
+	return delta
+}

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -59,6 +59,14 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
     return newResourceDelta(a.(*resource), b.(*resource))
 }
 
+// DeltaForPreDelete returns an `ackcompare.Delta` that includes fields
+// normally excluded by compare.is_ignored. Used during pre-delete sync.
+func (d *resourceDescriptor) DeltaForPreDelete(
+	a, b acktypes.AWSResource,
+) *ackcompare.Delta {
+	return newResourceDeltaForPreDelete(a.(*resource), b.(*resource))
+}
+
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a

--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -59,13 +59,18 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
     return newResourceDelta(a.(*resource), b.(*resource))
 }
 
+{{ if HasPreDeleteSync .CRD }}
 // DeltaForPreDelete returns an `ackcompare.Delta` that includes fields
-// normally excluded by compare.is_ignored. Used during pre-delete sync.
+// configured for pre-delete comparison, and a merged resource that is a deep
+// copy of b (observed) with only those differing fields overwritten from a
+// (desired). Used during pre-delete sync.
 func (d *resourceDescriptor) DeltaForPreDelete(
 	a, b acktypes.AWSResource,
-) *ackcompare.Delta {
-	return newResourceDeltaForPreDelete(a.(*resource), b.(*resource))
+) (*ackcompare.Delta, acktypes.AWSResource) {
+	delta, merged := newResourceDeltaForPreDelete(a.(*resource), b.(*resource))
+	return delta, merged
 }
+{{ end }}
 
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the


### PR DESCRIPTION
Add pre-delete delta comparison support to the code generator. Controllers can opt specific fields into pre-delete comparison via `compare.pre_delete_include: true` in generator.yaml, so that fields like `DeletionProtectionEnabled` are synced before deletion even when they use `compare.is_ignored` for normal reconciliation.

Config changes:
- Add `PreDeleteInclude` bool to `CompareFieldConfig` (field.go)
- Add `PreDeleteSyncConfig` with `CompareAll to ResourceConfig` (resource.go)

Code generation:
- Add `CompareResourceForPreDelete` function that emits comparison code
  only for opted-in fields (or all fields when compare_all is true)
- Register `GoCodeCompareForPreDelete` template function (controller.go)
- Add `newResourceDeltaForPreDelete` in delta.go.tpl
- Add `DeltaForPreDelete` method on `resourceDescriptor` in descriptor.go.tpl

Tests:
- Four tests covering no-opt-in (empty), explicit opt-in, compare_all,
  and empty-without-opt-in scenarios
- Two new S3 test fixture generator YAMLs

runtime changes: https://github.com/aws-controllers-k8s/runtime/pull/234

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
