### PR TITLE
fix: prevent aws:* tag leakage into CR spec during LateInitialize

### DIFF
--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -208,7 +208,11 @@ func (rm *resourceManager) LateInitialize(
 {{- if $hookCode := Hook .CRD "late_initialize_pre_read_one" }}
 {{ $hookCode }}
 {{- end }}
-	observed, err := rm.ReadOne(ctx, latestCopy)
+	// Pass a separate copy to ReadOne because it may mutate its input
+	// (e.g. mirrorAWSTags injects aws:* tags). We keep latestCopy clean
+	// so that lateInitializeFromReadOneOutput doesn't carry those tags
+	// into the resource that gets patched back to the CR.
+	observed, err := rm.ReadOne(ctx, latest.DeepCopy())
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"


### PR DESCRIPTION
Description of changes:
ReadOne may mutate its input via mirrorAWSTags, which injects aws:*
tags from the observed AWS state. In LateInitialize, the same object
passed to ReadOne was then used by lateInitializeFromReadOneOutput to
build the resource that gets patched back to the CR. This caused
AWS-managed tags (e.g. aws:cloudformation:*) to leak into the CR spec
after late initialization.

Pass a separate DeepCopy to ReadOne so that latestCopy remains clean
for lateInitializeFromReadOneOutput.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
