### PR TITLE
fix: ensure identifier lookup uses renames

### DIFF
--- a/pkg/generate/code/check.go
+++ b/pkg/generate/code/check.go
@@ -179,7 +179,6 @@ func checkRequiredFieldsMissingFromShapeReadMany(
 	result := fmt.Sprintf("%sreturn false", indent)
 
 	reqIdentifier, _ := FindPluralizedIdentifiersInShape(r, shape, op)
-
 	resVarPath, err := r.GetSanitizedMemberPath(reqIdentifier, op, koVarName)
 	if err != nil {
 		return result

--- a/pkg/generate/code/check_test.go
+++ b/pkg/generate/code/check_test.go
@@ -143,6 +143,28 @@ func TestCheckRequiredFields_StatusField_ReadMany(t *testing.T) {
 	)
 }
 
+func TestCheckRequiredFields_StatusField_ReadMany_EgressOnlyIGW(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ec2", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-egress.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "EgressOnlyInternetGateway")
+	require.NotNil(crd)
+
+	expRequiredFieldsCode := `
+	return r.ko.Status.ID == nil
+`
+	gotCode, err := code.CheckRequiredFieldsMissingFromShape(
+		crd, model.OpTypeList, "r.ko", 1,
+	)
+	require.NoError(err)
+	assert.Equal(
+		strings.TrimSpace(expRequiredFieldsCode),
+		strings.TrimSpace(gotCode),
+	)
+}
+
 func TestCheckNilFieldPath(t *testing.T) {
 	// Empty FieldPath
 	field := model.Field{Path: ""}

--- a/pkg/generate/code/common.go
+++ b/pkg/generate/code/common.go
@@ -43,9 +43,13 @@ func FindIdentifiersInShape(
 
 	identifierLookup := []string{
 		"Id",
+		"ID",
 		"Ids",
+		"IDs",
 		r.Names.Original + "Id",
+		r.Names.Original + "ID",
 		r.Names.Original + "Ids",
+		r.Names.Original + "IDs",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",
@@ -132,7 +136,8 @@ func FindPluralizedIdentifiersInShape(
 					// 'Id' identifier. Checking 'Id' to determine resource
 					// creation should be safe as the field is usually
 					// present in CR.Status.
-					if !strings.Contains(crField, "Id") {
+					// Renames may produce "Id" or "ID" variants
+					if !strings.Contains(strings.ToLower(crField), "id") {
 						crField = ci
 						shapeField = si
 					}

--- a/pkg/generate/code/common_test.go
+++ b/pkg/generate/code/common_test.go
@@ -44,6 +44,64 @@ func TestFindIdentifiersInShape_EC2_VPC_ReadMany(t *testing.T) {
 	)
 }
 
+func TestFindIdentifiersInShape_EC2_EgressOnlyIGW_ReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ec2", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-egress.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "EgressOnlyInternetGateway")
+	require.NotNil(crd)
+
+	// The rename maps EgressOnlyInternetGatewayIds → ID, and the function
+	// returns the post-rename name when it matches the lookup list.
+	expIdentifier := "ID"
+	op := crd.Ops.ReadMany
+	actualIdentifiers := code.FindIdentifiersInShape(crd, op.InputRef.Shape, op)
+	assert.Len(actualIdentifiers, 1)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifiers[0]),
+	)
+}
+
+func TestGetIdentifiers_EC2_EgressOnlyIGW(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ec2", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-egress.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "EgressOnlyInternetGateway")
+	require.NotNil(crd)
+
+	expIdentifier := "ID"
+	actualIdentifiers := crd.GetIdentifiers()
+	assert.Len(actualIdentifiers, 1)
+	assert.Equal(
+		strings.TrimSpace(expIdentifier),
+		strings.TrimSpace(actualIdentifiers[0]),
+	)
+}
+
+func TestFindPluralizedIdentifiersInShape_EC2_EgressOnlyIGW_ReadMany(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "ec2", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-egress.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "EgressOnlyInternetGateway")
+	require.NotNil(crd)
+
+	expModelIdentifier := "ID"
+	expShapeIdentifier := "ID"
+	op := crd.Ops.ReadMany
+	crIdentifier, shapeIdentifier := code.FindPluralizedIdentifiersInShape(crd,
+		op.InputRef.Shape, op)
+
+	assert.Equal(expModelIdentifier, crIdentifier)
+	assert.Equal(expShapeIdentifier, shapeIdentifier)
+}
+
 func TestFindIdentifiersInCRD_S3_Bucket_ReadMany_Empty(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -881,9 +881,13 @@ func (r *CRD) GetIdentifiers() []string {
 	}
 	identifierLookup := []string{
 		"Id",
+		"ID",
 		"Ids",
+		"IDs",
 		r.Names.Original + "Id",
+		r.Names.Original + "ID",
 		r.Names.Original + "Ids",
+		r.Names.Original + "IDs",
 		"Name",
 		"Names",
 		r.Names.Original + "Name",

--- a/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-egress.yaml
+++ b/pkg/testdata/models/apis/ec2/0000-00-00/generator-with-egress.yaml
@@ -1,0 +1,161 @@
+ignore:
+  field_paths:
+    - CreateDhcpOptionsInput.DryRun
+    - CreateVpcInput.DryRun
+    - CreateVpcEndpointInput.DryRun
+    - Instance.ClientToken
+    - InstanceNetworkInterfaceSpecification.Groups
+    - RunInstancesInput.AdditionalInfo
+    - RunInstancesInput.ClientToken
+    - RunInstancesInput.DryRun
+    - LaunchTemplate.Operator
+    - Instance.CpuOptions.AmdSevSnp
+    - Instance.CurrentInstanceBootMode
+    - Instance.Ipv6Address
+    - Instance.MaintenanceOptions
+    - Instance.MetadataOptions.InstanceMetadataTags
+    - Instance.NetworkPerformanceOptions
+    - Instance.Operator
+    - Instance.PrivateDnsNameOptions
+    - Instance.Placement.GroupId
+    - Instance.TpmSupport
+    - InstanceIpv6Address.IsPrimaryIpv6
+  resource_names:
+    - AccountAttribute
+    - CapacityReservation
+    - CarrierGateway
+    - ClientVpnEndpoint
+    - ClientVpnRoute
+    - CustomerGateway
+    - DefaultSubnet
+    - DefaultVpc
+    #- DhcpOptions
+    #- EgressOnlyInternetGateway
+    - Fleet
+    - FpgaImage
+    - Image
+    #- Instance
+    - InstanceExportTask
+    - InternetGateway
+    - KeyPair
+    - LaunchTemplateVersion
+    #- LaunchTemplate
+    - LocalGatewayRouteTableVpcAssociation
+    - LocalGatewayRoute
+    - ManagedPrefixList
+    - NatGateway
+    - NetworkAclEntry
+    - NetworkAcl
+    - NetworkInsightsPath
+    - NetworkInterfacePermission
+    - NetworkInterface
+    - PlacementGroup
+    - ReservedInstancesListing
+    - RouteTable
+    - Route
+    #- SecurityGroup
+    - Snapshot
+    - SpotDatafeedSubscription
+    - Subnet 
+    - TrafficMirrorFilterRule
+    - TrafficMirrorFilter
+    - TrafficMirrorSession
+    - TrafficMirrorTarget
+    - TransitGatewayConnectPeer
+    - TransitGatewayConnect
+    - TransitGatewayMulticastDomain
+    - TransitGatewayPeeringAttachment
+    - TransitGatewayPrefixListReference
+    - TransitGatewayRouteTable
+    - TransitGatewayRoute
+    - TransitGatewayVpcAttachment
+    - TransitGateway
+    #- Volume
+    - VpcEndpointConnectionNotification
+    - VpcEndpointServiceConfiguration
+    #- VpcEndpoint
+    #- Vpc
+    - VpcCidrBlock
+    - VpcPeeringConnection
+    - VpnConnectionRoute
+    - VpnConnection
+    - VpnGateway
+
+operations:
+  CreateLaunchTemplate:
+    output_wrapper_field_path: LaunchTemplate
+  CreateVpcEndpoint:
+    output_wrapper_field_path: VpcEndpoint
+  RunInstances:
+    #output shape: Reservation
+    output_wrapper_field_path: Instances
+    operation_type:
+      - Create
+    resource_name: Instance
+  DescribeInstances:
+    #output shape: DescribeInstancesOutput
+    output_wrapper_field_path: Reservations.Instances
+    operation_type:
+      - List
+    resource_name: Instance
+  TerminateInstances:
+    operation_type:
+      - Delete
+    resource_name: Instance
+  CreateEgressOnlyInternetGateway:
+    output_wrapper_field_path: EgressOnlyInternetGateway
+resources:
+  DhcpOptions:
+    fields:
+      DHCPConfigurations.Values:
+        set:
+          - from: AttributeValue.Value
+  Instance:
+    fields:
+      SecurityGroups:
+        set:
+          - from: GroupName
+  SecurityGroup:
+    renames:
+      operations:
+        CreateSecurityGroup:
+          input_fields:
+            GroupName: Name
+          output_fields:
+            GroupId: Id
+        DeleteSecurityGroup:
+          input_fields:
+            GroupId: Id
+            GroupName: Name
+        DescribeSecurityGroups:
+          input_fields:
+            GroupIds: Ids
+            GroupNames: Names
+  EgressOnlyInternetGateway:
+    renames:
+      operations:
+        CreateEgressOnlyInternetGateway:
+          output_fields:
+            EgressOnlyInternetGatewayId: ID
+        DescribeEgressOnlyInternetGateways:
+          input_fields:
+            EgressOnlyInternetGatewayIds: ID
+          output_fields:
+            EgressOnlyInternetGatewayId: ID
+        DeleteEgressOnlyInternetGateway:
+          input_fields:
+            EgressOnlyInternetGatewayId: ID
+    fields:
+      ID:
+        is_primary_key: true
+        print:
+          name: ID
+      VpcId:
+        is_immutable: true
+        references:
+          resource: VPC
+          path: Status.VPCID
+      Tags:
+        from:
+          operation: CreateTags
+          path: Tags


### PR DESCRIPTION
Description of changes:
When looking for identifiers, code-gen expected generator.yaml fields to
contain the normal name (eg. Id instead of ID).
With this change, we ensure to check for both `Id` and `ID` when looking
for the identifier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
