### PR TITLE
fix(compare): support scalar slice element types in compareSlice

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -525,8 +525,9 @@ func compareSlice(
 			"%sif !equality.Semantic.Equalities.DeepEqual(%s, %s) {\n",
 			indent, firstResVarName, secondResVarName,
 		)
-	case "list", "map":
-		// For nested collection types (e.g. [][]*string or []map[string]*string),
+	case "list", "map", "long", "integer", "double", "float", "boolean":
+		// For nested collection types (e.g. [][]*string, []map[string]*string)
+		// and scalar pointer slices (e.g. []*int64, []*float64, []*bool),
 		// use DeepEqual since there's no simple element-wise comparison available.
 		out += fmt.Sprintf(
 			"%sif !equality.Semantic.Equalities.DeepEqual(%s, %s) {\n",

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -754,3 +754,63 @@ func TestCompareResource_QuickSight_DataSet(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(expected, got)
 }
+
+// TestCompareResource_S3Files_AccessPoint verifies that the code generator
+// correctly handles the S3 Files AccessPoint resource, specifically the
+// PosixUser.SecondaryGids field which is a list of longs ([]*int64).
+// This was previously unsupported and caused "unsupported element type in
+// compareSlice: long" errors.
+func TestCompareResource_S3Files_AccessPoint(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "s3files")
+
+	crd := testutil.GetCRDByName(t, g, "AccessPoint")
+	require.NotNil(crd)
+
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.FileSystemID, b.ko.Spec.FileSystemID) {
+		delta.Add("Spec.FileSystemID", a.ko.Spec.FileSystemID, b.ko.Spec.FileSystemID)
+	} else if a.ko.Spec.FileSystemID != nil && b.ko.Spec.FileSystemID != nil {
+		if *a.ko.Spec.FileSystemID != *b.ko.Spec.FileSystemID {
+			delta.Add("Spec.FileSystemID", a.ko.Spec.FileSystemID, b.ko.Spec.FileSystemID)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.PosixUser, b.ko.Spec.PosixUser) {
+		delta.Add("Spec.PosixUser", a.ko.Spec.PosixUser, b.ko.Spec.PosixUser)
+	} else if a.ko.Spec.PosixUser != nil && b.ko.Spec.PosixUser != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.PosixUser.GID, b.ko.Spec.PosixUser.GID) {
+			delta.Add("Spec.PosixUser.GID", a.ko.Spec.PosixUser.GID, b.ko.Spec.PosixUser.GID)
+		} else if a.ko.Spec.PosixUser.GID != nil && b.ko.Spec.PosixUser.GID != nil {
+			if *a.ko.Spec.PosixUser.GID != *b.ko.Spec.PosixUser.GID {
+				delta.Add("Spec.PosixUser.GID", a.ko.Spec.PosixUser.GID, b.ko.Spec.PosixUser.GID)
+			}
+		}
+		if len(a.ko.Spec.PosixUser.SecondaryGIDs) != len(b.ko.Spec.PosixUser.SecondaryGIDs) {
+			delta.Add("Spec.PosixUser.SecondaryGIDs", a.ko.Spec.PosixUser.SecondaryGIDs, b.ko.Spec.PosixUser.SecondaryGIDs)
+		} else if len(a.ko.Spec.PosixUser.SecondaryGIDs) > 0 {
+			if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.PosixUser.SecondaryGIDs, b.ko.Spec.PosixUser.SecondaryGIDs) {
+				delta.Add("Spec.PosixUser.SecondaryGIDs", a.ko.Spec.PosixUser.SecondaryGIDs, b.ko.Spec.PosixUser.SecondaryGIDs)
+			}
+		}
+		if ackcompare.HasNilDifference(a.ko.Spec.PosixUser.UID, b.ko.Spec.PosixUser.UID) {
+			delta.Add("Spec.PosixUser.UID", a.ko.Spec.PosixUser.UID, b.ko.Spec.PosixUser.UID)
+		} else if a.ko.Spec.PosixUser.UID != nil && b.ko.Spec.PosixUser.UID != nil {
+			if *a.ko.Spec.PosixUser.UID != *b.ko.Spec.PosixUser.UID {
+				delta.Add("Spec.PosixUser.UID", a.ko.Spec.PosixUser.UID, b.ko.Spec.PosixUser.UID)
+			}
+		}
+	}
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
+`
+	got, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}

--- a/pkg/testdata/codegen/sdk-codegen/aws-models/s3files.json
+++ b/pkg/testdata/codegen/sdk-codegen/aws-models/s3files.json
@@ -1,0 +1,114 @@
+{
+  "smithy": "2.0",
+  "metadata": {},
+  "shapes": {
+    "com.amazonaws.s3files#S3Files": {
+      "type": "service",
+      "version": "2024-08-20",
+      "traits": {
+        "aws.api#service": {"sdkId": "S3Files"},
+        "smithy.api#documentation": "Amazon S3 Files"
+      },
+      "operations": [
+        {"target": "com.amazonaws.s3files#CreateAccessPoint"},
+        {"target": "com.amazonaws.s3files#GetAccessPoint"},
+        {"target": "com.amazonaws.s3files#DeleteAccessPoint"}
+      ]
+    },
+    "com.amazonaws.s3files#CreateAccessPoint": {
+      "type": "operation",
+      "input": {"target": "com.amazonaws.s3files#CreateAccessPointInput"},
+      "output": {"target": "com.amazonaws.s3files#CreateAccessPointOutput"}
+    },
+    "com.amazonaws.s3files#CreateAccessPointInput": {
+      "type": "structure",
+      "members": {
+        "FileSystemId": {"target": "com.amazonaws.s3files#FileSystemId"},
+        "PosixUser": {"target": "com.amazonaws.s3files#PosixUser"},
+        "Tags": {"target": "com.amazonaws.s3files#Tags"}
+      }
+    },
+    "com.amazonaws.s3files#CreateAccessPointOutput": {
+      "type": "structure",
+      "members": {
+        "AccessPointId": {"target": "com.amazonaws.s3files#AccessPointId"},
+        "FileSystemId": {"target": "com.amazonaws.s3files#FileSystemId"},
+        "PosixUser": {"target": "com.amazonaws.s3files#PosixUser"},
+        "Tags": {"target": "com.amazonaws.s3files#Tags"}
+      }
+    },
+    "com.amazonaws.s3files#GetAccessPoint": {
+      "type": "operation",
+      "input": {"target": "com.amazonaws.s3files#GetAccessPointInput"},
+      "output": {"target": "com.amazonaws.s3files#GetAccessPointOutput"}
+    },
+    "com.amazonaws.s3files#GetAccessPointInput": {
+      "type": "structure",
+      "members": {
+        "AccessPointId": {"target": "com.amazonaws.s3files#AccessPointId"}
+      }
+    },
+    "com.amazonaws.s3files#GetAccessPointOutput": {
+      "type": "structure",
+      "members": {
+        "AccessPointId": {"target": "com.amazonaws.s3files#AccessPointId"},
+        "FileSystemId": {"target": "com.amazonaws.s3files#FileSystemId"},
+        "PosixUser": {"target": "com.amazonaws.s3files#PosixUser"},
+        "Tags": {"target": "com.amazonaws.s3files#Tags"}
+      }
+    },
+    "com.amazonaws.s3files#DeleteAccessPoint": {
+      "type": "operation",
+      "input": {"target": "com.amazonaws.s3files#DeleteAccessPointInput"},
+      "output": {"target": "com.amazonaws.s3files#DeleteAccessPointOutput"}
+    },
+    "com.amazonaws.s3files#DeleteAccessPointInput": {
+      "type": "structure",
+      "members": {
+        "AccessPointId": {"target": "com.amazonaws.s3files#AccessPointId"}
+      }
+    },
+    "com.amazonaws.s3files#DeleteAccessPointOutput": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.s3files#AccessPointId": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#FileSystemId": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#PosixUser": {
+      "type": "structure",
+      "members": {
+        "Uid": {"target": "com.amazonaws.s3files#Long"},
+        "Gid": {"target": "com.amazonaws.s3files#Long"},
+        "SecondaryGids": {"target": "com.amazonaws.s3files#SecondaryGids"}
+      }
+    },
+    "com.amazonaws.s3files#SecondaryGids": {
+      "type": "list",
+      "member": {"target": "com.amazonaws.s3files#Long"}
+    },
+    "com.amazonaws.s3files#Long": {
+      "type": "long"
+    },
+    "com.amazonaws.s3files#Tags": {
+      "type": "list",
+      "member": {"target": "com.amazonaws.s3files#Tag"}
+    },
+    "com.amazonaws.s3files#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {"target": "com.amazonaws.s3files#TagKey"},
+        "Value": {"target": "com.amazonaws.s3files#TagValue"}
+      }
+    },
+    "com.amazonaws.s3files#TagKey": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#TagValue": {
+      "type": "string"
+    }
+  }
+}

--- a/pkg/testdata/models/apis/s3files/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/s3files/0000-00-00/generator.yaml
@@ -1,0 +1,23 @@
+sdk_names:
+  model_name: s3files
+  package_name: s3files
+ignore:
+  resource_names: []
+resources:
+  AccessPoint:
+    fields:
+      ID:
+        is_primary_key: true
+    renames:
+      operations:
+        CreateAccessPoint:
+          output_fields:
+            AccessPointId: ID
+        GetAccessPoint:
+          input_fields:
+            AccessPointId: ID
+          output_fields:
+            AccessPointId: ID
+        DeleteAccessPoint:
+          input_fields:
+            AccessPointId: ID


### PR DESCRIPTION

Issue #, if available: N/A

Description of changes:

Add long, integer, double, float, and boolean to the existing list/map case in compareSlice(). These scalar pointer slice types (e.g. []*int64) previously hit the default error case with 'unsupported element type in compareSlice: long', forcing service controllers to use compare.is_ignored workarounds.

Uses DeepEqual (same as list/map/structure cases) since there is no typed slice comparison helper in the runtime for these types.

Add s3files test fixture with AccessPoint resource containing a PosixUser.SecondaryGIDs field ([]*int64) to exercise the new code path.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
