### PR TITLE
Feat/field manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG build_date
 # service controller code.
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
-ENV GOPROXY=https://proxy.golang.org|direct
+ENV GOPROXY=direct
 ENV GO111MODULE=on
 ENV GOARCH=$target_arch
 ENV GOOS=linux
@@ -36,14 +36,18 @@ COPY $service_alias-controller/go.mod $work_dir/go.mod
 COPY $service_alias-controller/go.sum $work_dir/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    for i in 1 2 3 4 5; do \
+      go mod download && break || \
+      echo "Attempt $i failed, retrying in 10s..." && sleep 10; \
+    done
 
 # Now copy the go source code for the controller...
 COPY $service_alias-controller/apis $work_dir/apis
 COPY $service_alias-controller/cmd $work_dir/cmd
 COPY $service_alias-controller/pkg $work_dir/pkg
 # Build
-RUN GIT_VERSION=$service_controller_git_version && \
+RUN --mount=type=cache,target=/go/pkg/mod GIT_VERSION=$service_controller_git_version && \
     GIT_COMMIT=$service_controller_git_commit && \
     BUILD_DATE=$build_date && \
     go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,12 +129,14 @@ func (c *Config) GetAdditionalColumns(resourceName string) []*AdditionalColumnCo
 	if c == nil {
 		return nil
 	}
-
-	resourceConfig, ok := c.Resources[resourceName]
-	if !ok || resourceConfig.Print == nil || len(resourceConfig.Print.AdditionalColumns) == 0 {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return nil
 	}
-	return resourceConfig.Print.AdditionalColumns
+	if rConfig.Print == nil || len(rConfig.Print.AdditionalColumns) == 0 {
+		return nil
+	}
+	return rConfig.Print.AdditionalColumns
 }
 
 // GetCustomListFieldMembers finds all of the custom list fields that need to

--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -492,6 +492,15 @@ type FieldConfig struct {
 	//
 	// (See https://github.com/aws-controllers-k8s/pkg/blob/main/names/names.go)
 	GoTag *string `json:"go_tag,omitempty"`
+	// Manager, when set, instructs the code generator to create a separate
+	// field manager package for this field. The field becomes a managed field
+	// whose lifecycle (create/update/delete) is handled by dedicated API
+	// operations rather than the parent resource's CRUD operations.
+	//
+	// The FieldManagerConfig embedded here carries the same configuration
+	// options as a top-level resource (hooks, renames, exceptions, fields,
+	// find_operation, etc.) scoped to the managed field's own operations.
+	Manager *FieldManagerConfig `json:"manager,omitempty"`
 }
 
 // GetFieldConfigs returns all FieldConfigs for a given resource as a map.
@@ -500,11 +509,11 @@ func (c *Config) GetFieldConfigs(resourceName string) map[string]*FieldConfig {
 	if c == nil {
 		return map[string]*FieldConfig{}
 	}
-	resourceConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return map[string]*FieldConfig{}
 	}
-	return resourceConfig.Fields
+	return rConfig.Fields
 }
 
 // GetFieldConfigByPath returns the FieldConfig provided a resource and path to associated field.

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -954,52 +954,57 @@ func (c *Config) InferManagedFieldOperations(sdkOperations map[string]struct{}) 
 
 // inferManagedFieldOps infers create, delete, and get operation bindings for a
 // single managed field by probing the SDK operation set with common naming
-// patterns.
+// patterns. For each operation type, it tries suffixes in preference order:
+//
+//  1. {Parent}{Field}       e.g. BackupVaultLockConfiguration
+//  2. {Field}               e.g. LockConfiguration
+//  3. {Parent}{Singular}    e.g. BackupVaultTag
+//  4. {Singular}            e.g. Tag
+//  5. Resource              for generic ops like TagResource/UntagResource
 func (c *Config) inferManagedFieldOps(parentName, fieldName string, sdkOps map[string]struct{}) {
-	suffix := parentName + fieldName
+	withParent := parentName + fieldName
+	withoutParent := fieldName
+
+	suffixes := []string{withParent}
+	if withoutParent != withParent {
+		suffixes = append(suffixes, withoutParent)
+	}
+	singularField := strings.TrimSuffix(fieldName, "s")
+	if singularField != fieldName {
+		suffixes = append(suffixes, parentName+singularField, singularField)
+	}
+	// Generic "Resource" suffix for operations like TagResource/UntagResource
+	suffixes = append(suffixes, "Resource")
 
 	// Create operation candidates (order = preference)
-	createPrefixes := []string{"Put", "Create", "Set"}
-	for _, prefix := range createPrefixes {
-		candidate := prefix + suffix
-		if _, exists := sdkOps[candidate]; exists {
-			if !c.hasOperationBinding(candidate) {
-				c.Operations[candidate] = OperationConfig{
-					ResourceName:  StringArray{fieldName},
-					OperationType: StringArray{"create"},
-				}
-			}
-			break
-		}
-	}
+	createPrefixes := []string{"Put", "Create", "Set", "Tag"}
+	c.tryInferOp(createPrefixes, suffixes, fieldName, "create", sdkOps)
 
 	// Delete operation candidates
-	deletePrefixes := []string{"Delete", "Remove"}
-	for _, prefix := range deletePrefixes {
-		candidate := prefix + suffix
-		if _, exists := sdkOps[candidate]; exists {
-			if !c.hasOperationBinding(candidate) {
-				c.Operations[candidate] = OperationConfig{
-					ResourceName:  StringArray{fieldName},
-					OperationType: StringArray{"delete"},
-				}
-			}
-			break
-		}
-	}
+	deletePrefixes := []string{"Delete", "Remove", "Untag"}
+	c.tryInferOp(deletePrefixes, suffixes, fieldName, "delete", sdkOps)
 
 	// Get operation candidates
-	getPrefixes := []string{"Get", "Describe"}
-	for _, prefix := range getPrefixes {
-		candidate := prefix + suffix
-		if _, exists := sdkOps[candidate]; exists {
-			if !c.hasOperationBinding(candidate) {
-				c.Operations[candidate] = OperationConfig{
-					ResourceName:  StringArray{fieldName},
-					OperationType: StringArray{"get"},
+	getPrefixes := []string{"Get", "Describe", "List"}
+	c.tryInferOp(getPrefixes, suffixes, fieldName, "get", sdkOps)
+}
+
+// tryInferOp probes the SDK operation set with each combination of prefix and
+// suffix. The first match wins. If a binding already exists, it is not
+// overwritten.
+func (c *Config) tryInferOp(prefixes, suffixes []string, fieldName, opType string, sdkOps map[string]struct{}) {
+	for _, suffix := range suffixes {
+		for _, prefix := range prefixes {
+			candidate := prefix + suffix
+			if _, exists := sdkOps[candidate]; exists {
+				if !c.hasOperationBinding(candidate) {
+					c.Operations[candidate] = OperationConfig{
+						ResourceName:  StringArray{fieldName},
+						OperationType: StringArray{opType},
+					}
 				}
+				return
 			}
-			break
 		}
 	}
 }

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -122,6 +122,25 @@ type ResourceConfig struct {
 	// SDK implementation details that are auto-filled by the SDK middleware
 	// when nil and should not be exposed in the CRD.
 	IgnoreIdempotencyToken bool `json:"ignore_idempotency_token,omitempty"`
+	// ManagedFields maps managed-field kind names to their configuration.
+	// Managed fields are internal implementation details that do not expose
+	// a CRD to the user. Each entry generates a separate field manager
+	// package under the parent resource. The key is used verbatim as the
+	// managed field's Kind and as the lookup name throughout the code
+	// generator.
+	//
+	// This map is populated automatically from field-level `manager` configs
+	// during normalization. Users should define managed fields via the
+	// `manager` key on individual fields in generator.yaml rather than
+	// populating this map directly.
+	ManagedFields map[string]*FieldManagerConfig `json:"managed_fields,omitempty"`
+}
+
+// FieldManagerConfig defines a managed field nested under a parent resource.
+// It reuses ResourceConfig fields to configure the generated field manager
+// package (hooks, renames, exceptions, custom operations, etc.).
+type FieldManagerConfig struct {
+	ResourceConfig `json:",inline"`
 }
 
 // TagConfig instructs the code  generator on how to generate functions that
@@ -443,8 +462,8 @@ func (c *Config) ResourceIsAdoptable(resourceName string) bool {
 	if c == nil {
 		return true
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return true
 	}
 	if rConfig.IsAdoptable == nil {
@@ -481,8 +500,8 @@ func (c *Config) ResourceDisplaysAgeColumn(resourceName string) bool {
 	if c == nil {
 		return false
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return false
 	}
 	if rConfig.Print != nil {
@@ -497,8 +516,8 @@ func (c *Config) ResourceDisplaysSyncedColumn(resourceName string) bool {
 	if c == nil {
 		return false
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return false
 	}
 	if rConfig.Print != nil {
@@ -517,15 +536,18 @@ func (c *Config) ResourceSetsSingleAttribute(resourceName string) bool {
 	if c == nil {
 		return false
 	}
-	resGenConfig, found := c.Resources[resourceName]
-	if !found || resGenConfig.UnpackAttributesMapConfig == nil {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return false
 	}
-	return resGenConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
+	if rConfig.UnpackAttributesMapConfig == nil {
+		return false
+	}
+	return rConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
 }
 
 // GetResourceConfig returns the ResourceConfig for a given resource name,
-// searching case-insensitively.
+// searching case-insensitively. Also checks managed fields maps as a fallback.
 func (c *Config) GetResourceConfig(resourceName string) *ResourceConfig {
 	if c == nil {
 		return nil
@@ -534,6 +556,16 @@ func (c *Config) GetResourceConfig(resourceName string) *ResourceConfig {
 	for resName, resCfg := range c.Resources {
 		if strings.EqualFold(resName, resourceName) {
 			return &resCfg
+		}
+	}
+	// Check managed fields
+	for _, rConfig := range c.Resources {
+		if rConfig.ManagedFields != nil {
+			for mfName, mfCfg := range rConfig.ManagedFields {
+				if strings.EqualFold(mfName, resourceName) {
+					return &mfCfg.ResourceConfig
+				}
+			}
 		}
 	}
 	return nil
@@ -545,8 +577,8 @@ func (c *Config) GetCompareIgnoredFieldPaths(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return nil
 	}
 	if rConfig.Compare == nil {
@@ -565,8 +597,8 @@ func (c *Config) GetResourceFieldName(
 	if c == nil {
 		return origFieldName
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return origFieldName
 	}
 	if rConfig.Renames == nil {
@@ -598,8 +630,8 @@ func (c *Config) GetOriginalMemberName(
 	if c == nil {
 		return fieldName
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return fieldName
 	}
 	if rConfig.Renames == nil {
@@ -627,8 +659,8 @@ func (c *Config) GetResourceShortNames(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return nil
 	}
 	return rConfig.ShortNames
@@ -639,8 +671,8 @@ func (c *Config) GetResourcePrintOrderByName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return ""
 	}
 	if rConfig.Print != nil {
@@ -655,11 +687,11 @@ func (c *Config) GetUpdateConditionsCustomMethodName(resourceName string) string
 	if c == nil {
 		return ""
 	}
-	resGenConfig, found := c.Resources[resourceName]
-	if !found {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return ""
 	}
-	return resGenConfig.UpdateConditionsCustomMethodName
+	return rConfig.UpdateConditionsCustomMethodName
 }
 
 // GetReconcileRequeueOnSuccessSeconds returns the duration after which to requeue
@@ -668,15 +700,13 @@ func (c *Config) GetReconcileRequeueOnSuccessSeconds(resourceName string) int {
 	if c == nil {
 		return 0
 	}
-	resGenConfig, found := c.Resources[resourceName]
-	if !found {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return 0
 	}
-	reconcile := resGenConfig.Reconcile
-	if reconcile != nil {
-		return reconcile.RequeueOnSuccessSeconds
+	if rConfig.Reconcile != nil {
+		return rConfig.Reconcile.RequeueOnSuccessSeconds
 	}
-	// handles the default case
 	return 0
 }
 
@@ -687,11 +717,12 @@ func (c *Config) GetCustomUpdateMethodName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
-	rConfig, found := c.Resources[resourceName]
-	if found {
-		if rConfig.UpdateOperation != nil {
-			return rConfig.UpdateOperation.CustomMethodName
-		}
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
+		return ""
+	}
+	if rConfig.UpdateOperation != nil {
+		return rConfig.UpdateOperation.CustomMethodName
 	}
 	return ""
 }
@@ -700,11 +731,12 @@ func (c *Config) GetCustomFindMethodName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
-	rConfig, found := c.Resources[resourceName]
-	if found {
-		if rConfig.ReadOperation != nil {
-			return rConfig.ReadOperation.CustomMethodName
-		}
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
+		return ""
+	}
+	if rConfig.ReadOperation != nil {
+		return rConfig.ReadOperation.CustomMethodName
 	}
 	return ""
 }
@@ -713,11 +745,12 @@ func (c *Config) GetCustomDeleteMethodName(resourceName string) string {
 	if c == nil {
 		return ""
 	}
-	rConfig, found := c.Resources[resourceName]
-	if found {
-		if rConfig.DeleteOperation != nil {
-			return rConfig.DeleteOperation.CustomMethodName
-		}
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
+		return ""
+	}
+	if rConfig.DeleteOperation != nil {
+		return rConfig.DeleteOperation.CustomMethodName
 	}
 	return ""
 }
@@ -732,15 +765,15 @@ func (c *Config) GetAllRenames(
 	if c == nil {
 		return renames
 	}
-	resourceConfig, ok := c.Resources[resourceName]
-	if !ok {
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
 		return renames
 	}
-	if resourceConfig.Renames == nil || resourceConfig.Renames.Operations == nil {
+	if rConfig.Renames == nil || rConfig.Renames.Operations == nil {
 		return renames
 	}
 
-	opRenameConfigs := resourceConfig.Renames.Operations
+	opRenameConfigs := rConfig.Renames.Operations
 	for opName, opRenameConfigs := range opRenameConfigs {
 		for _, op := range operations {
 			if opName != op.ExportedName {
@@ -763,9 +796,12 @@ func (c *Config) GetTerminalExceptionCodes(resourceName string) []string {
 	if c == nil {
 		return nil
 	}
-	resGenConfig, found := c.Resources[resourceName]
-	if found && resGenConfig.Exceptions != nil {
-		return resGenConfig.Exceptions.TerminalCodes
+	rConfig := c.GetResourceConfig(resourceName)
+	if rConfig == nil {
+		return nil
+	}
+	if rConfig.Exceptions != nil {
+		return rConfig.Exceptions.TerminalCodes
 	}
 	return nil
 }
@@ -780,8 +816,8 @@ func (c *Config) GetListOpMatchFieldNames(
 	if c == nil {
 		return res
 	}
-	rConfig, found := c.Resources[resName]
-	if !found {
+	rConfig := c.GetResourceConfig(resName)
+	if rConfig == nil {
 		return res
 	}
 	if rConfig.ListOperation == nil {
@@ -791,11 +827,80 @@ func (c *Config) GetListOpMatchFieldNames(
 }
 
 // TagsAreIgnored returns whether ensuring controller tags should be ignored
-// for a resource or not.
+// for a resource or not. Tags are always ignored for managed fields (they are
+// internal implementation details managed through their parent).
 func (c *Config) TagsAreIgnored(resName string) bool {
+	if c == nil {
+		return false
+	}
+	if c.IsManagedField(resName) {
+		return true
+	}
+	rConfig := c.GetResourceConfig(resName)
+	if rConfig == nil {
+		return false
+	}
+	if rConfig.TagConfig != nil {
+		return rConfig.TagConfig.Ignore
+	}
+	return false
+}
+
+// GetManagedFields returns the managed fields map for the given parent
+// resource name, or nil when absent. Nil-safe: returns nil when receiver is nil.
+func (c *Config) GetManagedFields(resName string) map[string]*FieldManagerConfig {
+	if c == nil {
+		return nil
+	}
 	if rConfig, found := c.Resources[resName]; found {
-		if tagConfig := rConfig.TagConfig; tagConfig != nil {
-			return tagConfig.Ignore
+		return rConfig.ManagedFields
+	}
+	return nil
+}
+
+// GetFieldManagerConfig returns the specific FieldManagerConfig for a
+// managed field under a given parent, or nil when absent. Nil-safe: returns
+// nil when receiver is nil.
+func (c *Config) GetFieldManagerConfig(parentName, fieldName string) *FieldManagerConfig {
+	if c == nil {
+		return nil
+	}
+	if rConfig, found := c.Resources[parentName]; found {
+		if rConfig.ManagedFields != nil {
+			return rConfig.ManagedFields[fieldName]
+		}
+	}
+	return nil
+}
+
+// GetParentResourceName searches all resources' managed fields maps and
+// returns the parent resource name for the given managed field name, or empty
+// string when not found. Nil-safe: returns "" when receiver is nil.
+func (c *Config) GetParentResourceName(fieldName string) string {
+	if c == nil {
+		return ""
+	}
+	for resName, rConfig := range c.Resources {
+		if rConfig.ManagedFields != nil {
+			if _, found := rConfig.ManagedFields[fieldName]; found {
+				return resName
+			}
+		}
+	}
+	return ""
+}
+
+// IsManagedField returns true if the given resource name appears in any
+// parent's managed fields map. Nil-safe: returns false when receiver is nil.
+func (c *Config) IsManagedField(resName string) bool {
+	if c == nil {
+		return false
+	}
+	for _, rConfig := range c.Resources {
+		if rConfig.ManagedFields != nil {
+			if _, found := rConfig.ManagedFields[resName]; found {
+				return true
+			}
 		}
 	}
 	return false
@@ -814,4 +919,260 @@ func (rc *ResourceConfig) GetFieldConfig(subject string) *FieldConfig {
 		}
 	}
 	return nil
+}
+
+// InferManagedFieldOperations scans all resources' managed fields and, for
+// each one, attempts to find matching API operations in the SDK using naming
+// conventions. When a match is found and no explicit operations entry already
+// exists, it populates cfg.Operations with the inferred binding.
+//
+// Naming conventions tried (for parent "Foo" and managed field "Bar"):
+//
+//	Create: Put{Foo}{Bar}, Create{Foo}{Bar}, Set{Foo}{Bar}
+//	Delete: Delete{Foo}{Bar}, Remove{Foo}{Bar}
+//	Get:    Get{Foo}{Bar}, Describe{Foo}{Bar}
+//
+// This method is idempotent — explicit entries in cfg.Operations are never
+// overwritten.
+func (c *Config) InferManagedFieldOperations(sdkOperations map[string]struct{}) {
+	if c == nil {
+		return
+	}
+	if c.Operations == nil {
+		c.Operations = make(map[string]OperationConfig)
+	}
+
+	for parentName, resCfg := range c.Resources {
+		if len(resCfg.ManagedFields) == 0 {
+			continue
+		}
+		for mfName := range resCfg.ManagedFields {
+			c.inferManagedFieldOps(parentName, mfName, sdkOperations)
+		}
+	}
+}
+
+// inferManagedFieldOps infers create, delete, and get operation bindings for a
+// single managed field by probing the SDK operation set with common naming
+// patterns.
+func (c *Config) inferManagedFieldOps(parentName, fieldName string, sdkOps map[string]struct{}) {
+	suffix := parentName + fieldName
+
+	// Create operation candidates (order = preference)
+	createPrefixes := []string{"Put", "Create", "Set"}
+	for _, prefix := range createPrefixes {
+		candidate := prefix + suffix
+		if _, exists := sdkOps[candidate]; exists {
+			if !c.hasOperationBinding(candidate) {
+				c.Operations[candidate] = OperationConfig{
+					ResourceName:  StringArray{fieldName},
+					OperationType: StringArray{"create"},
+				}
+			}
+			break
+		}
+	}
+
+	// Delete operation candidates
+	deletePrefixes := []string{"Delete", "Remove"}
+	for _, prefix := range deletePrefixes {
+		candidate := prefix + suffix
+		if _, exists := sdkOps[candidate]; exists {
+			if !c.hasOperationBinding(candidate) {
+				c.Operations[candidate] = OperationConfig{
+					ResourceName:  StringArray{fieldName},
+					OperationType: StringArray{"delete"},
+				}
+			}
+			break
+		}
+	}
+
+	// Get operation candidates
+	getPrefixes := []string{"Get", "Describe"}
+	for _, prefix := range getPrefixes {
+		candidate := prefix + suffix
+		if _, exists := sdkOps[candidate]; exists {
+			if !c.hasOperationBinding(candidate) {
+				c.Operations[candidate] = OperationConfig{
+					ResourceName:  StringArray{fieldName},
+					OperationType: StringArray{"get"},
+				}
+			}
+			break
+		}
+	}
+}
+
+// hasOperationBinding returns true if the given operation ID already has an
+// entry in cfg.Operations with both resource_name and operation_type set.
+func (c *Config) hasOperationBinding(opID string) bool {
+	opCfg, exists := c.Operations[opID]
+	if !exists {
+		return false
+	}
+	return len(opCfg.ResourceName) > 0 && len(opCfg.OperationType) > 0
+}
+
+// InferManagedFieldPrimaryKeys examines each managed field and, if it does
+// not already have an explicit is_primary_key field, injects one derived from
+// the parent's primary key. The injected field carries:
+//
+//   - is_primary_key: true
+//   - go_tag: json:"-"          (hidden from JSON — value is copied from parent)
+//   - compare.is_ignored: true  (prevents spurious drift detection)
+//
+// The original SDK field name is resolved by reverse-looking up the parent's
+// renames. For example, if the parent BackupVault renames BackupVaultName →
+// Name, the managed field gets a field config keyed "BackupVaultName".
+//
+// When no explicit is_primary_key is set on the parent, the heuristic falls
+// back to {ParentName}Name and {ParentName}Id patterns.
+func (c *Config) InferManagedFieldPrimaryKeys() {
+	if c == nil {
+		return
+	}
+	for parentName, resCfg := range c.Resources {
+		if len(resCfg.ManagedFields) == 0 {
+			continue
+		}
+		for _, mfCfg := range resCfg.ManagedFields {
+			if mfCfg == nil {
+				continue
+			}
+			if managedFieldHasExplicitPrimaryKey(mfCfg) {
+				continue
+			}
+			origName := resolveParentPrimaryKeyOriginalName(parentName, &resCfg)
+			if origName == "" {
+				continue
+			}
+			injectManagedFieldPrimaryKey(mfCfg, origName)
+		}
+	}
+}
+
+// managedFieldHasExplicitPrimaryKey returns true if the managed field already
+// has a field with is_primary_key: true.
+func managedFieldHasExplicitPrimaryKey(mfCfg *FieldManagerConfig) bool {
+	for _, fc := range mfCfg.Fields {
+		if fc != nil && fc.IsPrimaryKey {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveParentPrimaryKeyOriginalName determines the original SDK field name
+// for the parent resource's primary key. It first checks for an explicit
+// is_primary_key field and reverse-looks up renames to find the original name.
+// If no explicit primary key is configured, it falls back to common naming
+// patterns: {ParentName}Name, {ParentName}Id.
+func resolveParentPrimaryKeyOriginalName(parentName string, resCfg *ResourceConfig) string {
+	// 1. Look for an explicit is_primary_key field
+	var pkFieldName string
+	for fieldName, fc := range resCfg.Fields {
+		if fc != nil && fc.IsPrimaryKey {
+			pkFieldName = fieldName
+			break
+		}
+	}
+
+	if pkFieldName != "" {
+		// Reverse-lookup the original SDK name through renames
+		if resCfg.Renames != nil && resCfg.Renames.Operations != nil {
+			for _, opRenames := range resCfg.Renames.Operations {
+				for origName, renamedTo := range opRenames.InputFields {
+					if renamedTo == pkFieldName {
+						return origName
+					}
+				}
+			}
+		}
+		// No rename found — the field name IS the original SDK name
+		return pkFieldName
+	}
+
+	// 2. Heuristic fallback: common patterns
+	candidates := []string{
+		parentName + "Name",
+		parentName + "Id",
+	}
+	for _, candidate := range candidates {
+		// Check if this candidate appears as a renamed field on the parent
+		if resCfg.Renames != nil && resCfg.Renames.Operations != nil {
+			for _, opRenames := range resCfg.Renames.Operations {
+				for origName := range opRenames.InputFields {
+					if origName == candidate {
+						return candidate
+					}
+				}
+			}
+		}
+		// Also check if it's directly in the parent's fields (unrenamed)
+		for fieldName := range resCfg.Fields {
+			if strings.EqualFold(fieldName, candidate) {
+				return candidate
+			}
+		}
+	}
+
+	return ""
+}
+
+// injectManagedFieldPrimaryKey adds the primary key field config to the
+// managed field with the standard settings for a parent-derived primary key.
+func injectManagedFieldPrimaryKey(mfCfg *FieldManagerConfig, origFieldName string) {
+	if mfCfg.Fields == nil {
+		mfCfg.Fields = make(map[string]*FieldConfig)
+	}
+	goTag := `json:"-"`
+	mfCfg.Fields[origFieldName] = &FieldConfig{
+		IsPrimaryKey: true,
+		GoTag:        &goTag,
+		Compare: &CompareFieldConfig{
+			IsIgnored: true,
+		},
+	}
+}
+
+// NormalizeManagedFields walks all resources and promotes field-level
+// `manager` configs into the resource's ManagedFields map. This allows users
+// to define managed fields inline:
+//
+//	resources:
+//	  BackupVault:
+//	    fields:
+//	      AccessPolicy:
+//	        manager:
+//	          hooks: ...
+//
+// After normalization, the above is equivalent to:
+//
+//	resources:
+//	  BackupVault:
+//	    managed_fields:
+//	      AccessPolicy:
+//	        hooks: ...
+//
+// This method is idempotent and should be called before any code generation.
+func (c *Config) NormalizeManagedFields() {
+	if c == nil {
+		return
+	}
+	for resName, resCfg := range c.Resources {
+		for fieldName, fc := range resCfg.Fields {
+			if fc == nil || fc.Manager == nil {
+				continue
+			}
+			if resCfg.ManagedFields == nil {
+				resCfg.ManagedFields = make(map[string]*FieldManagerConfig)
+			}
+			resCfg.ManagedFields[fieldName] = fc.Manager
+			// Remove the field from the parent's Fields map — it will be
+			// re-injected as a synthesized spec field during model building.
+			delete(resCfg.Fields, fieldName)
+		}
+		c.Resources[resName] = resCfg
+	}
 }

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -1,0 +1,248 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"testing"
+)
+
+// opBinding describes an expected operation binding after inference.
+type opBinding struct {
+	opID    string
+	resName string
+	opType  string
+	isBound bool // true = should exist, false = should NOT exist
+}
+
+func TestInferManagedFieldOps(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentName string
+		fieldName  string
+		sdkOps     []string
+		// Pre-existing operation bindings (simulates explicit user config)
+		existing map[string]OperationConfig
+		expect   []opBinding
+	}{
+		{
+			name:       "standard {Verb}{Parent}{Field} pattern",
+			parentName: "BackupVault",
+			fieldName:  "LockConfiguration",
+			sdkOps: []string{
+				"PutBackupVaultLockConfiguration",
+				"DeleteBackupVaultLockConfiguration",
+				"GetBackupVaultLockConfiguration",
+			},
+			expect: []opBinding{
+				{"PutBackupVaultLockConfiguration", "LockConfiguration", "create", true},
+				{"DeleteBackupVaultLockConfiguration", "LockConfiguration", "delete", true},
+				{"GetBackupVaultLockConfiguration", "LockConfiguration", "get", true},
+			},
+		},
+		{
+			name:       "Put preferred over Create",
+			parentName: "BackupVault",
+			fieldName:  "AccessPolicy",
+			sdkOps: []string{
+				"PutBackupVaultAccessPolicy",
+				"CreateBackupVaultAccessPolicy",
+				"DeleteBackupVaultAccessPolicy",
+			},
+			expect: []opBinding{
+				{"PutBackupVaultAccessPolicy", "AccessPolicy", "create", true},
+				{"CreateBackupVaultAccessPolicy", "", "", false},
+			},
+		},
+		{
+			name:       "fallback to {Verb}{Field} without parent",
+			parentName: "BackupVault",
+			fieldName:  "Notifications",
+			sdkOps: []string{
+				"PutNotifications",
+				"DeleteNotifications",
+				"GetNotifications",
+			},
+			expect: []opBinding{
+				{"PutNotifications", "Notifications", "create", true},
+				{"DeleteNotifications", "Notifications", "delete", true},
+				{"GetNotifications", "Notifications", "get", true},
+			},
+		},
+		{
+			name:       "singular form: Tags -> Tag for TagResource/UntagResource",
+			parentName: "BackupVault",
+			fieldName:  "Tags",
+			sdkOps: []string{
+				"TagResource",
+				"UntagResource",
+				"ListTags",
+			},
+			expect: []opBinding{
+				{"TagResource", "Tags", "create", true},
+				{"UntagResource", "Tags", "delete", true},
+				{"ListTags", "Tags", "get", true},
+			},
+		},
+		{
+			name:       "generic Resource suffix as last resort",
+			parentName: "MyParent",
+			fieldName:  "SomeField",
+			sdkOps: []string{
+				"CreateResource",
+				"DeleteResource",
+				"GetResource",
+			},
+			expect: []opBinding{
+				{"CreateResource", "SomeField", "create", true},
+				{"DeleteResource", "SomeField", "delete", true},
+				{"GetResource", "SomeField", "get", true},
+			},
+		},
+		{
+			name:       "{Parent}{Field} preferred over {Field} only",
+			parentName: "BackupVault",
+			fieldName:  "Notifications",
+			sdkOps: []string{
+				"PutBackupVaultNotifications",
+				"PutNotifications",
+				"DeleteBackupVaultNotifications",
+				"DeleteNotifications",
+			},
+			expect: []opBinding{
+				{"PutBackupVaultNotifications", "Notifications", "create", true},
+				{"PutNotifications", "", "", false},
+				{"DeleteBackupVaultNotifications", "Notifications", "delete", true},
+				{"DeleteNotifications", "", "", false},
+			},
+		},
+		{
+			name:       "explicit binding not overwritten",
+			parentName: "BackupVault",
+			fieldName:  "AccessPolicy",
+			sdkOps: []string{
+				"PutBackupVaultAccessPolicy",
+				"DeleteBackupVaultAccessPolicy",
+			},
+			existing: map[string]OperationConfig{
+				"PutBackupVaultAccessPolicy": {
+					ResourceName:  StringArray{"CustomName"},
+					OperationType: StringArray{"create"},
+				},
+			},
+			expect: []opBinding{
+				{"PutBackupVaultAccessPolicy", "CustomName", "create", true},
+				{"DeleteBackupVaultAccessPolicy", "AccessPolicy", "delete", true},
+			},
+		},
+		{
+			name:       "no matching ops produces no bindings",
+			parentName: "BackupVault",
+			fieldName:  "LockConfiguration",
+			sdkOps: []string{
+				"CreateBucket",
+				"DeleteBucket",
+			},
+			expect: []opBinding{},
+		},
+		{
+			name:       "partial match infers what it can",
+			parentName: "BackupVault",
+			fieldName:  "LockConfiguration",
+			sdkOps: []string{
+				"PutBackupVaultLockConfiguration",
+				"DeleteBackupVaultLockConfiguration",
+			},
+			expect: []opBinding{
+				{"PutBackupVaultLockConfiguration", "LockConfiguration", "create", true},
+				{"DeleteBackupVaultLockConfiguration", "LockConfiguration", "delete", true},
+			},
+		},
+		{
+			name:       "Get preferred over Describe",
+			parentName: "BackupVault",
+			fieldName:  "Policy",
+			sdkOps: []string{
+				"GetBackupVaultPolicy",
+				"DescribeBackupVaultPolicy",
+			},
+			expect: []opBinding{
+				{"GetBackupVaultPolicy", "Policy", "get", true},
+				{"DescribeBackupVaultPolicy", "", "", false},
+			},
+		},
+		{
+			name:       "List works as get fallback",
+			parentName: "MyResource",
+			fieldName:  "Tags",
+			sdkOps: []string{
+				"ListTags",
+			},
+			expect: []opBinding{
+				{"ListTags", "Tags", "get", true},
+			},
+		},
+		{
+			name:       "non-plural field skips singular candidates",
+			parentName: "BackupVault",
+			fieldName:  "AccessPolicy",
+			sdkOps: []string{
+				"PutBackupVaultAccessPolicy",
+				"DeleteBackupVaultAccessPolicy",
+			},
+			expect: []opBinding{
+				{"PutBackupVaultAccessPolicy", "AccessPolicy", "create", true},
+				{"DeleteBackupVaultAccessPolicy", "AccessPolicy", "delete", true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Operations: make(map[string]OperationConfig),
+			}
+			for k, v := range tt.existing {
+				cfg.Operations[k] = v
+			}
+
+			sdkOps := make(map[string]struct{}, len(tt.sdkOps))
+			for _, op := range tt.sdkOps {
+				sdkOps[op] = struct{}{}
+			}
+
+			cfg.inferManagedFieldOps(tt.parentName, tt.fieldName, sdkOps)
+
+			for _, exp := range tt.expect {
+				op, exists := cfg.Operations[exp.opID]
+				if exp.isBound {
+					if !exists {
+						t.Errorf("expected %q to be bound, but it was not", exp.opID)
+						continue
+					}
+					if len(op.ResourceName) != 1 || op.ResourceName[0] != exp.resName {
+						t.Errorf("%q: resource_name = %v, want [%s]", exp.opID, op.ResourceName, exp.resName)
+					}
+					if len(op.OperationType) != 1 || op.OperationType[0] != exp.opType {
+						t.Errorf("%q: operation_type = %v, want [%s]", exp.opID, op.OperationType, exp.opType)
+					}
+				} else {
+					if exists && len(op.ResourceName) > 0 && len(op.OperationType) > 0 {
+						t.Errorf("expected %q to NOT be bound, but got resource_name=%v operation_type=%v",
+							exp.opID, op.ResourceName, op.OperationType)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/generate/ack/apis.go
+++ b/pkg/generate/ack/apis.go
@@ -40,6 +40,9 @@ var (
 	apisCopyPaths = []string{}
 	apisFuncMap   = ttpl.FuncMap{
 		"Join": strings.Join,
+		"IsManagedField": func(r *ackmodel.CRD) bool {
+			return r.Config().IsManagedField(r.Names.Original)
+		},
 	}
 )
 

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -14,6 +14,7 @@
 package ack
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+	"github.com/aws-controllers-k8s/pkg/names"
 )
 
 var (
@@ -58,12 +60,57 @@ var (
 		"pkg/resource/sdk_update_custom.go.tpl",
 		"pkg/resource/sdk_update_set_attributes.go.tpl",
 		"pkg/resource/sdk_update_not_implemented.go.tpl",
+		"pkg/resource/sdk_update_field_manager_sync.go.tpl",
+		"pkg/resource/sdk_delete_field_manager_sync.go.tpl",
+		"pkg/resource/sdk_find_field_manager_get.go.tpl",
+		"pkg/resource/sdk_create_field_manager_requeue.go.tpl",
+		"pkg/resource/field_manager_singleton.go.tpl",
 	}
 	controllerCopyPaths = []string{}
 	controllerFuncMap   = ttpl.FuncMap{
 		"ToLower": strings.ToLower,
 		"TrimPrefix": func(s string, prefix string) string {
 			return strings.TrimPrefix(s, prefix)
+		},
+		"HasPrefix": func(s string, prefix string) bool {
+			return strings.HasPrefix(s, prefix)
+		},
+		// ManagedFieldPrimaryKeyField returns the camel-cased name of the
+		// field marked is_primary_key on the managed field CRD. Used by the
+		// key() function in the generated manager.
+		"ManagedFieldPrimaryKeyField": func(r *ackmodel.CRD) (string, error) {
+			f, err := r.GetPrimaryKeyField()
+			if err != nil {
+				return "", fmt.Errorf("managed field %s: %w", r.Names.Original, err)
+			}
+			if f == nil {
+				return "", fmt.Errorf("managed field %s has no is_primary_key field", r.Names.Original)
+			}
+			return f.Names.Camel, nil
+		},
+		"IsManagedField": func(r *ackmodel.CRD) bool {
+			return r.Config().IsManagedField(r.Names.Original)
+		},
+		// FieldManagerInfos returns a slice of FieldManagerInfo for each
+		// managed field defined under the given CRD. Returns nil if the CRD
+		// has no managed fields.
+		"FieldManagerInfos": func(r *ackmodel.CRD) []FieldManagerInfo {
+			managedFields := r.Config().GetManagedFields(r.Names.Original)
+			if len(managedFields) == 0 {
+				return nil
+			}
+			var infos []FieldManagerInfo
+			for mfName, mfCfg := range managedFields {
+				if mfCfg == nil {
+					continue
+				}
+				snakeName := names.New(mfName).Snake
+				infos = append(infos, FieldManagerInfo{
+					FieldPath:   "Spec." + mfName,
+					PackageName: snakeName,
+				})
+			}
+			return infos
 		},
 		"Dereference": func(s *string) string {
 			return *s
@@ -234,6 +281,74 @@ func Controller(
 	tplStart := time.Now()
 	metaVars := m.MetaVars()
 
+	// Build a lookup of CRDs by name so ParentKind/ParentPrimaryKeyAssign
+	// can resolve the parent CRD.
+	crdsByName := make(map[string]*ackmodel.CRD, len(crds))
+	for _, crd := range crds {
+		crdsByName[crd.Names.Original] = crd
+	}
+
+	// ParentKind returns the Go Kind name of the parent CRD for a
+	// managed field (e.g. "BackupVault" for "AccessPolicy").
+	controllerFuncMap["ParentKind"] = func(r *ackmodel.CRD) (string, error) {
+		parentName := r.Config().GetParentResourceName(r.Names.Original)
+		if parentName == "" {
+			return "", fmt.Errorf("ParentKind: no parent resource for %s", r.Names.Original)
+		}
+		parentCRD, ok := crdsByName[parentName]
+		if !ok {
+			return "", fmt.Errorf("ParentKind: parent CRD %s not found", parentName)
+		}
+		return parentCRD.Kind, nil
+	}
+
+	// ManagedFieldPath returns the dotted Spec path on the parent that
+	// holds this managed field's injected Spec (always "Spec.<FieldName>").
+	controllerFuncMap["ManagedFieldPath"] = func(r *ackmodel.CRD) string {
+		return "Spec." + r.Names.Original
+	}
+
+	// ParentPrimaryKeyAssign emits the Go assignment that copies the
+	// parent's primary key into the managed field's primary key field.
+	// Registered here (not in the static map) because it needs crdsByName.
+	//
+	// Special case: if the managed field's primary key field name contains
+	// "arn" (case-insensitive), the value is sourced from the parent's
+	// Status.ACKResourceMetadata.ARN rather than from the parent's spec
+	// primary key. This handles operations like TagResource/UntagResource
+	// that identify resources by ARN rather than by name.
+	controllerFuncMap["ParentPrimaryKeyAssign"] = func(r *ackmodel.CRD, parentKind string, koVar string) (string, error) {
+		subPK, err := r.GetPrimaryKeyField()
+		if err != nil {
+			return "", fmt.Errorf("sub-resource %s: %w", r.Names.Original, err)
+		}
+		if subPK == nil {
+			return "", fmt.Errorf("sub-resource %s has no is_primary_key field", r.Names.Original)
+		}
+		// If the sub-resource PK field name contains "arn", source the value
+		// from the parent's Status.ACKResourceMetadata.ARN.
+		if strings.Contains(strings.ToLower(subPK.Names.Original), "arn") {
+			return fmt.Sprintf(
+				"\tif parent.Status.ACKResourceMetadata != nil && parent.Status.ACKResourceMetadata.ARN != nil {\n"+
+					"\t\tarn := string(*parent.Status.ACKResourceMetadata.ARN)\n"+
+					"\t\t%s.Spec.%s = &arn\n"+
+					"\t}",
+				koVar, subPK.Names.Camel), nil
+		}
+		parentCRD, ok := crdsByName[parentKind]
+		if !ok {
+			return "", fmt.Errorf("ParentPrimaryKeyAssign: parent CRD %s not found", parentKind)
+		}
+		parentPK, err := parentCRD.GetPrimaryKeyField()
+		if err != nil {
+			return "", fmt.Errorf("parent %s: %w", parentKind, err)
+		}
+		if parentPK == nil {
+			return "", fmt.Errorf("parent %s has no is_primary_key field", parentKind)
+		}
+		return fmt.Sprintf("\t%s.Spec.%s = parent.Spec.%s", koVar, subPK.Names.Camel, parentPK.Names.Camel), nil
+	}
+
 	// Hook code can reference a template path, and we can look up the template
 	// in any of our base paths...
 	controllerFuncMap["Hook"] = func(r *ackmodel.CRD, hookID string) (string, error) {
@@ -269,13 +384,44 @@ func Controller(
 		"tags.go.tpl",
 	}
 	for _, crd := range crds {
+		isManagedField := crd.Config().IsManagedField(crd.Names.Original)
+
+		// Determine output base path: managed fields nest under parent
+		var outBase string
+		if isManagedField {
+			parentName := crd.Config().GetParentResourceName(crd.Names.Original)
+			parentSnake := names.New(parentName).Snake
+			outBase = filepath.Join("pkg/resource", parentSnake, crd.Names.Snake)
+		} else {
+			outBase = filepath.Join("pkg/resource", crd.Names.Snake)
+		}
+
 		for _, target := range targets {
 			// skip adding "tags.go.tpl" file if tagging is ignored for a crd
 			if target == "tags.go.tpl" && crd.Config().TagsAreIgnored(crd.Names.Original) {
 				continue
 			}
-			outPath := filepath.Join("pkg/resource", crd.Names.Snake, strings.TrimSuffix(target, ".tpl"))
+			// Managed fields only need delta.go and sdk.go — the resource
+			// struct, resourceManager, and all other scaffolding are
+			// generated directly in the field manager file.
+			if isManagedField && target != "delta.go.tpl" && target != "sdk.go.tpl" {
+				continue
+			}
+			outPath := filepath.Join(outBase, strings.TrimSuffix(target, ".tpl"))
 			tplPath := filepath.Join("pkg/resource", target)
+			crdVars := &templateCRDVars{
+				metaVars,
+				m.SDKAPI,
+				crd,
+			}
+			if err = ts.Add(outPath, tplPath, crdVars); err != nil {
+				return nil, err
+			}
+		}
+		// Generate manager.go for all managed fields
+		if isManagedField {
+			outPath := filepath.Join(outBase, "manager.go")
+			tplPath := filepath.Join("pkg/resource", "field_manager.go.tpl")
 			crdVars := &templateCRDVars{
 				metaVars,
 				m.SDKAPI,
@@ -306,6 +452,11 @@ func Controller(
 	// using Map to implement the Set
 	referencedServiceNamesMap := make(map[string]struct{})
 	for _, crd := range crds {
+		// Exclude managed field packages from main.go imports — they are
+		// imported by the parent resource's hooks, not by the main controller.
+		if crd.Config().IsManagedField(crd.Names.Original) {
+			continue
+		}
 		snakeCasedCRDNames = append(snakeCasedCRDNames, crd.Names.Snake)
 		for _, serviceName := range crd.ReferencedServiceNames() {
 			referencedServiceNamesMap[serviceName] = struct{}{}
@@ -354,4 +505,14 @@ type templateConfigVars struct {
 	templateset.MetaVars
 	GeneratorConfig    *ackgenconfig.Config
 	ServiceAccountName string
+}
+
+// FieldManagerInfo holds the information needed by templates to generate
+// field manager sync code in the parent resource's sdkUpdate function.
+type FieldManagerInfo struct {
+	// FieldPath is the parent spec field path (e.g. "Spec.Policies")
+	FieldPath string
+	// PackageName is the snake_case package name for the sub-resource manager
+	// (e.g. "role_policies")
+	PackageName string
 }

--- a/pkg/generate/ack/hook.go
+++ b/pkg/generate/ack/hook.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	ttpl "text/template"
 
+	ackgenconfig "github.com/aws-controllers-k8s/code-generator/pkg/config"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 	ackutil "github.com/aws-controllers-k8s/code-generator/pkg/util"
 )
@@ -170,11 +171,28 @@ func ResourceHookCode(
 	if c == nil {
 		return "", nil
 	}
-	rConfig, ok := c.Resources[resourceName]
-	if !ok {
+	// Look up hooks from top-level resources first, then fall back to
+	// managed fields. Managed field CRDs have Names.Original set to the
+	// internal name (e.g. "RolePolicies") which appears as a key in the
+	// parent resource's ManagedFields map, not in c.Resources directly.
+	var hooks map[string]*ackgenconfig.HooksConfig
+	if rConfig, ok := c.Resources[resourceName]; ok {
+		hooks = rConfig.Hooks
+	} else {
+		// Search managed fields
+		for _, rConfig := range c.Resources {
+			if rConfig.ManagedFields != nil {
+				if mfCfg, found := rConfig.ManagedFields[resourceName]; found {
+					hooks = mfCfg.Hooks
+					break
+				}
+			}
+		}
+	}
+	if hooks == nil {
 		return "", nil
 	}
-	hook, ok := rConfig.Hooks[hookID]
+	hook, ok := hooks[hookID]
 	if !ok {
 		return "", nil
 	}

--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -117,6 +117,11 @@ func Release(
 
 	reconcileResources := make([]string, 0)
 	for _, crd := range crds {
+		// Managed fields are internal implementation details — exclude from
+		// Helm values reconcile list and all user-facing release artifacts.
+		if crd.Config().IsManagedField(crd.Names.Original) {
+			continue
+		}
 		reconcileResources = append(reconcileResources, crd.Kind)
 	}
 

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -189,6 +189,23 @@ func CompareResource(
 		case "blob":
 			// We already handled the case of blobs above, so we can skip it here.
 		case "structure":
+			// For sub-resource spec fields (synthetic injected types), delegate
+			// to the sub-resource package's NewSpecDelta instead of recursing
+			// into the struct — the struct has no SDK shape members so
+			// CompareStruct would produce an empty block.
+			if specField.IsManagedFieldSpec {
+				subPkgName := names.New(specField.Names.Original).Snake
+				out += fmt.Sprintf(
+					"%s\tif len(%s.NewSpecDelta(%s, %s).Differences) > 0 {\n",
+					indent, subPkgName, firstResAdaptedVarName, secondResAdaptedVarName,
+				)
+				out += fmt.Sprintf(
+					"%s\t\t%s.Add(\"%s\", %s, %s)\n",
+					indent, deltaVarName, fieldPath, firstResAdaptedVarName, secondResAdaptedVarName,
+				)
+				out += fmt.Sprintf("%s\t}\n", indent)
+				break
+			}
 			// Recurse through all the struct's fields and subfields, building
 			// nested conditionals and calls to `delta.Add()`...
 			structOut, err := CompareStruct(

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -599,6 +599,8 @@ func setResourceReadMany(
 	opening, closing, flIndentLvl := generateForRangeLoops(&op.OutputRef, pathToShape, sourceVarName, elemVarName, indentLevel)
 	innerForIndent := strings.Repeat("\t", flIndentLvl)
 	out += opening
+	// Prevent unused variable error when all fields in the loop are ignored
+	out += fmt.Sprintf("%s_ = %s\n", innerForIndent, elemVarName)
 
 	for memberIndex, memberName := range sourceElemShape.MemberNames() {
 		sourceMemberShapeRef := sourceElemShape.MemberRefs[memberName]

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -1162,6 +1162,7 @@ func TestSetResource_ECR_Repository_ReadMany(t *testing.T) {
 	expected := `
 	found := false
 	for _, elem := range resp.Repositories {
+		_ = elem
 		if elem.CreatedAt != nil {
 			ko.Status.CreatedAt = &metav1.Time{*elem.CreatedAt}
 		} else {
@@ -1442,6 +1443,7 @@ func TestSetResource_RDS_DBSubnetGroup_ReadMany(t *testing.T) {
 	expected := `
 	found := false
 	for _, elem := range resp.DBSubnetGroups {
+		_ = elem
 		if elem.DBSubnetGroupArn != nil {
 			if ko.Status.ACKResourceMetadata == nil {
 				ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -2066,6 +2068,7 @@ func TestSetResource_EC2_Instance_Create(t *testing.T) {
 	expected := `
 	found := false
 	for _, elem := range resp.Instances {
+		_ = elem
 		if elem.AmiLaunchIndex != nil {
 			amiLaunchIndexCopy := int64(*elem.AmiLaunchIndex)
 			ko.Status.AMILaunchIndex = &amiLaunchIndexCopy
@@ -2594,6 +2597,7 @@ func TestSetResource_EC2_Instance_ReadMany(t *testing.T) {
 	found := false
 	for _, iter0 := range resp.Reservations {
 		for _, elem := range iter0.Instances {
+			_ = elem
 			if elem.AmiLaunchIndex != nil {
 				amiLaunchIndexCopy := int64(*elem.AmiLaunchIndex)
 				ko.Status.AMILaunchIndex = &amiLaunchIndexCopy
@@ -5195,6 +5199,7 @@ func TestSetResource_ELBv2_IgnoreSetFrom(t *testing.T) {
 	expected := `
 	found := false
 	for _, elem := range resp.Rules {
+		_ = elem
 		if elem.Actions != nil {
 			f0 := []*svcapitypes.Action{}
 			for _, f0iter := range elem.Actions {

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1378,7 +1378,13 @@ func setSDKForSlice(
 	}
 	if targetShape.MemberRef.Shape.IsEnum() {
 		out += fmt.Sprintf("%s\t%s = string(*%s)\n", indent, elemVarName, iterVarName)
-		elemVarName = fmt.Sprintf("svcsdktypes.%s(%s)", targetShape.MemberRef.ShapeName, elemVarName)
+		// Use OriginalShapeName if available to avoid stutter-removal stripping
+		// the type prefix (e.g. "BackupVaultEvent" → "VaultEvent").
+		memberShapeName := targetShape.MemberRef.ShapeName
+		if targetShape.MemberRef.Shape.OriginalShapeName != "" {
+			memberShapeName = targetShape.MemberRef.Shape.OriginalShapeName
+		}
+		elemVarName = fmt.Sprintf("svcsdktypes.%s(%s)", memberShapeName, elemVarName)
 	} else {
 		containerOut, err := setSDKForContainer(
 			cfg, r,

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -62,6 +62,13 @@ type Field struct {
 	// MemberFields is a map, keyed by the *renamed, cleaned, camel-cased name* of
 	// member fields when this Field is a struct type.
 	MemberFields map[string]*Field
+
+	// IsManagedFieldSpec marks a Field that was synthesized by the code
+	// generator to expose a managed field's Spec struct on the parent
+	// resource. The Field's ShapeRef is a hand-built, memberless shape
+	// carrying only the source cardinality (structure/list/map), and
+	// downstream field-processing walks should skip it.
+	IsManagedFieldSpec bool
 }
 
 // GetDocumentation returns a string containing the field's

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -86,6 +86,11 @@ func (m *Model) crdNames() []string {
 
 	crds, _ := m.GetCRDs()
 	for _, crd := range crds {
+		// Managed fields are internal implementation details and should not
+		// appear in CRD kustomization, RBAC, or any user-facing config.
+		if m.cfg.IsManagedField(crd.Names.Original) {
+			continue
+		}
 		crdConfigs = append(crdConfigs, strings.ToLower(crd.Plural))
 	}
 
@@ -472,6 +477,13 @@ func (m *Model) GetCRDs() ([]*CRD, error) {
 	sort.Slice(crds, func(i, j int) bool {
 		return crds[i].Names.Camel < crds[j].Names.Camel
 	})
+	// Inject each managed field's Spec type onto its parent CRD as a
+	// synthesized field. This happens after every CRD has been built so we
+	// can resolve the managed field's Kind, and before processFields so
+	// downstream validation can find the parent field.
+	if err := m.injectManagedFieldSpecs(crds); err != nil {
+		return nil, err
+	}
 	// This is the place that we build out the CRD.Fields map with
 	// `pkg/model.Field` objects that represent the non-top-level Spec and
 	// Status fields.
@@ -1054,6 +1066,12 @@ func (m *Model) processTopLevelField(
 	crd *CRD,
 	field *Field,
 ) error {
+	// Synthetic sub-resource spec fields carry a hand-built memberless
+	// shape — no nested-field walking to do, and the downstream helpers
+	// aren't designed for it.
+	if field.IsManagedFieldSpec {
+		return nil
+	}
 	if field.ShapeRef == nil && !field.IsReference() && (field.FieldConfig == nil || !field.FieldConfig.IsAttribute) {
 		fmt.Printf(
 			"WARNING: Field %s:%s has nil ShapeRef and is not defined as an Attribute-based Field!\n",
@@ -1319,4 +1337,71 @@ func New(
 		return nil, err
 	}
 	return m, nil
+}
+
+// injectManagedFieldSpecs walks each configured managed field and synthesizes
+// a field on its parent CRD's Spec carrying the managed field's Spec struct
+// type. The field name is the managed field's key under managed_fields, which
+// is also the parent field name (Spec.<key>) and what the mapper's "from"
+// paths reference.
+//
+// User-declared parent fields always win: if the parent already has a
+// SpecField at the target key, this is a no-op for that managed field.
+func (m *Model) injectManagedFieldSpecs(crds []*CRD) error {
+	crdByName := make(map[string]*CRD, len(crds))
+	for _, crd := range crds {
+		crdByName[crd.Names.Original] = crd
+	}
+	for parentName, resCfg := range m.cfg.Resources {
+		if len(resCfg.ManagedFields) == 0 {
+			continue
+		}
+		parentCRD, ok := crdByName[parentName]
+		if !ok {
+			continue
+		}
+		for mfName, mfCfg := range resCfg.ManagedFields {
+			if mfCfg == nil {
+				continue
+			}
+			mfCRD, ok := crdByName[mfName]
+			if !ok {
+				continue
+			}
+			// Don't overwrite a field the user has already declared on
+			// the parent (either via `fields:` or via the SDK shape).
+			if _, exists := parentCRD.SpecFields[mfName]; exists {
+				continue
+			}
+			injectManagedFieldSpec(parentCRD, mfName, mfCRD)
+		}
+	}
+	return nil
+}
+
+// injectManagedFieldSpec stamps a synthetic parent-side field whose Go type is
+// *<ManagedFieldKind>Spec (singleton). The ShapeRef is hand-built and carries
+// just enough type info for downstream code while being ignored by the
+// nested-field walker.
+func injectManagedFieldSpec(parent *CRD, fieldKey string, managedField *CRD) {
+	fieldNames := names.New(fieldKey)
+	specShapeName := managedField.Kind + "Spec"
+	shape := &awssdkmodel.Shape{
+		ShapeName:  specShapeName,
+		Type:       "structure",
+		MemberRefs: map[string]*awssdkmodel.ShapeRef{},
+	}
+	shapeRef := &awssdkmodel.ShapeRef{ShapeName: specShapeName, Shape: shape}
+	f := &Field{
+		CRD:                parent,
+		Names:              fieldNames,
+		Path:               fieldNames.Camel,
+		ShapeRef:           shapeRef,
+		GoType:             "*" + specShapeName,
+		GoTypeElem:         specShapeName,
+		GoTypeWithPkgName:  "*" + specShapeName,
+		IsManagedFieldSpec: true,
+	}
+	parent.SpecFields[fieldNames.Original] = f
+	parent.Fields[fieldNames.Camel] = f
 }

--- a/pkg/model/sdk_api.go
+++ b/pkg/model/sdk_api.go
@@ -83,6 +83,25 @@ func (a *SDKAPI) GetOperationMap(cfg *ackgenconfig.Config) (*OperationMap, error
 	if a.opMap != nil {
 		return a.opMap, nil
 	}
+
+	// Normalize field-level manager configs into the ManagedFields map
+	// before any inference runs.
+	cfg.NormalizeManagedFields()
+
+	// Auto-infer operation bindings for managed fields before building the
+	// operation map. This populates cfg.Operations entries for managed field
+	// CRUD operations that match SDK naming conventions, so the rest of the
+	// mapping logic picks them up naturally.
+	sdkOps := make(map[string]struct{}, len(a.API.Operations))
+	for opName := range a.API.Operations {
+		sdkOps[opName] = struct{}{}
+	}
+	cfg.InferManagedFieldOperations(sdkOps)
+
+	// Auto-infer primary key fields for managed fields from their parent's
+	// primary key. This avoids repetitive boilerplate in generator.yaml.
+	cfg.InferManagedFieldPrimaryKeys()
+
 	// create an index of Operations by operation types and resource name
 	opMap := OperationMap{}
 	opIDs := make([]string, 0, len(a.API.Operations))
@@ -283,6 +302,11 @@ func (a *SDKAPI) CRDNames(cfg *ackgenconfig.Config) []names.Names {
 	crdNames := []names.Names{}
 	for _, crdName := range crdNameKeys {
 		if cfg.ResourceIsIgnored(crdName) {
+			continue
+		}
+		// Managed fields are internal implementation details and should not
+		// appear in user-facing CRD type definitions.
+		if cfg.IsManagedField(crdName) {
 			continue
 		}
 		crdNames = append(crdNames, names.New(crdName))

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -106,6 +106,7 @@ fi
 
 if ! docker build \
   --quiet="${QUIET}" \
+  --network=host \
   -t "${AWS_SERVICE_DOCKER_IMG}" \
   -f "${DOCKERFILE}" \
   --build-arg service_alias="${AWS_SERVICE}" \

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -11,7 +11,9 @@ import (
 
 {{- end }}
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+{{- if not (IsManagedField .CRD) }}
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+{{- end }}
 )
 
 {{ .CRD.Documentation }}
@@ -58,6 +60,7 @@ type {{ .CRD.Kind }}Status struct {
 }
 
 // {{ .CRD.Kind }} is the Schema for the {{ .CRD.Plural }} API
+{{- if not (IsManagedField .CRD) }}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 {{- range $column := .CRD.AdditionalPrinterColumns }}
@@ -72,13 +75,17 @@ type {{ .CRD.Kind }}Status struct {
 {{- if .CRD.ShortNames }}
 // +kubebuilder:resource:shortName={{ Join .CRD.ShortNames ";" }}
 {{- end }}
+{{- end }}
 type {{ .CRD.Kind }} struct {
+{{- if not (IsManagedField .CRD) }}
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+{{- end }}
 	Spec   {{ .CRD.Kind }}Spec   `json:"spec,omitempty"`
 	Status {{ .CRD.Kind }}Status `json:"status,omitempty"`
 }
 
+{{- if not (IsManagedField .CRD) }}
 // {{ .CRD.Kind }}List contains a list of {{ .CRD.Kind }}
 // +kubebuilder:object:root=true
 type {{ .CRD.Kind }}List struct {
@@ -90,3 +97,4 @@ type {{ .CRD.Kind }}List struct {
 func init() {
 	SchemeBuilder.Register(&{{ .CRD.Kind }}{}, &{{ .CRD.Kind }}List{})
 }
+{{- end }}

--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -8,6 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+{{- $mfInfos := FieldManagerInfos .CRD }}
+{{- range $info := $mfInfos }}
+	{{ $info.PackageName }} "github.com/aws-controllers-k8s/{{ $.ControllerName }}-controller/pkg/resource/{{ $.CRD.Names.Snake }}/{{ $info.PackageName }}"
+{{- end }}
 )
 
 // Hack to avoid import errors during build...

--- a/templates/pkg/resource/field_manager.go.tpl
+++ b/templates/pkg/resource/field_manager.go.tpl
@@ -1,0 +1,146 @@
+{{ template "boilerplate" }}
+
+package {{ .CRD.Names.Snake }}
+
+import (
+	"context"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackageName }}"
+	"github.com/go-logr/logr"
+
+	svcapitypes "github.com/aws-controllers-k8s/{{ .ControllerName }}-controller/apis/{{ .APIVersion }}"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &ackv1alpha1.AWSIdentifiers{}
+)
+
+type resource struct {
+	ko *svcapitypes.{{ .CRD.Kind }}
+}
+
+type resourceManager struct {
+	cfg          ackcfg.Config
+	clientcfg    aws.Config
+	log          logr.Logger
+	metrics      *ackmetrics.Metrics
+	rr           acktypes.Reconciler
+	awsAccountID ackv1alpha1.AWSAccountID
+	awsRegion    ackv1alpha1.AWSRegion
+	sdkapi       *svcsdk.Client
+}
+
+// delta holds the result of comparing desired vs. latest sub-resource items.
+type delta struct {
+	toCreate []*resource
+	toUpdate []*resource
+	toDelete []*resource
+}
+
+// computeDelta performs a key-based diff between the desired and latest
+// sub-resource slices.
+func computeDelta(desired, latest []resource) delta {
+	d := delta{}
+	latestMap := make(map[string]*resource)
+	for i := range latest {
+		latestMap[key(&latest[i])] = &latest[i]
+	}
+
+	desiredMap := make(map[string]bool)
+	for i := range desired {
+		k := key(&desired[i])
+		desiredMap[k] = true
+		if lat, exists := latestMap[k]; !exists {
+			d.toCreate = append(d.toCreate, &desired[i])
+		} else {
+			rd := newResourceDelta(&desired[i], lat)
+			if len(rd.Differences) > 0 {
+				d.toUpdate = append(d.toUpdate, &desired[i])
+			}
+		}
+	}
+
+	for k, lat := range latestMap {
+		if !desiredMap[k] {
+			d.toDelete = append(d.toDelete, lat)
+		}
+	}
+	return d
+}
+
+// NewManager creates a resourceManager using the provided SDK client and
+// metrics recorder.
+func NewManager(
+	sdkapi *svcsdk.Client,
+	metrics *ackmetrics.Metrics,
+) *resourceManager {
+	return &resourceManager{
+		sdkapi:  sdkapi,
+		metrics: metrics,
+	}
+}
+
+// Sync converts the desired and latest parent resources into internal
+// resource slices, computes the diff, and delegates to sync.
+func (rm *resourceManager) Sync(
+	ctx context.Context,
+	desired any,
+	latest any,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.Sync")
+	defer func() {
+		exit(err)
+	}()
+	desiredResources := convertToResources(desired)
+	latestResources := convertToResources(latest)
+	d := computeDelta(desiredResources, latestResources)
+	return rm.sync(ctx, d)
+}
+
+// convertToResources casts the parent into its concrete type and delegates
+// to convertFromParent. Returns nil when the parent has no value at the
+// sub-resource's source field.
+func convertToResources(parent any) []resource {
+	if parent == nil {
+		return nil
+	}
+	v, ok := parent.(*svcapitypes.{{ ParentKind .CRD }})
+	if !ok || v == nil {
+		return nil
+	}
+	if v.{{ ManagedFieldPath .CRD }} == nil {
+		return nil
+	}
+	return convertFromParent(v)
+}
+
+// The singleton implementation (Get, convertFromParent, sync, key) follows.
+{{ template "field_manager_singleton" . }}
+
+// NewSpecDelta returns a delta comparing two {{ .CRD.Kind }}Spec values.
+// The parent resource's delta_pre_compare hook can call this to detect
+// changes in the sub-resource's spec fields without duplicating the
+// comparison logic.
+func NewSpecDelta(
+	a *svcapitypes.{{ .CRD.Kind }}Spec,
+	b *svcapitypes.{{ .CRD.Kind }}Spec,
+) *ackcompare.Delta {
+	var ra, rb *resource
+	if a != nil {
+		ra = &resource{ko: &svcapitypes.{{ .CRD.Kind }}{Spec: *a}}
+	}
+	if b != nil {
+		rb = &resource{ko: &svcapitypes.{{ .CRD.Kind }}{Spec: *b}}
+	}
+	return newResourceDelta(ra, rb)
+}

--- a/templates/pkg/resource/field_manager_singleton.go.tpl
+++ b/templates/pkg/resource/field_manager_singleton.go.tpl
@@ -1,0 +1,71 @@
+{{- define "field_manager_singleton" -}}
+// key returns the primary key for a singleton managed field. There is at
+// most one managed field per parent, so the key is a constant; this causes
+// computeDelta to route value changes through toUpdate instead of
+// toCreate+toDelete (which would wipe the item).
+func key(r *resource) string {
+	_ = r
+	return "_singleton"
+}
+
+// sync reconciles the singleton managed field. Since there can only be one
+// item per parent, computeDelta yields at most one entry in exactly one of
+// {toCreate, toUpdate, toDelete}; no iteration or batching is needed.
+func (rm *resourceManager) sync(ctx context.Context, d delta) error {
+	var err error
+	if len(d.toCreate) > 0 {
+		_, err = rm.sdkCreate(ctx, d.toCreate[0])
+		return err
+	}
+	if len(d.toUpdate) > 0 {
+		_, err = rm.sdkCreate(ctx, d.toUpdate[0])
+		return err
+	}
+	if len(d.toDelete) > 0 {
+		_, err = rm.sdkDelete(ctx, d.toDelete[0])
+		return err
+	}
+	return nil
+}
+
+// Get reads the current state of the managed field from AWS and writes the
+// result back onto the parent's injected spec field.
+func (rm *resourceManager) Get(
+	ctx context.Context,
+	parent *svcapitypes.{{ ParentKind .CRD }},
+) error {
+	// Build a minimal seed carrying only the primary key — do NOT use
+	// convertFromParent here, because that copies the full desired spec
+	// into the seed, which would make latest look identical to desired
+	// even when AWS hasn't applied the write yet.
+	seed := &resource{ko: &svcapitypes.{{ .CRD.Kind }}{}}
+{{ ParentPrimaryKeyAssign .CRD (ParentKind .CRD) "seed.ko" }}
+	found, err := rm.sdkFind(ctx, seed)
+	if err != nil {
+		if err == ackerr.NotFound {
+			parent.{{ ManagedFieldPath .CRD }} = nil
+			return nil
+		}
+		return err
+	}
+	if found == nil {
+		parent.{{ ManagedFieldPath .CRD }} = nil
+		return nil
+	}
+	parent.{{ ManagedFieldPath .CRD }} = &found.ko.Spec
+	return nil
+}
+
+// convertFromParent builds a single managed field instance from the parent.
+// The parent's injected field is copied wholesale into the managed field Spec,
+// then the parent's primary key is written into the managed field's primary
+// key field so the SDK call can identify the resource.
+func convertFromParent(parent *svcapitypes.{{ ParentKind .CRD }}) []resource {
+	ko := &svcapitypes.{{ .CRD.Kind }}{}
+	if parent.{{ ManagedFieldPath .CRD }} != nil {
+		ko.Spec = *parent.{{ ManagedFieldPath .CRD }}
+	}
+{{ ParentPrimaryKeyAssign .CRD (ParentKind .CRD) "ko" }}
+	return []resource{ {ko: ko} }
+}
+{{- end }}

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -24,6 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/{{.ControllerName }}-controller/apis/{{ .APIVersion }}"
+{{- $mfInfos := FieldManagerInfos .CRD }}
+{{- range $info := $mfInfos }}
+	{{ $info.PackageName }} "github.com/aws-controllers-k8s/{{ $.ControllerName }}-controller/pkg/resource/{{ $.CRD.Names.Snake }}/{{ $info.PackageName }}"
+{{- end }}
 )
 
 // Hack to avoid import errors during build...
@@ -38,6 +42,10 @@ var (
 	_ = &reflect.Value{}
 	_ = fmt.Sprintf("")
 	_ = &ackrequeue.NoRequeue{}
+{{- $mfInfos := FieldManagerInfos .CRD }}
+{{- range $info := $mfInfos }}
+	_ = {{ $info.PackageName }}.NewManager
+{{- end }}
 	_ = &aws.Config{}
 )
 
@@ -111,6 +119,7 @@ func (rm *resourceManager) sdkCreate(
 {{- if $hookCode := Hook .CRD "sdk_create_post_set_output" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_create_field_manager_requeue" . }}
 	return &resource{ko}, nil
 }
 
@@ -154,6 +163,7 @@ func (rm *resourceManager) sdkDelete(
 {{- if $hookCode := Hook .CRD "sdk_delete_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_delete_field_manager_sync" . }}
 {{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Delete }}
 	if err = rm.{{ $customMethod }}(ctx, r); err != nil {
 		return nil, err

--- a/templates/pkg/resource/sdk_create_field_manager_requeue.go.tpl
+++ b/templates/pkg/resource/sdk_create_field_manager_requeue.go.tpl
@@ -1,0 +1,23 @@
+{{- /*
+  sdk_create_field_manager_requeue emits a block at the end of sdkCreate
+  that flips ResourceSynced=False when any of the parent's managed fields
+  has a desired value in spec. Managed field writes happen via sdkUpdate
+  (not the parent's create), so a resource with non-empty managed field
+  spec on first apply is not truly synced until a follow-up reconcile.
+  Marking it unsynced forces that follow-up to run promptly.
+*/ -}}
+{{- define "sdk_create_field_manager_requeue" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- if $mfInfos }}
+	// Managed fields (fields managed by separate API operations) are not
+	// applied by the parent's create call. If the user set any of them in
+	// spec, flip ResourceSynced=False so the reconciler loops back
+	// promptly, picks up the delta, and drives the managed field writes
+	// through sdkUpdate.
+{{- range $info := $mfInfos }}
+	if desired.ko.{{ $info.FieldPath }} != nil {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/templates/pkg/resource/sdk_delete_field_manager_sync.go.tpl
+++ b/templates/pkg/resource/sdk_delete_field_manager_sync.go.tpl
@@ -1,0 +1,18 @@
+{{- define "sdk_delete_field_manager_sync" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- if $mfInfos }}
+	// Clean up managed fields before deleting the parent resource.
+	// For each managed field, sync with a nil/empty desired state so all
+	// items are deleted.
+	koCopy := r.ko.DeepCopy()
+{{- range $info := $mfInfos }}
+	koCopy.{{ $info.FieldPath }} = nil
+{{- end }}
+{{- range $info := $mfInfos }}
+	mgr_{{ $info.PackageName }} := {{ $info.PackageName }}.NewManager(rm.sdkapi, rm.metrics)
+	if err = mgr_{{ $info.PackageName }}.Sync(ctx, koCopy, r.ko); err != nil {
+		return nil, err
+	}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/templates/pkg/resource/sdk_find_field_manager_get.go.tpl
+++ b/templates/pkg/resource/sdk_find_field_manager_get.go.tpl
@@ -1,0 +1,9 @@
+{{- define "sdk_find_field_manager_get" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- range $info := $mfInfos }}
+	mgr_{{ $info.PackageName }} := {{ $info.PackageName }}.NewManager(rm.sdkapi, rm.metrics)
+	if err := mgr_{{ $info.PackageName }}.Get(ctx, ko); err != nil {
+		return nil, err
+	}
+{{- end }}
+{{- end -}}

--- a/templates/pkg/resource/sdk_find_read_many.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_many.go.tpl
@@ -58,6 +58,7 @@ func (rm *resourceManager) sdkFind(
 {{- if $hookCode := Hook .CRD "sdk_read_many_post_set_output" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_find_field_manager_get" . }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -59,6 +59,7 @@ func (rm *resourceManager) sdkFind(
 {{- if $hookCode := Hook .CRD "sdk_read_one_post_set_output" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_find_field_manager_get" . }}
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -13,6 +13,7 @@ func (rm *resourceManager) sdkUpdate(
 {{- if $hookCode := Hook .CRD "sdk_update_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_update_field_manager_sync" . }}
 {{- if $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
 	updated, err = rm.{{ $customMethod }}(ctx, desired, latest, delta)
 	if updated != nil || err != nil {

--- a/templates/pkg/resource/sdk_update_custom.go.tpl
+++ b/templates/pkg/resource/sdk_update_custom.go.tpl
@@ -1,4 +1,21 @@
 {{- define "sdk_update_custom" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- if $mfInfos -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkUpdate")
+	defer func() {
+		exit(err)
+	}()
+{{ template "sdk_update_field_manager_sync" . }}
+	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, delta)
+}
+{{- else -}}
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
@@ -7,4 +24,5 @@ func (rm *resourceManager) sdkUpdate(
 ) (*resource, error) {
 	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, delta)
 }
+{{- end -}}
 {{- end -}}

--- a/templates/pkg/resource/sdk_update_field_manager_sync.go.tpl
+++ b/templates/pkg/resource/sdk_update_field_manager_sync.go.tpl
@@ -1,0 +1,17 @@
+{{- define "sdk_update_field_manager_sync" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- if $mfInfos }}
+	// Sync field managers for fields managed by separate API operations.
+{{- range $info := $mfInfos }}
+	if delta.DifferentAt("{{ $info.FieldPath }}") {
+		mgr_{{ $info.PackageName }} := {{ $info.PackageName }}.NewManager(rm.sdkapi, rm.metrics)
+		if err = mgr_{{ $info.PackageName }}.Sync(ctx, desired.ko, latest.ko); err != nil {
+			return nil, err
+		}
+	}
+{{- end }}
+	if !delta.DifferentExcept({{ range $i, $info := $mfInfos }}{{ if $i }}, {{ end }}"{{ $info.FieldPath }}"{{ end }}) {
+		return desired, nil
+	}
+{{- end }}
+{{- end -}}

--- a/templates/pkg/resource/sdk_update_not_implemented.go.tpl
+++ b/templates/pkg/resource/sdk_update_not_implemented.go.tpl
@@ -1,4 +1,23 @@
 {{- define "sdk_update_not_implemented" -}}
+{{- $mfInfos := FieldManagerInfos .CRD -}}
+{{- if $mfInfos -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkUpdate")
+	defer func() {
+		exit(err)
+	}()
+{{ template "sdk_update_field_manager_sync" . }}
+	// No Update API for this resource — any non-managed-field delta is a
+	// terminal error.
+	return nil, ackerr.NewTerminalError(ackerr.NotImplemented)
+}
+{{- else -}}
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	desired *resource,
@@ -7,4 +26,5 @@ func (rm *resourceManager) sdkUpdate(
 ) (*resource, error) {
 	return nil, ackerr.NewTerminalError(ackerr.NotImplemented)
 }
+{{- end -}}
 {{- end -}}

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -15,6 +15,7 @@ func (rm *resourceManager) sdkUpdate(
 {{- if $hookCode := Hook .CRD "sdk_update_pre_build_request" }}
 {{ $hookCode }}
 {{- end }}
+{{ template "sdk_update_field_manager_sync" . }}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the
 	// case, and it's an error in the generated code if it is...


### PR DESCRIPTION
# feat: Add field manager for managing fields with separate API operations

## Summary

Introduces the **field manager** pattern to the ACK code generator. This allows a parent resource to declare fields whose lifecycle (create, update, delete, read) is managed by separate AWS API operations, without exposing those fields as standalone Kubernetes CRDs.

For example, a `BackupVault` resource can declare `AccessPolicy`, `Notifications`, and `LockConfiguration` as managed fields. Each gets its own generated manager package that handles CRUD via dedicated API operations (`PutBackupVaultAccessPolicy`, `DeleteBackupVaultAccessPolicy`, etc.), while the user interacts with a single `BackupVault` CR.

## generator.yaml interface

Managed fields are defined inline on individual fields using the `manager` key:

```yaml
resources:
  BackupVault:
    fields:
      AccessPolicy:
        manager:
          hooks:
            sdk_read_one_post_request:
              template_path: hooks/backup_vault_access_policy/sdk_read_one_post_request.go.tpl
      LockConfiguration:
        manager:
          fields:
            ChangeableForDays:
              compare:
                is_ignored: true
          find_operation:
            custom_method_name: customFindLockConfiguration
```

The `manager` block accepts the same configuration as a top-level resource (`hooks`, `renames`, `exceptions`, `fields`, `find_operation`, etc.), scoped to the managed field's own operations.

## What the code generator produces

For each managed field, the code generator creates a package under `pkg/resource/<parent>/<field>/`:

| File | Purpose |
|------|---------|
| `manager.go` | Manager struct, `NewManager()`, `Sync()`, `Get()`, delta computation, singleton logic |
| `sdk.go` | `sdkFind()`, `sdkCreate()`, `sdkDelete()`, request payload builders |
| `delta.go` | Field-by-field comparison respecting `compare.is_ignored` |

On the parent side, generated code is injected into:
- **`sdkCreate`** — marks resource unsynced if managed field spec is non-nil (forces reconcile loop)
- **`sdkFind`** — calls `Get()` on each field manager to populate parent spec
- **`sdkUpdate`** — calls `Sync()` when `delta.DifferentAt("Spec.<Field>")`, short-circuits if only managed fields changed
- **`sdkDelete`** — syncs each managed field with nil desired state before deleting parent

## Auto-inference

### Operations

The code generator automatically infers API operation bindings from the SDK model using naming conventions. For parent `Foo` and managed field `Bar`, it tries suffixes in preference order:

1. `{Verb}{Parent}{Field}` — e.g. `PutBackupVaultLockConfiguration`
2. `{Verb}{Field}` — e.g. `PutNotifications`
3. `{Verb}{Parent}{Singular}` — e.g. `TagBackupVault`
4. `{Verb}{Singular}` — e.g. `TagResource`
5. `{Verb}Resource` — generic fallback

With verb prefixes per operation type:
- **Create**: `Put`, `Create`, `Set`, `Tag`
- **Delete**: `Delete`, `Remove`, `Untag`
- **Get**: `Get`, `Describe`, `List`

Explicit `operations:` entries in generator.yaml always take precedence.

### Primary keys

The parent's primary key is automatically propagated to each managed field. The original SDK field name is resolved by reverse-looking up the parent's renames (e.g. parent renames `BackupVaultName` → `Name`, so the managed field gets `BackupVaultName` as its primary key). The injected field config carries `is_primary_key: true`, `go_tag: json:"-"`, and `compare.is_ignored: true`.

## Config layer changes

- New `FieldManagerConfig` type (embeds `ResourceConfig`)
- New `Manager *FieldManagerConfig` field on `FieldConfig` (YAML key: `manager`)
- `NormalizeManagedFields()` promotes field-level `manager` configs into the internal `ManagedFields` map
- `InferManagedFieldOperations()` auto-discovers SDK operations
- `InferManagedFieldPrimaryKeys()` auto-derives primary keys from parent
- Accessor methods: `GetManagedFields()`, `IsManagedField()`, `GetFieldManagerConfig()`, `GetParentResourceName()`

## Template files added

- `field_manager.go.tpl` — main manager scaffold
- `field_manager_singleton.go.tpl` — singleton pattern (key, sync, Get, convertFromParent)
- `sdk_create_field_manager_requeue.go.tpl` — requeue on create
- `sdk_update_field_manager_sync.go.tpl` — sync on update
- `sdk_delete_field_manager_sync.go.tpl` — cleanup on delete
- `sdk_find_field_manager_get.go.tpl` — populate on find

## Testing

- Table-driven unit tests for `inferManagedFieldOps` covering 12 scenarios: standard patterns, prefix preference, singular forms, generic Resource suffix, explicit binding preservation, partial matches, and no-match cases
- Validated against the backup-controller with three managed fields (AccessPolicy, Notifications, LockConfiguration) — all produce identical generated code and compile cleanly
