### PR TITLE
Support custom list and map fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.23
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/runtime v0.58.1
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.32.7
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.23 h1:iqu8jKQUnyP/c6TiVcXySQYpkATui0iXFC5ax9x01oM=
 github.com/aws-controllers-k8s/pkg v0.0.23/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.58.1 h1:FZso3Bwd2JIqglH6cpFurNAWkIyc4Z1qNXE7+t0wxdI=
+github.com/aws-controllers-k8s/runtime v0.58.1/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -40,6 +40,16 @@ type ResourceConfig struct {
 	// Synced contains instructions for the code generator to generate Go code
 	// that verifies whether a resource is synced or not.
 	Synced *SyncedConfig `json:"synced"`
+	// Updateable contains instructions for the code generator to generate
+	// guard code that checks whether a resource can be updated based on its
+	// current status. If the resource is not in an allowed state, the update
+	// operation is requeued.
+	Updateable *UpdateableConfig `json:"updateable,omitempty"`
+	// Deletable contains instructions for the code generator to generate
+	// guard code that checks whether a resource can be deleted based on its
+	// current status. If the resource is not in an allowed state, the delete
+	// operation is requeued.
+	Deletable *DeletableConfig `json:"deletable,omitempty"`
 	// Renames identifies fields in Operations that should be renamed.
 	Renames *RenamesConfig `json:"renames,omitempty"`
 	// ListOperation contains instructions for the code generator to generate
@@ -158,6 +168,42 @@ type SyncedCondition struct {
 	Path *string `json:"path"`
 	// In contains a list of possible values `Path` should be equal to.
 	In []string `json:"in"`
+}
+
+// StatusCondition represents a single field condition for updateable/deletable
+// guards. It uses the same path+in pattern as SyncedCondition but is a
+// separate type to allow future divergence (e.g. requeue_after_seconds).
+type StatusCondition struct {
+	// Path of the field. e.g. Status.Status
+	Path *string `json:"path"`
+	// In contains the list of values the field must be IN for the operation
+	// to proceed. If the field value is NOT in this list, the operation is
+	// requeued.
+	In []string `json:"in"`
+}
+
+// UpdateableConfig instructs the code generator on how to generate guard code
+// that checks whether a resource can be updated based on its current status.
+type UpdateableConfig struct {
+	// When is a list of conditions. ALL conditions must be satisfied for the
+	// resource to be considered updateable. If any condition is not met, the
+	// update is requeued.
+	When []StatusCondition `json:"when"`
+	// RequeueAfterSeconds is the delay in seconds before the requeue.
+	// Defaults to 30.
+	RequeueAfterSeconds *int `json:"requeue_after_seconds,omitempty"`
+}
+
+// DeletableConfig instructs the code generator on how to generate guard code
+// that checks whether a resource can be deleted based on its current status.
+type DeletableConfig struct {
+	// When is a list of conditions. ALL conditions must be satisfied for the
+	// resource to be considered deletable. If any condition is not met, the
+	// delete is requeued.
+	When []StatusCondition `json:"when"`
+	// RequeueAfterSeconds is the delay in seconds before the requeue.
+	// Defaults to 30.
+	RequeueAfterSeconds *int `json:"requeue_after_seconds,omitempty"`
 }
 
 // HooksConfig instructs the code generator how to inject custom callback hooks

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -148,6 +148,12 @@ var (
 		"GoCodeIsSynced": func(r *ackmodel.CRD, resVarName string, indentLevel int) (string, error) {
 			return code.ResourceIsSynced(r.Config(), r, resVarName, indentLevel)
 		},
+		"GoCodeResourceIsUpdateable": func(r *ackmodel.CRD, resVarName string, indentLevel int) (string, error) {
+			return code.ResourceIsUpdateable(r.Config(), r, resVarName, indentLevel)
+		},
+		"GoCodeResourceIsDeletable": func(r *ackmodel.CRD, resVarName string, indentLevel int) (string, error) {
+			return code.ResourceIsDeletable(r.Config(), r, resVarName, indentLevel)
+		},
 		"GoCodeCompareStruct": func(r *ackmodel.CRD, shape *awssdkmodel.Shape, deltaVarName string, sourceVarName string, targetVarName string, fieldPath string, indentLevel int) (string, error) {
 			return code.CompareStruct(r.Config(), r, nil, shape, deltaVarName, sourceVarName, targetVarName, fieldPath, indentLevel)
 		},

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -32,7 +32,7 @@ var (
 		"helm/templates/_helpers.tpl.tpl",
 		"helm/Chart.yaml.tpl",
 		"helm/values.yaml.tpl",
-		"helm/values.schema.json",
+		"helm/values.schema.json.tpl",
 		"helm/templates/NOTES.txt.tpl",
 		"helm/templates/role-reader.yaml.tpl",
 		"helm/templates/role-writer.yaml.tpl",

--- a/pkg/generate/code/resource_guard.go
+++ b/pkg/generate/code/resource_guard.go
@@ -1,0 +1,188 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code
+
+import (
+	"fmt"
+	"strings"
+
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/config"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+)
+
+// defaultRequeueAfterSeconds is the default delay in seconds before a requeue
+// when a resource is not in an allowed state for update or delete.
+const defaultRequeueAfterSeconds = 30
+
+// ResourceIsUpdateable returns Go code that checks whether a resource can be
+// updated based on its current status. If the resource is NOT updateable, the
+// generated code returns ackrequeue.NeededAfter.
+//
+// This follows the same pattern as ResourceIsSynced in synced.go.
+//
+// Sample output:
+//
+//	if latest.ko.Status.Status != nil {
+//	    if !ackutil.InStrings(*latest.ko.Status.Status, []string{"ACTIVE", "AVAILABLE"}) {
+//	        return nil, ackrequeue.NeededAfter(
+//	            fmt.Errorf("resource is in %s state, cannot be updated",
+//	                *latest.ko.Status.Status),
+//	            time.Duration(30)*time.Second,
+//	        )
+//	    }
+//	}
+func ResourceIsUpdateable(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// resource variable name — "latest" for sdkUpdate
+	resVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	return resourceIsGuarded(cfg, r, resVarName, indentLevel, "updateable", "updated")
+}
+
+// ResourceIsDeletable returns Go code that checks whether a resource can be
+// deleted based on its current status. If the resource is NOT deletable, the
+// generated code returns ackrequeue.NeededAfter.
+//
+// Sample output:
+//
+//	if r.ko.Status.Status != nil {
+//	    if !ackutil.InStrings(*r.ko.Status.Status, []string{"ACTIVE", "AVAILABLE", "FAILED"}) {
+//	        return nil, ackrequeue.NeededAfter(
+//	            fmt.Errorf("resource is in %s state, cannot be deleted",
+//	                *r.ko.Status.Status),
+//	            time.Duration(30)*time.Second,
+//	        )
+//	    }
+//	}
+func ResourceIsDeletable(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	// resource variable name — "r" for sdkDelete
+	resVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) (string, error) {
+	return resourceIsGuarded(cfg, r, resVarName, indentLevel, "deletable", "deleted")
+}
+
+// resourceIsGuarded is the shared implementation for ResourceIsUpdateable and
+// ResourceIsDeletable. It reads the appropriate config block and generates
+// guard code for each condition.
+func resourceIsGuarded(
+	cfg *ackgenconfig.Config,
+	r *model.CRD,
+	resVarName string,
+	indentLevel int,
+	// configKey is "updateable" or "deletable"
+	configKey string,
+	// opVerb is "updated" or "deleted" — used in the error message
+	opVerb string,
+) (string, error) {
+	out := ""
+	resConfig := cfg.GetResourceConfig(r.Names.Original)
+	if resConfig == nil {
+		return out, nil
+	}
+
+	var conditions []ackgenconfig.StatusCondition
+	var requeueSeconds int
+
+	switch configKey {
+	case "updateable":
+		if resConfig.Updateable == nil || len(resConfig.Updateable.When) == 0 {
+			return out, nil
+		}
+		conditions = resConfig.Updateable.When
+		requeueSeconds = defaultRequeueAfterSeconds
+		if resConfig.Updateable.RequeueAfterSeconds != nil &&
+			*resConfig.Updateable.RequeueAfterSeconds > 0 {
+			requeueSeconds = *resConfig.Updateable.RequeueAfterSeconds
+		}
+	case "deletable":
+		if resConfig.Deletable == nil || len(resConfig.Deletable.When) == 0 {
+			return out, nil
+		}
+		conditions = resConfig.Deletable.When
+		requeueSeconds = defaultRequeueAfterSeconds
+		if resConfig.Deletable.RequeueAfterSeconds != nil &&
+			*resConfig.Deletable.RequeueAfterSeconds > 0 {
+			requeueSeconds = *resConfig.Deletable.RequeueAfterSeconds
+		}
+	default:
+		return "", fmt.Errorf("unknown config key %q", configKey)
+	}
+
+	for _, condCfg := range conditions {
+		if condCfg.Path == nil || *condCfg.Path == "" {
+			return "", fmt.Errorf(
+				"resource %q: %s.when condition has empty path",
+				r.Names.Original, configKey,
+			)
+		}
+		if len(condCfg.In) == 0 {
+			return "", fmt.Errorf(
+				"resource %q, path %q: %s.when condition 'in' must not be empty",
+				r.Names.Original, *condCfg.Path, configKey,
+			)
+		}
+
+		_, err := getTopLevelField(r, *condCfg.Path)
+		if err != nil {
+			return "", fmt.Errorf(
+				"resource %q: cannot find field for path %q: %w",
+				r.Names.Original, *condCfg.Path, err,
+			)
+		}
+
+		out += renderGuardBlock(
+			resVarName, *condCfg.Path, condCfg.In,
+			requeueSeconds, opVerb, indentLevel,
+		)
+	}
+
+	return out, nil
+}
+
+// renderGuardBlock produces the Go source code for a single condition check.
+// It generates a nil check on the field pointer, then an InStrings check
+// against the allowed values, returning ackrequeue.NeededAfter if the value
+// is not in the allowed set.
+func renderGuardBlock(
+	resVarName string,
+	fieldPath string,
+	allowedValues []string,
+	requeueSeconds int,
+	opVerb string,
+	indentLevel int,
+) string {
+	indent := strings.Repeat("\t", indentLevel)
+	fullPath := fmt.Sprintf("%s.ko.%s", resVarName, fieldPath)
+
+	valuesSlice := fmt.Sprintf(`[]string{"%s"}`, strings.Join(allowedValues, `", "`))
+
+	out := ""
+	out += fmt.Sprintf("%sif %s != nil {\n", indent, fullPath)
+	out += fmt.Sprintf("%s\tif !ackutil.InStrings(*%s, %s) {\n", indent, fullPath, valuesSlice)
+	out += fmt.Sprintf("%s\t\treturn nil, ackrequeue.NeededAfter(\n", indent)
+	out += fmt.Sprintf("%s\t\t\tfmt.Errorf(\"resource is in %%s state, cannot be %s\",\n", indent, opVerb)
+	out += fmt.Sprintf("%s\t\t\t\t*%s),\n", indent, fullPath)
+	out += fmt.Sprintf("%s\t\t\ttime.Duration(%d)*time.Second,\n", indent, requeueSeconds)
+	out += fmt.Sprintf("%s\t\t)\n", indent)
+	out += fmt.Sprintf("%s\t}\n", indent)
+	out += fmt.Sprintf("%s}\n", indent)
+	return out
+}

--- a/pkg/generate/code/resource_guard_test.go
+++ b/pkg/generate/code/resource_guard_test.go
@@ -1,0 +1,223 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestResourceIsUpdateable_SingleCondition(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambda")
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expected := `	if latest.ko.Status.State != nil {
+		if !ackutil.InStrings(*latest.ko.Status.State, []string{"Active"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be updated",
+					*latest.ko.Status.State),
+				time.Duration(30)*time.Second,
+			)
+		}
+	}
+`
+	got, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}
+func TestResourceIsDeletable_SingleCondition(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambda")
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expected := `	if r.ko.Status.State != nil {
+		if !ackutil.InStrings(*r.ko.Status.State, []string{"Active", "Failed"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be deleted",
+					*r.ko.Status.State),
+				time.Duration(30)*time.Second,
+			)
+		}
+	}
+`
+	got, err := code.ResourceIsDeletable(
+		crd.Config(), crd, "r", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}
+
+func TestResourceIsUpdateable_MultipleConditions_CustomRequeue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-updateable-multi-condition.yaml",
+	})
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expected := `	if latest.ko.Status.State != nil {
+		if !ackutil.InStrings(*latest.ko.Status.State, []string{"Active"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be updated",
+					*latest.ko.Status.State),
+				time.Duration(15)*time.Second,
+			)
+		}
+	}
+	if latest.ko.Status.LastUpdateStatus != nil {
+		if !ackutil.InStrings(*latest.ko.Status.LastUpdateStatus, []string{"Successful"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be updated",
+					*latest.ko.Status.LastUpdateStatus),
+				time.Duration(15)*time.Second,
+			)
+		}
+	}
+`
+	got, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}
+
+func TestResourceIsUpdateable_NoConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambda")
+	crd := testutil.GetCRDByName(t, g, "CodeSigningConfig")
+	require.NotNil(crd)
+
+	got, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.NoError(err)
+	assert.Equal("", got)
+}
+
+func TestResourceIsDeletable_NoConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambda")
+	crd := testutil.GetCRDByName(t, g, "CodeSigningConfig")
+	require.NotNil(crd)
+
+	got, err := code.ResourceIsDeletable(
+		crd.Config(), crd, "r", 1,
+	)
+	require.NoError(err)
+	assert.Equal("", got)
+}
+
+func TestResourceIsUpdateable_EmptyPath(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-updateable-empty-path.yaml",
+	})
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	_, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.Error(err)
+	require.Contains(err.Error(), "empty path")
+}
+
+func TestResourceIsUpdateable_EmptyIn(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-updateable-empty-in.yaml",
+	})
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	_, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.Error(err)
+	require.Contains(err.Error(), "must not be empty")
+}
+
+func TestResourceIsDeletable_MultipleConditions_CustomRequeue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-deletable-multi-condition.yaml",
+	})
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	expected := `	if r.ko.Status.State != nil {
+		if !ackutil.InStrings(*r.ko.Status.State, []string{"Active"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be deleted",
+					*r.ko.Status.State),
+				time.Duration(20)*time.Second,
+			)
+		}
+	}
+	if r.ko.Status.LastUpdateStatus != nil {
+		if !ackutil.InStrings(*r.ko.Status.LastUpdateStatus, []string{"Successful"}) {
+			return nil, ackrequeue.NeededAfter(
+				fmt.Errorf("resource is in %s state, cannot be deleted",
+					*r.ko.Status.LastUpdateStatus),
+				time.Duration(20)*time.Second,
+			)
+		}
+	}
+`
+	got, err := code.ResourceIsDeletable(
+		crd.Config(), crd, "r", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}
+
+func TestResourceIsUpdateable_InvalidFieldPath(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "lambda", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-updateable-invalid-path.yaml",
+	})
+	crd := testutil.GetCRDByName(t, g, "Function")
+	require.NotNil(crd)
+
+	_, err := code.ResourceIsUpdateable(
+		crd.Config(), crd, "latest", 1,
+	)
+	require.Error(err)
+	require.Contains(err.Error(), "cannot find field")
+}

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -803,20 +803,33 @@ func (crd *CRD) addCustomNestedFields(customNestedFields map[string]*ackgenconfi
 			return fmt.Errorf("resource %q, custom nested field %q: %w", crd.Names.Original, customNestedField, err)
 		}
 		//parentField.ShapeRef.Shape.MemberRefs[fieldName] = memberShapeRef
-		addMemberShapRef(parentField.ShapeRef, memberShapeRef, fieldName)
+		if err := addMemberShapRef(parentField.ShapeRef, memberShapeRef, fieldName); err != nil {
+			return fmt.Errorf("resource %q, custom nested field %q: %w", crd.Names.Original, customNestedField, err)
+		}
 	}
 	return nil
 }
 
-func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName string) {
+// addMemberShapRef injects a new member shape into the specified shape.
+// It returns an error if the shape type is unsupported or if a member with
+// the given field name already exists.
+func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName string) error {
+	var memberRefs map[string]*awssdkmodel.ShapeRef
 	switch shapeRef.Shape.Type {
 	case "structure":
-		shapeRef.Shape.MemberRefs[fieldName] = memberShapeRef
+		memberRefs = shapeRef.Shape.MemberRefs
 	case "list":
-		shapeRef.Shape.MemberRef.Shape.MemberRefs[fieldName] = memberShapeRef
+		memberRefs = shapeRef.Shape.MemberRef.Shape.MemberRefs
 	case "map":
-		shapeRef.Shape.ValueRef.Shape.MemberRefs[fieldName] = memberShapeRef
+		memberRefs = shapeRef.Shape.ValueRef.Shape.MemberRefs
+	default:
+		return fmt.Errorf("unsupported shape type %q for adding member %q", shapeRef.Shape.Type, fieldName)
 	}
+	if _, exists := memberRefs[fieldName]; exists {
+		return fmt.Errorf("member %q already exists in shape of type %q", fieldName, shapeRef.Shape.Type)
+	}
+	memberRefs[fieldName] = memberShapeRef
+	return nil
 }
 
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -802,9 +802,21 @@ func (crd *CRD) addCustomNestedFields(customNestedFields map[string]*ackgenconfi
 		if err != nil {
 			return fmt.Errorf("resource %q, custom nested field %q: %w", crd.Names.Original, customNestedField, err)
 		}
-		parentField.ShapeRef.Shape.MemberRefs[fieldName] = memberShapeRef
+		//parentField.ShapeRef.Shape.MemberRefs[fieldName] = memberShapeRef
+		addMemberShapRef(parentField.ShapeRef, memberShapeRef, fieldName)
 	}
 	return nil
+}
+
+func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName string) {
+	switch shapeRef.Shape.Type {
+	case "structure":
+		shapeRef.Shape.MemberRefs[fieldName] = memberShapeRef
+	case "list":
+		shapeRef.Shape.MemberRef.Shape.MemberRefs[fieldName] = memberShapeRef
+	case "map":
+		shapeRef.Shape.ValueRef.Shape.MemberRefs[fieldName] = memberShapeRef
+	}
 }
 
 // ReconcileRequeuOnSuccessSeconds returns the duration after which to requeue

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -1,0 +1,323 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	awssdkmodel "github.com/aws-controllers-k8s/code-generator/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddMemberShapRef_Structure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	structShape := &awssdkmodel.Shape{
+		Type:       "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: structShape,
+	}
+
+	memberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+
+	err := addMemberShapRef(shapeRef, memberShapeRef, "NewField")
+
+	require.NoError(err)
+	require.Contains(structShape.MemberRefs, "NewField")
+	assert.Equal(memberShapeRef, structShape.MemberRefs["NewField"])
+}
+
+func TestAddMemberShapRef_List(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	innerStructShape := &awssdkmodel.Shape{
+		Type:       "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{},
+	}
+	listShape := &awssdkmodel.Shape{
+		Type: "list",
+		MemberRef: awssdkmodel.ShapeRef{
+			Shape: innerStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: listShape,
+	}
+
+	memberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, memberShapeRef, "Count")
+
+	require.NoError(err)
+	require.Contains(innerStructShape.MemberRefs, "Count")
+	assert.Equal(memberShapeRef, innerStructShape.MemberRefs["Count"])
+}
+
+func TestAddMemberShapRef_Map(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	valueStructShape := &awssdkmodel.Shape{
+		Type:       "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{},
+	}
+	mapShape := &awssdkmodel.Shape{
+		Type: "map",
+		ValueRef: awssdkmodel.ShapeRef{
+			Shape: valueStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: mapShape,
+	}
+
+	memberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "boolean"},
+	}
+
+	err := addMemberShapRef(shapeRef, memberShapeRef, "Enabled")
+
+	require.NoError(err)
+	require.Contains(valueStructShape.MemberRefs, "Enabled")
+	assert.Equal(memberShapeRef, valueStructShape.MemberRefs["Enabled"])
+}
+
+func TestAddMemberShapRef_UnsupportedType(t *testing.T) {
+	assert := assert.New(t)
+
+	scalarShape := &awssdkmodel.Shape{
+		Type:       "string",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: scalarShape,
+	}
+
+	memberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+
+	err := addMemberShapRef(shapeRef, memberShapeRef, "ShouldNotExist")
+
+	assert.Error(err)
+	assert.Contains(err.Error(), "unsupported shape type")
+	assert.Contains(err.Error(), "string")
+	assert.Contains(err.Error(), "ShouldNotExist")
+	assert.NotContains(scalarShape.MemberRefs, "ShouldNotExist")
+}
+
+func TestAddMemberShapRef_Structure_PreservesExistingMembers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	existingMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	structShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"ExistingField": existingMemberRef,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: structShape,
+	}
+
+	newMemberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberShapeRef, "NewField")
+
+	require.NoError(err)
+	require.Len(structShape.MemberRefs, 2)
+	assert.Equal(existingMemberRef, structShape.MemberRefs["ExistingField"])
+	assert.Equal(newMemberShapeRef, structShape.MemberRefs["NewField"])
+}
+
+func TestAddMemberShapRef_List_PreservesExistingMembers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	existingMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	innerStructShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"ExistingField": existingMemberRef,
+		},
+	}
+	listShape := &awssdkmodel.Shape{
+		Type: "list",
+		MemberRef: awssdkmodel.ShapeRef{
+			Shape: innerStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: listShape,
+	}
+
+	newMemberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "boolean"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberShapeRef, "Active")
+
+	require.NoError(err)
+	require.Len(innerStructShape.MemberRefs, 2)
+	assert.Equal(existingMemberRef, innerStructShape.MemberRefs["ExistingField"])
+	assert.Equal(newMemberShapeRef, innerStructShape.MemberRefs["Active"])
+}
+
+func TestAddMemberShapRef_Map_PreservesExistingMembers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	existingMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	valueStructShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"ExistingField": existingMemberRef,
+		},
+	}
+	mapShape := &awssdkmodel.Shape{
+		Type: "map",
+		ValueRef: awssdkmodel.ShapeRef{
+			Shape: valueStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: mapShape,
+	}
+
+	newMemberShapeRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberShapeRef, "Priority")
+
+	require.NoError(err)
+	require.Len(valueStructShape.MemberRefs, 2)
+	assert.Equal(existingMemberRef, valueStructShape.MemberRefs["ExistingField"])
+	assert.Equal(newMemberShapeRef, valueStructShape.MemberRefs["Priority"])
+}
+
+func TestAddMemberShapRef_DuplicateField_Structure(t *testing.T) {
+	assert := assert.New(t)
+
+	oldMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	structShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"Field": oldMemberRef,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: structShape,
+	}
+
+	newMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
+
+	assert.Error(err)
+	assert.Contains(err.Error(), "Field")
+	assert.Contains(err.Error(), "already exists")
+	// Original member should be unchanged
+	assert.Equal(oldMemberRef, structShape.MemberRefs["Field"])
+}
+
+func TestAddMemberShapRef_DuplicateField_List(t *testing.T) {
+	assert := assert.New(t)
+
+	oldMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	innerStructShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"Field": oldMemberRef,
+		},
+	}
+	listShape := &awssdkmodel.Shape{
+		Type: "list",
+		MemberRef: awssdkmodel.ShapeRef{
+			Shape: innerStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: listShape,
+	}
+
+	newMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
+
+	assert.Error(err)
+	assert.Contains(err.Error(), "Field")
+	assert.Contains(err.Error(), "already exists")
+	assert.Equal(oldMemberRef, innerStructShape.MemberRefs["Field"])
+}
+
+func TestAddMemberShapRef_DuplicateField_Map(t *testing.T) {
+	assert := assert.New(t)
+
+	oldMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "string"},
+	}
+	valueStructShape := &awssdkmodel.Shape{
+		Type: "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{
+			"Field": oldMemberRef,
+		},
+	}
+	mapShape := &awssdkmodel.Shape{
+		Type: "map",
+		ValueRef: awssdkmodel.ShapeRef{
+			Shape: valueStructShape,
+		},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{
+		Shape: mapShape,
+	}
+
+	newMemberRef := &awssdkmodel.ShapeRef{
+		Shape: &awssdkmodel.Shape{Type: "integer"},
+	}
+
+	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
+
+	assert.Error(err)
+	assert.Contains(err.Error(), "Field")
+	assert.Contains(err.Error(), "already exists")
+	assert.Equal(oldMemberRef, valueStructShape.MemberRefs["Field"])
+}

--- a/pkg/model/model_bedrockagentcorecontrol_test.go
+++ b/pkg/model/model_bedrockagentcorecontrol_test.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+func TestBedrockAgentCoreControl_GatewayTarget_CustomNestedField_ListOfStruct(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "bedrock-agentcore-control", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-custom-nested-fields.yaml",
+	})
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("GatewayTarget", crds)
+	require.NotNil(crd)
+
+	// Walk the nested path to the InlinePayload field:
+	// TargetConfiguration -> Mcp -> Lambda -> ToolSchema -> InlinePayload
+	// InlinePayload is a list of ToolDefinition structs.
+	targetConfigField := crd.Fields["TargetConfiguration"]
+	require.NotNil(targetConfigField, "TargetConfiguration field should exist")
+
+	mcpField := targetConfigField.MemberFields["Mcp"]
+	require.NotNil(mcpField, "Mcp member field should exist")
+
+	lambdaField := mcpField.MemberFields["Lambda"]
+	require.NotNil(lambdaField, "Lambda member field should exist")
+
+	toolSchemaField := lambdaField.MemberFields["ToolSchema"]
+	require.NotNil(toolSchemaField, "ToolSchema member field should exist")
+
+	inlinePayloadField := toolSchemaField.MemberFields["InlinePayload"]
+	require.NotNil(inlinePayloadField, "InlinePayload member field should exist")
+	require.NotNil(inlinePayloadField.ShapeRef)
+	require.NotNil(inlinePayloadField.ShapeRef.Shape)
+	assert.Equal("list", inlinePayloadField.ShapeRef.Shape.Type)
+
+	// The list element shape (ToolDefinition) should be a structure
+	toolDefShape := inlinePayloadField.ShapeRef.Shape.MemberRef.Shape
+	require.NotNil(toolDefShape)
+	assert.Equal("structure", toolDefShape.Type)
+
+	// Verify the custom nested fields "InputSchema" and "OutputSchema" were
+	// added to the ToolDefinition struct shape as string types
+	require.Contains(toolDefShape.MemberRefs, "InputSchema")
+	inputSchemaRef := toolDefShape.MemberRefs["InputSchema"]
+	require.NotNil(inputSchemaRef.Shape)
+	assert.Equal("string", inputSchemaRef.Shape.Type)
+
+	require.Contains(toolDefShape.MemberRefs, "OutputSchema")
+	outputSchemaRef := toolDefShape.MemberRefs["OutputSchema"]
+	require.NotNil(outputSchemaRef.Shape)
+	assert.Equal("string", outputSchemaRef.Shape.Type)
+
+	// Verify the original ToolDefinition members are still present
+	assert.Contains(toolDefShape.MemberRefs, "Name")
+	assert.Contains(toolDefShape.MemberRefs, "Description")
+
+	// Verify the custom nested fields appear as MemberFields on the
+	// InlinePayload field
+	require.NotNil(inlinePayloadField.MemberFields)
+	inputSchemaMember := inlinePayloadField.MemberFields["InputSchema"]
+	require.NotNil(inputSchemaMember)
+
+	outputSchemaMember := inlinePayloadField.MemberFields["OutputSchema"]
+	require.NotNil(outputSchemaMember)
+}

--- a/pkg/model/model_sagemaker_test.go
+++ b/pkg/model/model_sagemaker_test.go
@@ -226,3 +226,48 @@ func TestSageMaker_RequeueOnSuccessSeconds_Default(t *testing.T) {
 	assert.Equal(0, crd.ReconcileRequeuOnSuccessSeconds())
 
 }
+
+func TestSageMaker_TrialComponent_CustomNestedField_MapOfStruct(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "sagemaker", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-with-custom-nested-fields.yaml",
+	})
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("TrialComponent", crds)
+	require.NotNil(crd)
+
+	// InputArtifacts is a map-of-struct field (map[string]*TrialComponentArtifact).
+	// The generator config adds a custom nested field "InputArtifacts.CustomTag"
+	// of type *string. Verify it was injected into the map value's struct shape.
+	inputArtifactsField := crd.Fields["InputArtifacts"]
+	require.NotNil(inputArtifactsField)
+	require.NotNil(inputArtifactsField.ShapeRef)
+	require.NotNil(inputArtifactsField.ShapeRef.Shape)
+	assert.Equal("map", inputArtifactsField.ShapeRef.Shape.Type)
+
+	// The map value shape should be a structure
+	valueShape := inputArtifactsField.ShapeRef.Shape.ValueRef.Shape
+	require.NotNil(valueShape)
+	assert.Equal("structure", valueShape.Type)
+
+	// Verify the custom nested field "CustomTag" was added to the map value's struct
+	require.Contains(valueShape.MemberRefs, "CustomTag")
+	customTagRef := valueShape.MemberRefs["CustomTag"]
+	require.NotNil(customTagRef)
+	require.NotNil(customTagRef.Shape)
+	assert.Equal("string", customTagRef.Shape.Type)
+
+	// Verify the original members are still present
+	assert.Contains(valueShape.MemberRefs, "Value")
+	assert.Contains(valueShape.MemberRefs, "MediaType")
+
+	// Verify the custom nested field also appears as a MemberField on the CRD field
+	require.NotNil(inputArtifactsField.MemberFields)
+	customTagMemberField := inputArtifactsField.MemberFields["CustomTag"]
+	require.NotNil(customTagMemberField)
+}

--- a/pkg/testdata/models/apis/bedrock-agentcore-control/0000-00-00/generator-with-custom-nested-fields.yaml
+++ b/pkg/testdata/models/apis/bedrock-agentcore-control/0000-00-00/generator-with-custom-nested-fields.yaml
@@ -1,0 +1,38 @@
+ignore:
+  resource_names:
+    - AgentRuntime
+    - AgentRuntimeEndpoint
+    - ApiKeyCredentialProvider
+    - Browser
+    - BrowserProfile
+    - CodeInterpreter
+    - Evaluator
+    - Gateway
+    # GatewayTarget
+    - Memory
+    - Oauth2CredentialProvider
+    - OnlineEvaluationConfig
+    - WorkloadIdentity
+    - Policy
+    - PolicyEngine
+  field_paths:
+    - CreateGatewayTargetInput.TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.ToolDefinition.InputSchema
+    - CreateGatewayTargetInput.TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.ToolDefinition.OutputSchema
+sdk_names:
+  model_name: bedrock-agentcore-control
+resources:
+  GatewayTarget:
+    ignore_idempotency_token: true
+    fields:
+      TargetId:
+        is_primary_key: true
+      # Custom nested fields injected into a list-of-struct shape.
+      # InlinePayload is a list of ToolDefinition structs. InputSchema
+      # and OutputSchema are ignored from the SDK model (recursive
+      # SchemaDefinition type) and re-added here as simple string fields.
+      TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.InputSchema:
+        type: "*string"
+      TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.OutputSchema:
+        type: "*string"
+    tags:
+      ignore: true

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-deletable-multi-condition.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-deletable-multi-condition.yaml
@@ -11,41 +11,20 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
-    synced:
-      when:
-        - path: Status.State
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.LastUpdateStatus
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.CodeSize
-          in:
-            - 1
-            - 2
-    updateable:
-      when:
-        - path: Status.State
-          in:
-            - Active
     deletable:
       when:
         - path: Status.State
           in:
             - Active
-            - Failed
-  CodeSigningConfig:
-    fields:
-      Tags:
-        compare:
-          is_ignored: true
+        - path: Status.LastUpdateStatus
+          in:
+            - Successful
+      requeue_after_seconds: 20
 ignore:
   field_paths:
     - CreateFunctionInput.Architectures
     - CreateFunctionInput.LoggingConfig
-    - CreateFunctionInput.EphemeralStorage   
+    - CreateFunctionInput.EphemeralStorage
     - FunctionCode.SourceKMSKeyArn
     - CreateFunctionInput.SnapStart
     - CreateFunctionInput.VpcConfig.Ipv6AllowedForDualStack

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-empty-in.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-empty-in.yaml
@@ -11,41 +11,15 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
-    synced:
-      when:
-        - path: Status.State
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.LastUpdateStatus
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.CodeSize
-          in:
-            - 1
-            - 2
     updateable:
       when:
         - path: Status.State
-          in:
-            - Active
-    deletable:
-      when:
-        - path: Status.State
-          in:
-            - Active
-            - Failed
-  CodeSigningConfig:
-    fields:
-      Tags:
-        compare:
-          is_ignored: true
+          in: []
 ignore:
   field_paths:
     - CreateFunctionInput.Architectures
     - CreateFunctionInput.LoggingConfig
-    - CreateFunctionInput.EphemeralStorage   
+    - CreateFunctionInput.EphemeralStorage
     - FunctionCode.SourceKMSKeyArn
     - CreateFunctionInput.SnapStart
     - CreateFunctionInput.VpcConfig.Ipv6AllowedForDualStack

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-empty-path.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-empty-path.yaml
@@ -11,41 +11,16 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
-    synced:
-      when:
-        - path: Status.State
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.LastUpdateStatus
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.CodeSize
-          in:
-            - 1
-            - 2
     updateable:
       when:
-        - path: Status.State
+        - path: ""
           in:
             - Active
-    deletable:
-      when:
-        - path: Status.State
-          in:
-            - Active
-            - Failed
-  CodeSigningConfig:
-    fields:
-      Tags:
-        compare:
-          is_ignored: true
 ignore:
   field_paths:
     - CreateFunctionInput.Architectures
     - CreateFunctionInput.LoggingConfig
-    - CreateFunctionInput.EphemeralStorage   
+    - CreateFunctionInput.EphemeralStorage
     - FunctionCode.SourceKMSKeyArn
     - CreateFunctionInput.SnapStart
     - CreateFunctionInput.VpcConfig.Ipv6AllowedForDualStack

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-invalid-path.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-invalid-path.yaml
@@ -11,41 +11,16 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
-    synced:
-      when:
-        - path: Status.State
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.LastUpdateStatus
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.CodeSize
-          in:
-            - 1
-            - 2
     updateable:
       when:
-        - path: Status.State
+        - path: Status.NonExistentField
           in:
             - Active
-    deletable:
-      when:
-        - path: Status.State
-          in:
-            - Active
-            - Failed
-  CodeSigningConfig:
-    fields:
-      Tags:
-        compare:
-          is_ignored: true
 ignore:
   field_paths:
     - CreateFunctionInput.Architectures
     - CreateFunctionInput.LoggingConfig
-    - CreateFunctionInput.EphemeralStorage   
+    - CreateFunctionInput.EphemeralStorage
     - FunctionCode.SourceKMSKeyArn
     - CreateFunctionInput.SnapStart
     - CreateFunctionInput.VpcConfig.Ipv6AllowedForDualStack

--- a/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-multi-condition.yaml
+++ b/pkg/testdata/models/apis/lambda/0000-00-00/generator-updateable-multi-condition.yaml
@@ -11,41 +11,20 @@ resources:
         from:
           operation: GetFunction
           path: Code.RepositoryType
-    synced:
-      when:
-        - path: Status.State
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.LastUpdateStatus
-          in:
-            - AVAILABLE
-            - ACTIVE
-        - path: Status.CodeSize
-          in:
-            - 1
-            - 2
     updateable:
       when:
         - path: Status.State
           in:
             - Active
-    deletable:
-      when:
-        - path: Status.State
+        - path: Status.LastUpdateStatus
           in:
-            - Active
-            - Failed
-  CodeSigningConfig:
-    fields:
-      Tags:
-        compare:
-          is_ignored: true
+            - Successful
+      requeue_after_seconds: 15
 ignore:
   field_paths:
     - CreateFunctionInput.Architectures
     - CreateFunctionInput.LoggingConfig
-    - CreateFunctionInput.EphemeralStorage   
+    - CreateFunctionInput.EphemeralStorage
     - FunctionCode.SourceKMSKeyArn
     - CreateFunctionInput.SnapStart
     - CreateFunctionInput.VpcConfig.Ipv6AllowedForDualStack

--- a/pkg/testdata/models/apis/sagemaker/0000-00-00/generator-with-custom-nested-fields.yaml
+++ b/pkg/testdata/models/apis/sagemaker/0000-00-00/generator-with-custom-nested-fields.yaml
@@ -1,0 +1,112 @@
+resources:
+  Domain:
+    fields:
+      DomainId:
+        is_read_only: true
+        print:
+          name: DOMAIN-ID
+        from:
+          operation: DescribeDomain
+          path: DomainId
+      Status:
+        is_read_only: true
+        print:
+          name: STATUS
+        from:
+          operation: DescribeDomain
+          path: Status
+  DataQualityJobDefinition:
+    exceptions:
+      errors:
+          404:
+            code: ResourceNotFound
+    fields:
+      JobDefinitionArn:
+        is_arn: true
+  TrainingJob:
+    exceptions:
+      errors:
+          404:
+            code: ValidationException
+            message_prefix: Requested resource not found
+  ModelPackageGroup:
+      exceptions:
+        errors:
+            404:
+              code: ValidationException
+              message_suffix: does not exist.
+  Endpoint:
+    reconcile:
+      requeue_on_success_seconds: 10
+  ModelPackage:
+    is_arn_primary_key: true
+  TrialComponent:
+    fields:
+      # Custom nested field injected into a map-of-struct shape
+      InputArtifacts.CustomTag:
+        type: "*string"
+ignore:
+    resource_names:
+      - Algorithm
+      - App
+      - AutoMLJob
+      - Action
+      - AppImageConfig
+      - Artifact
+      - CodeRepository
+      - CompilationJob
+      - Context
+      # - DataQualityJobDefinition
+      - DeviceFleet
+      - EdgePackagingJob
+      - EndpointConfig
+      # - Endpoint
+      - Experiment
+      - FeatureGroup
+      - FlowDefinition
+      - HumanTaskUi
+      - HyperParameterTuningJob
+      - Image
+      - ImageVersion
+      - LabelingJob
+      - Model
+      - ModelBiasJobDefinition
+      - ModelExplainabilityJobDefinition
+      # - ModelPackage
+      # ModelPackageGroup
+      - ModelQualityJobDefinition
+      - MonitoringSchedule
+      - NotebookInstanceLifecycleConfig
+      - NotebookInstance
+      - Pipeline
+      - PresignedDomainUrl
+      - PresignedNotebookInstanceUrl
+      - ProcessingJob
+      - Project
+      # TrainingJob
+      - TransformJob
+      #- TrialComponent
+      - Trial
+      - UserProfile
+      - Workforce
+      - Workteam
+    shape_names:
+      - RSessionAppSettings
+      - TagList
+      - ModelDataSource
+      - DefaultSpaceSettings
+      - CanvasAppSettings
+      - CodeRepositories
+      - ExecutionRoleIdentityConfig
+    field_paths:
+      - CreateDomainInput.TagPropagation
+      - CreateDomainInput.DomainSettings.AmazonQSettings
+      - CreateDomainInput.DefaultUserSettings.JupyterLabAppSettings.AppLifecycleManagement
+      - CreateDomainInput.DefaultUserSettings.JupyterLabAppSettings.BuiltInLifecycleConfigArn
+      - CreateDomainInput.DefaultUserSettings.JupyterLabAppSettings.EmrSettings
+      - CreateDomainInput.DefaultUserSettings.StudioWebPortalSettings
+      - CreateDomainInput.DefaultUserSettings.AutoMountHomeEFS
+      - CreateUserProfileInput.UserSettings.CodeEditorAppSettings.AppLifecycleManagement
+      - CreateUserProfileInput.UserSettings.CodeEditorAppSettings.BuiltInLifecycleConfigArn
+      - CreateUserProfileInput.UserSettings.CodeEditorAppSettings.CustomImages
+      - CreateDomainInput.DefaultUserSettings.JupyterLabAppSettings.EmrSettings

--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -58,6 +58,11 @@ spec:
 {{ "{{- if .Values.aws.allow_unsafe_aws_endpoint_urls }}" }}
         - --allow-unsafe-aws-endpoint-urls
 {{ "{{- end }}" }}
+{{- if eq .ControllerName "s3" }}
+{{ "{{- if .Values.aws.endpoint_use_path_style }}" }}
+        - --aws-endpoint-use-path-style
+{{ "{{- end }}" }}
+{{- end }}
 {{ "{{- if .Values.log.enable_development_logging }}" }}
         - --enable-development-logging
 {{ "{{- end }}" }}

--- a/templates/helm/values.schema.json.tpl
+++ b/templates/helm/values.schema.json.tpl
@@ -181,6 +181,12 @@
           "type": "boolean",
           "default": false
         },
+        {{- if eq .ControllerName "s3" }}
+        "endpoint_use_path_style": {
+          "type": "boolean",
+          "default": false
+        },
+        {{- end }}
         "credentials": {
           "description": "AWS credentials information",
           "properties": {

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -92,6 +92,9 @@ aws:
   endpoint_url: ""
   identity_endpoint_url: ""
   allow_unsafe_aws_endpoint_urls: false
+{{- if eq .ControllerName "s3" }}
+  endpoint_use_path_style: false
+{{- end }}
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -435,7 +435,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
-		sdkapi:	      svcsdk.NewFromConfig(clientcfg),
+		sdkapi:	      svcsdk.NewFromConfig(clientcfg{{- if $hookCode := Hook .CRD "new_resource_manager_client_options" }}, {{ $hookCode }}{{ end }}),
 	}, nil
 }
 

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -154,6 +154,7 @@ func (rm *resourceManager) sdkDelete(
 {{- if $hookCode := Hook .CRD "sdk_delete_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{- GoCodeResourceIsDeletable .CRD "r" 1 }}
 {{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Delete }}
 	if err = rm.{{ $customMethod }}(ctx, r); err != nil {
 		return nil, err

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -13,6 +13,7 @@ func (rm *resourceManager) sdkUpdate(
 {{- if $hookCode := Hook .CRD "sdk_update_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{- GoCodeResourceIsUpdateable .CRD "latest" 1 }}
 {{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
 	updated, err = rm.{{ $customMethod }}(ctx, desired, latest, delta)
 	if updated != nil || err != nil {

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -15,6 +15,7 @@ func (rm *resourceManager) sdkUpdate(
 {{- if $hookCode := Hook .CRD "sdk_update_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{- GoCodeResourceIsUpdateable .CRD "latest" 1 }}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the
 	// case, and it's an error in the generated code if it is...


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Prior to this PR custom fields could only be applied to `structure` shapes. This PR adds support for adding custom fields to the elements of `list` and `map` types as well.

- Add new addMemberShapRef function for applying a shape as a member of another shape
- Add error checks for unsupported types
- Add error check to prevent overriding an existing field
- Add unit test cases to validate new behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
