### PR TITLE
Add newline to generated resource guards

### DIFF
--- a/pkg/generate/code/resource_guard.go
+++ b/pkg/generate/code/resource_guard.go
@@ -126,6 +126,7 @@ func resourceIsGuarded(
 		return "", fmt.Errorf("unknown config key %q", configKey)
 	}
 
+	out += "\n"
 	for _, condCfg := range conditions {
 		if condCfg.Path == nil || *condCfg.Path == "" {
 			return "", fmt.Errorf(

--- a/pkg/generate/code/resource_guard_test.go
+++ b/pkg/generate/code/resource_guard_test.go
@@ -31,7 +31,7 @@ func TestResourceIsUpdateable_SingleCondition(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Function")
 	require.NotNil(crd)
 
-	expected := `	if latest.ko.Status.State != nil {
+	expected := "\n" + `	if latest.ko.Status.State != nil {
 		if !ackutil.InStrings(*latest.ko.Status.State, []string{"Active"}) {
 			return nil, ackrequeue.NeededAfter(
 				fmt.Errorf("resource is in %s state, cannot be updated",
@@ -55,7 +55,7 @@ func TestResourceIsDeletable_SingleCondition(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Function")
 	require.NotNil(crd)
 
-	expected := `	if r.ko.Status.State != nil {
+	expected := "\n" + `	if r.ko.Status.State != nil {
 		if !ackutil.InStrings(*r.ko.Status.State, []string{"Active", "Failed"}) {
 			return nil, ackrequeue.NeededAfter(
 				fmt.Errorf("resource is in %s state, cannot be deleted",
@@ -82,7 +82,7 @@ func TestResourceIsUpdateable_MultipleConditions_CustomRequeue(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Function")
 	require.NotNil(crd)
 
-	expected := `	if latest.ko.Status.State != nil {
+	expected := "\n" + `	if latest.ko.Status.State != nil {
 		if !ackutil.InStrings(*latest.ko.Status.State, []string{"Active"}) {
 			return nil, ackrequeue.NeededAfter(
 				fmt.Errorf("resource is in %s state, cannot be updated",
@@ -180,7 +180,7 @@ func TestResourceIsDeletable_MultipleConditions_CustomRequeue(t *testing.T) {
 	crd := testutil.GetCRDByName(t, g, "Function")
 	require.NotNil(crd)
 
-	expected := `	if r.ko.Status.State != nil {
+	expected := "\n" + `	if r.ko.Status.State != nil {
 		if !ackutil.InStrings(*r.ko.Status.State, []string{"Active"}) {
 			return nil, ackrequeue.NeededAfter(
 				fmt.Errorf("resource is in %s state, cannot be deleted",


### PR DESCRIPTION
- Update resourceIsGuarded to start output with a newline to avoid generated code ending up on same line as previous characters in template.

Issue #, if available:

Description of changes:
When no `pre_build` hook was present the code generated by the `updatable` and `deletable` resource guard configs would end up on the same line as the function signature. This PR updates the generated resource guard code to include a new line to avoid collisions with the function signature when no hook code is present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
