### PR TITLE
feat(compare): add is_document field config for semantic JSON/YAML comparison

### DIFF
--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -428,6 +428,11 @@ type FieldConfig struct {
 	// string comparison. This handles IAM-specific semantics like statement
 	// ordering independence and Action/Resource as string vs array.
 	IsIAMPolicy bool `json:"is_iam_policy"`
+	// IsDocument indicates that the field contains a JSON or YAML document
+	// and should be compared using semantic document comparison rather than
+	// string comparison. This handles differences in whitespace, key ordering,
+	// and formatting that are semantically equivalent.
+	IsDocument bool `json:"is_document"`
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`

--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -166,6 +166,12 @@ func CompareResource(
 			continue
 		}
 
+		// Use semantic document comparison for fields marked as documents
+		if fieldConfig != nil && fieldConfig.IsDocument {
+			out += compareDocument(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, fieldPath, indentLevel)
+			continue
+		}
+
 		memberShapeRef := specField.ShapeRef
 		memberShape := memberShapeRef.Shape
 
@@ -635,6 +641,67 @@ func compareIAMPolicy(
 	//     }
 	out += fmt.Sprintf("%s\t}\n", indent)
 	// }
+	out += fmt.Sprintf("%s}\n", indent)
+
+	return out
+}
+
+// compareDocument outputs Go code that compares two JSON or YAML document
+// strings using semantic comparison that handles differences in whitespace,
+// key ordering, and formatting.
+//
+// Output code will look something like this:
+//
+//	if ackcompare.HasNilDifference(a.ko.Spec.Configuration, b.ko.Spec.Configuration) {
+//	    delta.Add("Spec.Configuration", a.ko.Spec.Configuration, b.ko.Spec.Configuration)
+//	} else if a.ko.Spec.Configuration != nil && b.ko.Spec.Configuration != nil {
+//	    if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.Configuration, *b.ko.Spec.Configuration); err != nil || !equal {
+//	        delta.Add("Spec.Configuration", a.ko.Spec.Configuration, b.ko.Spec.Configuration)
+//	    }
+//	}
+func compareDocument(
+	// String representing the name of the variable that is of type
+	// `*ackcompare.Delta`. We will generate Go code that calls the `Add()`
+	// method of this variable when differences between fields are detected.
+	deltaVarName string,
+	// String representing the name of the variable that represents the desired
+	// CR under comparison. This will typically be something like
+	// "a.ko.Spec.Configuration". See `templates/pkg/resource/delta.go.tpl`.
+	desiredResVarName string,
+	// String representing the name of the variable that represents the latest
+	// CR under comparison. This will typically be something like
+	// "b.ko.Spec.Configuration". See `templates/pkg/resource/delta.go.tpl`.
+	latestResVarName string,
+	// String indicating the current field path being evaluated, e.g.
+	// "Spec.Configuration".
+	fieldPath string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	out := ""
+	indent := strings.Repeat("\t", indentLevel)
+
+	out += fmt.Sprintf(
+		"%sif ackcompare.HasNilDifference(%s, %s) {\n",
+		indent, desiredResVarName, latestResVarName,
+	)
+	out += fmt.Sprintf(
+		"%s\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, desiredResVarName, latestResVarName,
+	)
+	out += fmt.Sprintf(
+		"%s} else if %s != nil && %s != nil {\n",
+		indent, desiredResVarName, latestResVarName,
+	)
+	out += fmt.Sprintf(
+		"%s\tif equal, err := ackcompare.DocumentEqual(*%s, *%s); err != nil || !equal {\n",
+		indent, desiredResVarName, latestResVarName,
+	)
+	out += fmt.Sprintf(
+		"%s\t\t%s.Add(\"%s\", %s, %s)\n",
+		indent, deltaVarName, fieldPath, desiredResVarName, latestResVarName,
+	)
+	out += fmt.Sprintf("%s\t}\n", indent)
 	out += fmt.Sprintf("%s}\n", indent)
 
 	return out

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -669,6 +669,91 @@ func TestCompareResource_IAM_Role_IAMPolicy(t *testing.T) {
 	assert.Equal(expected, got)
 }
 
+func TestCompareResource_SNS_Subscription_Document(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "sns", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-document.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Subscription")
+	require.NotNil(crd)
+
+	// The FilterPolicy field is marked as is_document: true so it should use
+	// DocumentEqual instead of string comparison (community#2872)
+	expected := `
+	if ackcompare.HasNilDifference(a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy) {
+		delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
+	} else if a.ko.Spec.DeliveryPolicy != nil && b.ko.Spec.DeliveryPolicy != nil {
+		if *a.ko.Spec.DeliveryPolicy != *b.ko.Spec.DeliveryPolicy {
+			delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Endpoint, b.ko.Spec.Endpoint) {
+		delta.Add("Spec.Endpoint", a.ko.Spec.Endpoint, b.ko.Spec.Endpoint)
+	} else if a.ko.Spec.Endpoint != nil && b.ko.Spec.Endpoint != nil {
+		if *a.ko.Spec.Endpoint != *b.ko.Spec.Endpoint {
+			delta.Add("Spec.Endpoint", a.ko.Spec.Endpoint, b.ko.Spec.Endpoint)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy) {
+		delta.Add("Spec.FilterPolicy", a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy)
+	} else if a.ko.Spec.FilterPolicy != nil && b.ko.Spec.FilterPolicy != nil {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.FilterPolicy, *b.ko.Spec.FilterPolicy); err != nil || !equal {
+			delta.Add("Spec.FilterPolicy", a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope) {
+		delta.Add("Spec.FilterPolicyScope", a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope)
+	} else if a.ko.Spec.FilterPolicyScope != nil && b.ko.Spec.FilterPolicyScope != nil {
+		if *a.ko.Spec.FilterPolicyScope != *b.ko.Spec.FilterPolicyScope {
+			delta.Add("Spec.FilterPolicyScope", a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Protocol, b.ko.Spec.Protocol) {
+		delta.Add("Spec.Protocol", a.ko.Spec.Protocol, b.ko.Spec.Protocol)
+	} else if a.ko.Spec.Protocol != nil && b.ko.Spec.Protocol != nil {
+		if *a.ko.Spec.Protocol != *b.ko.Spec.Protocol {
+			delta.Add("Spec.Protocol", a.ko.Spec.Protocol, b.ko.Spec.Protocol)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.RawMessageDelivery, b.ko.Spec.RawMessageDelivery) {
+		delta.Add("Spec.RawMessageDelivery", a.ko.Spec.RawMessageDelivery, b.ko.Spec.RawMessageDelivery)
+	} else if a.ko.Spec.RawMessageDelivery != nil && b.ko.Spec.RawMessageDelivery != nil {
+		if *a.ko.Spec.RawMessageDelivery != *b.ko.Spec.RawMessageDelivery {
+			delta.Add("Spec.RawMessageDelivery", a.ko.Spec.RawMessageDelivery, b.ko.Spec.RawMessageDelivery)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy) {
+		delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
+	} else if a.ko.Spec.RedrivePolicy != nil && b.ko.Spec.RedrivePolicy != nil {
+		if *a.ko.Spec.RedrivePolicy != *b.ko.Spec.RedrivePolicy {
+			delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.SubscriptionRoleARN, b.ko.Spec.SubscriptionRoleARN) {
+		delta.Add("Spec.SubscriptionRoleARN", a.ko.Spec.SubscriptionRoleARN, b.ko.Spec.SubscriptionRoleARN)
+	} else if a.ko.Spec.SubscriptionRoleARN != nil && b.ko.Spec.SubscriptionRoleARN != nil {
+		if *a.ko.Spec.SubscriptionRoleARN != *b.ko.Spec.SubscriptionRoleARN {
+			delta.Add("Spec.SubscriptionRoleARN", a.ko.Spec.SubscriptionRoleARN, b.ko.Spec.SubscriptionRoleARN)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.TopicARN, b.ko.Spec.TopicARN) {
+		delta.Add("Spec.TopicARN", a.ko.Spec.TopicARN, b.ko.Spec.TopicARN)
+	} else if a.ko.Spec.TopicARN != nil && b.ko.Spec.TopicARN != nil {
+		if *a.ko.Spec.TopicARN != *b.ko.Spec.TopicARN {
+			delta.Add("Spec.TopicARN", a.ko.Spec.TopicARN, b.ko.Spec.TopicARN)
+		}
+	}
+`
+	got, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(expected, got)
+}
+
 // TestCompareResource_QuickSight_DataSet tests that the delta code generation
 // correctly handles the QuickSight DataSet resource, specifically the
 // RowLevelPermissionTagConfiguration.TagRuleConfigurations field which is a

--- a/pkg/testdata/models/apis/sns/0000-00-00/generator-document.yaml
+++ b/pkg/testdata/models/apis/sns/0000-00-00/generator-document.yaml
@@ -1,0 +1,56 @@
+operations:
+  Subscribe:
+    resource_name: Subscription
+    operation_type: CREATE
+  Unsubscribe:
+    resource_name: Subscription
+    operation_type: DELETE
+  GetSubscriptionAttributes:
+    resource_name: Subscription
+    operation_type: GET_ATTRIBUTES
+  SetSubscriptionAttributes:
+    resource_name: Subscription
+    operation_type: SET_ATTRIBUTES
+resources:
+  Subscription:
+    is_arn_primary_key: true
+    update_operation:
+      custom_method_name: customUpdate
+    unpack_attributes_map:
+      set_attributes_single_attribute: true
+    fields:
+      FilterPolicy:
+        is_attribute: true
+        is_document: true
+      FilterPolicyScope:
+        is_attribute: true
+      Owner:
+        is_attribute: true
+        is_read_only: true
+        is_owner_account_id: true
+      PendingConfirmation:
+        is_attribute: true
+        is_read_only: true
+      ConfirmationWasAuthenticated:
+        is_attribute: true
+        is_read_only: true
+      EffectiveDeliveryPolicy:
+        is_attribute: true
+        is_read_only: true
+      DeliveryPolicy:
+        is_attribute: true
+      RawMessageDelivery:
+        is_attribute: true
+      RedrivePolicy:
+        is_attribute: true
+      SubscriptionRoleArn:
+        is_attribute: true
+    tags:
+      ignore: true
+ignore:
+  resource_names:
+    - PlatformApplication
+    - Endpoint
+    - Topic
+  field_paths:
+    - SubscribeInput.ReturnSubscriptionArn


### PR DESCRIPTION
Description of changes:
Fields marked with `is_document: true` in generator.yaml will use
ackcompare.DocumentEqual for delta comparison, preventing infinite
reconciliation caused by whitespace/key-ordering differences in
JSON or YAML document strings returned by AWS APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
