### PR TITLE
Fix nested secrets and names conversion

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -237,6 +237,9 @@ func SetResource(
 		if setCfg != nil && setCfg.IgnoreResourceSetter() {
 			continue
 		}
+        if inSpec && f.FieldConfig != nil && f.FieldConfig.IsSecret {
+            continue
+        }
 
 		onlySetChangedFieldsOnUpdate := op == r.Ops.Update && r.OnlySetChangedFieldsOnUpdate()
 		if onlySetChangedFieldsOnUpdate && inSpec {
@@ -670,6 +673,9 @@ func setResourceReadMany(
 		if setCfg != nil && setCfg.IgnoreResourceSetter() {
 			continue
 		}
+        if inSpec && f.FieldConfig != nil && f.FieldConfig.IsSecret {
+            continue
+        }
 
 		targetMemberShapeRef = f.ShapeRef
 		if sourceMemberShapeRef.Shape.RealType == "union" {
@@ -1815,6 +1821,9 @@ func SetResourceForStruct(
 				if setCfg != nil && setCfg.IgnoreResourceSetter() {
 					continue
 				}
+                if mf.FieldConfig != nil && mf.FieldConfig.IsSecret {
+                    continue
+                }
 			}
 		}
 
@@ -2466,6 +2475,9 @@ func setResourceForUnion(
 				if setCfg != nil && setCfg.IgnoreResourceSetter() {
 					continue
 				}
+                if mf.FieldConfig != nil && mf.FieldConfig.IsSecret {
+                    continue
+                }
 			}
 		}
 

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -1809,7 +1809,7 @@ func SetResourceForStruct(
 		var setCfg *ackgenconfig.SetFieldConfig
 		f, ok := r.Fields[targetFieldPath]
 		if ok {
-			mf, ok := f.MemberFields[targetMemberName]
+			mf, ok := f.MemberFields[names.New(targetMemberName).Camel]
 			if ok {
 				setCfg = mf.GetSetterConfig(op)
 				if setCfg != nil && setCfg.IgnoreResourceSetter() {

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1208,7 +1208,7 @@ func SetSDKForStruct(
 		var setCfg *ackgenconfig.SetFieldConfig
 		f, ok := r.Fields[sourceFieldPath]
 		if ok {
-			mf, ok := f.MemberFields[memberName]
+			mf, ok := f.MemberFields[names.New(memberName).Camel]
 			if ok {
 				setCfg = mf.GetSetterConfig(op)
 				if setCfg != nil && setCfg.IgnoreSDKSetter() {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -374,9 +374,8 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 // IsSecretField returns true if the supplied field *path* refers to a Field
 // that is a SecretKeyReference
 func (r *CRD) IsSecretField(path string) bool {
-	fConfigs := r.cfg.GetFieldConfigs(r.Names.Original)
-	fConfig, found := fConfigs[path]
-	if found {
+	fConfig := r.cfg.GetFieldConfigByPath(r.Names.Original, path)
+	if fConfig != nil {
 		return fConfig.IsSecret
 	}
 	return false

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1016,7 +1016,7 @@ func replaceSecretAttrGoType(
 	}
 	// Now we modify the parent type def's Attr that corresponds to
 	// the secret field...
-	attr, found := parentTypeDef.Attrs[field.Names.Camel]
+	attr, found := parentTypeDef.Attrs[field.Names.Original]
 	if !found {
 		return fmt.Errorf(
 			"unable to find attr %s in TypeDef %s at path %s",


### PR DESCRIPTION
Issue #, if available:

This PR is related to https://github.com/aws-controllers-k8s/community/issues/2813.

During my attempt to generate the ack-dms-controller, I identified the following problems:

- Nested secret fields with acronyms (e.g., `SASLPassword`, `SSLClientKeyPassword`) could not be found in `MemberFields` map because the lookup used raw AWS SDK names (`SaslPassword`, `SslClientKeyPassword`) while the map is keyed by normalized camelCase names.
- Secret field setters for nested struct members were not being automatically suppressed based on the `is_secret: true` configuration.

Description of changes:

- All secret fields (top-level and nested) marked with `is_secret: true` automatically suppress SDK→CRD output setters.
- Field config lookups are now consistently case-insensitive across all code paths.
- Acronym normalization (e.g., `Sasl` → `SASL`) no longer causes member field lookup failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.