### PR TITLE
Complete implementation for NilEqualsZeroValue

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -301,6 +301,8 @@ func compareNil(
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
 
+	nilEqualsZeroValue := compareConfig != nil && compareConfig.NilEqualsZeroValue
+
 	switch shape.Type {
 	case "boolean", "string", "character", "byte", "short", "integer", "long",
 		"float", "double", "timestamp", "structure", "jsonvalue":
@@ -312,11 +314,32 @@ func compareNil(
 	default:
 		return "", fmt.Errorf("field %q: unsupported shape type in compareNil: %s", fieldPath, shape.Type)
 	}
-	//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
-	out += fmt.Sprintf(
-		"%s\t%s.Add(\"%s\", %s, %s)\n",
-		indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
-	)
+
+	if nilEqualsZeroValue {
+		// When nil_equals_zero_value is true, a nil pointer in the desired
+		// state (first resource) is considered equal to a pointer to the
+		// zero value in the latest state (second resource). We only add a
+		// delta if IsNilEqualsZero returns false.
+		out += fmt.Sprintf(
+			"%s\tif !ackcompare.IsNilEqualsZero(%s, %s) {\n",
+			indent, firstResVarName, secondResVarName,
+		)
+		//     delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		out += fmt.Sprintf(
+			"%s\t\t%s.Add(\"%s\", %s, %s)\n",
+			indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+		)
+		//   }
+		out += fmt.Sprintf(
+			"%s\t}\n", indent,
+		)
+	} else {
+		//   delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		out += fmt.Sprintf(
+			"%s\t%s.Add(\"%s\", %s, %s)\n",
+			indent, deltaVarName, fieldPath, firstResVarName, secondResVarName,
+		)
+	}
 	// }
 	out += fmt.Sprintf(
 		"%s}", indent,

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -814,3 +814,69 @@ func TestCompareResource_S3Files_AccessPoint(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(expected, got)
 }
+
+func TestCompareResource_SNS_Topic_NilEqualsZeroValue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "sns", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-nil-equals-zero-value.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Topic")
+	require.NotNil(crd)
+
+	// DisplayName has compare.nil_equals_zero_value: true, so the generated
+	// code should only report a nil difference if the non-nil side (latest
+	// from AWS) is not an empty string. This prevents permanent drift when
+	// AWS returns "" for an unset optional field while the desired state has nil.
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy) {
+		delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
+	} else if a.ko.Spec.DeliveryPolicy != nil && b.ko.Spec.DeliveryPolicy != nil {
+		if *a.ko.Spec.DeliveryPolicy != *b.ko.Spec.DeliveryPolicy {
+			delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.DisplayName, b.ko.Spec.DisplayName) {
+		if !ackcompare.IsNilEqualsZero(a.ko.Spec.DisplayName, b.ko.Spec.DisplayName) {
+			delta.Add("Spec.DisplayName", a.ko.Spec.DisplayName, b.ko.Spec.DisplayName)
+		}
+	} else if a.ko.Spec.DisplayName != nil && b.ko.Spec.DisplayName != nil {
+		if *a.ko.Spec.DisplayName != *b.ko.Spec.DisplayName {
+			delta.Add("Spec.DisplayName", a.ko.Spec.DisplayName, b.ko.Spec.DisplayName)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.KMSMasterKeyID, b.ko.Spec.KMSMasterKeyID) {
+		delta.Add("Spec.KMSMasterKeyID", a.ko.Spec.KMSMasterKeyID, b.ko.Spec.KMSMasterKeyID)
+	} else if a.ko.Spec.KMSMasterKeyID != nil && b.ko.Spec.KMSMasterKeyID != nil {
+		if *a.ko.Spec.KMSMasterKeyID != *b.ko.Spec.KMSMasterKeyID {
+			delta.Add("Spec.KMSMasterKeyID", a.ko.Spec.KMSMasterKeyID, b.ko.Spec.KMSMasterKeyID)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
+		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
+		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+		}
+	}
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
+`
+	got, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}

--- a/pkg/testdata/models/apis/sns/0000-00-00/generator-nil-equals-zero-value.yaml
+++ b/pkg/testdata/models/apis/sns/0000-00-00/generator-nil-equals-zero-value.yaml
@@ -1,0 +1,33 @@
+resources:
+  Topic:
+    is_arn_primary_key: true
+    unpack_attributes_map:
+      set_attributes_single_attribute: true
+    fields:
+      DeliveryPolicy:
+        is_attribute: true
+      DisplayName:
+        is_attribute: true
+        compare:
+          nil_equals_zero_value: true
+      Policy:
+        is_attribute: true
+      KmsMasterKeyId:
+        is_attribute: true
+      Owner:
+        is_attribute: true
+        is_read_only: true
+        is_owner_account_id: true
+      EffectiveDeliveryPolicy:
+        is_attribute: true
+        is_read_only: true
+      TopicArn:
+        is_attribute: true
+        is_read_only: true
+ignore:
+  resource_names:
+    - PlatformApplication
+    - Endpoint
+    - Subscription
+  field_paths:
+    - CreateTopicInput.DataProtectionPolicy


### PR DESCRIPTION
## Implement `nil_equals_zero_value` for field comparison

### Problem

AWS APIs often return empty strings for unset optional fields (e.g., SNS Topic `DisplayName`). The desired CR state has `nil` for unspecified fields, causing permanent drift on every reconciliation.

### Solution

Wire the existing `NilEqualsZeroValue` config in `CompareFieldConfig` into the `compareNil` code generation function. When configured with `compare.nil_equals_zero_value: true` in `generator.yaml`, the generated delta code calls `ackcompare.IsNilEqualsZero()` to suppress false drift.

This is one-way: `nil` desired + zero-value latest = no drift. But zero-value desired + `nil` latest = real drift reported.

### Changes

- `pkg/generate/code/compare.go` — Generate `ackcompare.IsNilEqualsZero` guard inside the nil-difference block when config is set
- `pkg/generate/code/compare_test.go` — Unit test validating generated output for SNS Topic with `nil_equals_zero_value`
- `pkg/testdata/models/apis/sns/0000-00-00/generator-nil-equals-zero-value.yaml` — Test fixture

### Testing
- Validated that SNS controller creates correct code and verified logic with additional delta unit test. 

### Dependencies

Requires runtime with `IsNilEqualsZero` in `pkg/compare/zero.go`.

Fixes: https://github.com/aws-controllers-k8s/community/issues/2873

