### PR TITLE
Fix error generating custom fields for shared Statement shape in Wafv2

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -825,7 +825,10 @@ func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName 
 		return fmt.Errorf("unsupported shape type %q for adding member %q", shapeRef.Shape.Type, fieldName)
 	}
 	if _, exists := memberRefs[fieldName]; exists {
-		return fmt.Errorf("member %q already exists in shape of type %q", fieldName, shapeRef.Shape.Type)
+		// Multiple resources may reference the same underlying SDK shape (e.g.
+		// WAFv2 Statement is shared between WebACL and RuleGroup). When a custom
+		// nested field has already been injected by another resource, skip silently.
+		return nil
 	}
 	memberRefs[fieldName] = memberShapeRef
 	return nil

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -831,8 +831,8 @@ func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName 
 				fieldName, shapeRef.ShapeName, existing.Shape.Type, memberShapeRef.Shape.Type,
 			)
 		}
-		fmt.Printf(
-			"WARNING: member %q already injected into shared shape %q, skipping duplicate\n",
+		util.Warnf(
+			"member %q already injected into shared shape %q, skipping duplicate\n",
 			fieldName, shapeRef.ShapeName,
 		)
 		return nil

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -811,7 +811,7 @@ func (crd *CRD) addCustomNestedFields(customNestedFields map[string]*ackgenconfi
 
 // addMemberShapRef injects a new member shape into the specified shape.
 // It returns an error if the shape type is unsupported or if a member with
-// the given field name already exists.
+// the given field name already exists with a conflicting type.
 func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName string) error {
 	var memberRefs map[string]*awssdkmodel.ShapeRef
 	switch shapeRef.Shape.Type {
@@ -824,10 +824,17 @@ func addMemberShapRef(shapeRef, memberShapeRef *awssdkmodel.ShapeRef, fieldName 
 	default:
 		return fmt.Errorf("unsupported shape type %q for adding member %q", shapeRef.Shape.Type, fieldName)
 	}
-	if _, exists := memberRefs[fieldName]; exists {
-		// Multiple resources may reference the same underlying SDK shape (e.g.
-		// WAFv2 Statement is shared between WebACL and RuleGroup). When a custom
-		// nested field has already been injected by another resource, skip silently.
+	if existing, exists := memberRefs[fieldName]; exists {
+		if existing.Shape.Type != memberShapeRef.Shape.Type {
+			return fmt.Errorf(
+				"member %q already exists in shape %q with type %q, cannot override with type %q",
+				fieldName, shapeRef.ShapeName, existing.Shape.Type, memberShapeRef.Shape.Type,
+			)
+		}
+		fmt.Printf(
+			"WARNING: member %q already injected into shared shape %q, skipping duplicate\n",
+			fieldName, shapeRef.ShapeName,
+		)
 		return nil
 	}
 	memberRefs[fieldName] = memberShapeRef

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -247,9 +247,7 @@ func TestAddMemberShapRef_DuplicateField_Structure(t *testing.T) {
 
 	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
 
-	assert.Error(err)
-	assert.Contains(err.Error(), "Field")
-	assert.Contains(err.Error(), "already exists")
+	assert.NoError(err)
 	// Original member should be unchanged
 	assert.Equal(oldMemberRef, structShape.MemberRefs["Field"])
 }
@@ -282,9 +280,7 @@ func TestAddMemberShapRef_DuplicateField_List(t *testing.T) {
 
 	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
 
-	assert.Error(err)
-	assert.Contains(err.Error(), "Field")
-	assert.Contains(err.Error(), "already exists")
+	assert.NoError(err)
 	assert.Equal(oldMemberRef, innerStructShape.MemberRefs["Field"])
 }
 
@@ -316,8 +312,6 @@ func TestAddMemberShapRef_DuplicateField_Map(t *testing.T) {
 
 	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
 
-	assert.Error(err)
-	assert.Contains(err.Error(), "Field")
-	assert.Contains(err.Error(), "already exists")
+	assert.NoError(err)
 	assert.Equal(oldMemberRef, valueStructShape.MemberRefs["Field"])
 }

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -225,7 +225,7 @@ func TestAddMemberShapRef_Map_PreservesExistingMembers(t *testing.T) {
 	assert.Equal(newMemberShapeRef, valueStructShape.MemberRefs["Priority"])
 }
 
-func TestAddMemberShapRef_DuplicateField_Structure(t *testing.T) {
+func TestAddMemberShapRef_DuplicateField_SameType(t *testing.T) {
 	assert := assert.New(t)
 
 	oldMemberRef := &awssdkmodel.ShapeRef{
@@ -238,40 +238,35 @@ func TestAddMemberShapRef_DuplicateField_Structure(t *testing.T) {
 		},
 	}
 	shapeRef := &awssdkmodel.ShapeRef{
-		Shape: structShape,
+		ShapeName: "Statement",
+		Shape:     structShape,
 	}
 
 	newMemberRef := &awssdkmodel.ShapeRef{
-		Shape: &awssdkmodel.Shape{Type: "integer"},
+		Shape: &awssdkmodel.Shape{Type: "string"},
 	}
 
 	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
 
 	assert.NoError(err)
-	// Original member should be unchanged
 	assert.Equal(oldMemberRef, structShape.MemberRefs["Field"])
 }
 
-func TestAddMemberShapRef_DuplicateField_List(t *testing.T) {
+func TestAddMemberShapRef_DuplicateField_ConflictingType(t *testing.T) {
 	assert := assert.New(t)
 
 	oldMemberRef := &awssdkmodel.ShapeRef{
 		Shape: &awssdkmodel.Shape{Type: "string"},
 	}
-	innerStructShape := &awssdkmodel.Shape{
+	structShape := &awssdkmodel.Shape{
 		Type: "structure",
 		MemberRefs: map[string]*awssdkmodel.ShapeRef{
 			"Field": oldMemberRef,
 		},
 	}
-	listShape := &awssdkmodel.Shape{
-		Type: "list",
-		MemberRef: awssdkmodel.ShapeRef{
-			Shape: innerStructShape,
-		},
-	}
 	shapeRef := &awssdkmodel.ShapeRef{
-		Shape: listShape,
+		ShapeName: "Statement",
+		Shape:     structShape,
 	}
 
 	newMemberRef := &awssdkmodel.ShapeRef{
@@ -280,38 +275,9 @@ func TestAddMemberShapRef_DuplicateField_List(t *testing.T) {
 
 	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
 
-	assert.NoError(err)
-	assert.Equal(oldMemberRef, innerStructShape.MemberRefs["Field"])
-}
-
-func TestAddMemberShapRef_DuplicateField_Map(t *testing.T) {
-	assert := assert.New(t)
-
-	oldMemberRef := &awssdkmodel.ShapeRef{
-		Shape: &awssdkmodel.Shape{Type: "string"},
-	}
-	valueStructShape := &awssdkmodel.Shape{
-		Type: "structure",
-		MemberRefs: map[string]*awssdkmodel.ShapeRef{
-			"Field": oldMemberRef,
-		},
-	}
-	mapShape := &awssdkmodel.Shape{
-		Type: "map",
-		ValueRef: awssdkmodel.ShapeRef{
-			Shape: valueStructShape,
-		},
-	}
-	shapeRef := &awssdkmodel.ShapeRef{
-		Shape: mapShape,
-	}
-
-	newMemberRef := &awssdkmodel.ShapeRef{
-		Shape: &awssdkmodel.Shape{Type: "integer"},
-	}
-
-	err := addMemberShapRef(shapeRef, newMemberRef, "Field")
-
-	assert.NoError(err)
-	assert.Equal(oldMemberRef, valueStructShape.MemberRefs["Field"])
+	assert.Error(err)
+	assert.Contains(err.Error(), "Field")
+	assert.Contains(err.Error(), "Statement")
+	assert.Contains(err.Error(), "cannot override")
+	assert.Equal(oldMemberRef, structShape.MemberRefs["Field"])
 }

--- a/pkg/model/model_wafv2_test.go
+++ b/pkg/model/model_wafv2_test.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	 http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+// TestWAFv2_SharedShape_CustomNestedFields verifies that custom nested fields
+// can be injected into a shape (Statement) that is shared across multiple
+// resources (RuleGroup and WebACL). Both resources reference the same
+// underlying SDK Rules/Statement shape, so the second resource's injection
+// must not fail with "member already exists".
+func TestWAFv2_SharedShape_CustomNestedFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "wafv2")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	ruleGroupCRD := getCRDByName("RuleGroup", crds)
+	require.NotNil(ruleGroupCRD)
+
+	webACLCRD := getCRDByName("WebACL", crds)
+	require.NotNil(webACLCRD)
+
+	// Both resources inject custom nested fields (AndStatement, OrStatement,
+	// NotStatement) into the shared Statement shape. Verify they were injected
+	// successfully on both CRDs.
+	for _, crd := range []struct {
+		name string
+		fields map[string]*struct{}
+	}{
+		{name: "RuleGroup"},
+		{name: "WebACL"},
+	} {
+		c := getCRDByName(crd.name, crds)
+		require.NotNil(c, "CRD %s not found", crd.name)
+
+		rulesField := c.Fields["Rules"]
+		require.NotNil(rulesField, "%s.Rules field not found", crd.name)
+
+		// Rules is a list of Rule structs, each containing a Statement
+		stmtField := rulesField.MemberFields["Statement"]
+		require.NotNil(stmtField, "%s.Rules.Statement field not found", crd.name)
+
+		// Verify the custom nested fields were injected
+		assert.Contains(stmtField.MemberFields, "AndStatement",
+			"%s.Rules.Statement should have AndStatement", crd.name)
+		assert.Contains(stmtField.MemberFields, "OrStatement",
+			"%s.Rules.Statement should have OrStatement", crd.name)
+		assert.Contains(stmtField.MemberFields, "NotStatement",
+			"%s.Rules.Statement should have NotStatement", crd.name)
+
+		// Verify the injected fields have string type (as configured)
+		andStmt := stmtField.MemberFields["AndStatement"]
+		require.NotNil(andStmt)
+		require.NotNil(andStmt.ShapeRef)
+		require.NotNil(andStmt.ShapeRef.Shape)
+		assert.Equal("string", andStmt.ShapeRef.Shape.Type,
+			"%s.Rules.Statement.AndStatement should be string type", crd.name)
+	}
+}

--- a/pkg/testdata/models/apis/wafv2/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/wafv2/0000-00-00/generator.yaml
@@ -5,6 +5,11 @@ ignore:
     - RuleGroup.Rules.Statement.NotStatement
     - RuleGroup.Rules.Statement.ManagedRuleGroupStatement.ScopeDownStatement
     - RuleGroup.Rules.Statement.RateBasedStatement.ScopeDownStatement
+    - WebACL.Rules.Statement.AndStatement
+    - WebACL.Rules.Statement.OrStatement
+    - WebACL.Rules.Statement.NotStatement
+    - WebACL.Rules.Statement.ManagedRuleGroupStatement.ScopeDownStatement
+    - WebACL.Rules.Statement.RateBasedStatement.ScopeDownStatement
 empty_shapes:
   - All
   - Method
@@ -18,9 +23,39 @@ empty_shapes:
 operations:
   GetRuleGroup:
     output_wrapper_field_path: RuleGroup
+  GetWebACL:
+    output_wrapper_field_path: WebACL
 resources:
   RuleGroup:
     fields:
+      Name:
+        is_primary_key: true
+        is_immutable: true
+      Rules.Statement.AndStatement:
+        type: string
+        set:
+          - ignore: "all"
+      Rules.Statement.OrStatement:
+        type: string
+        set:
+          - ignore: "all"
+      Rules.Statement.NotStatement:
+        type: string
+        set:
+          - ignore: "all"
+      Rules.Statement.ManagedRuleGroupStatement.ScopeDownStatement:
+        type: string
+        set:
+          - ignore: "all"
+      Rules.Statement.RateBasedStatement.ScopeDownStatement:
+        type: string
+        set:
+          - ignore: "all"
+  WebACL:
+    fields:
+      Name:
+        is_primary_key: true
+        is_immutable: true
       Rules.Statement.AndStatement:
         type: string
         set:

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -9,10 +9,11 @@ import (
 type logLevel int
 
 const (
-	levelNone  logLevel = iota
-	levelInfo           // LOG_LEVEL=info
-	levelDebug          // LOG_LEVEL=debug
-	levelTrace          // LOG_LEVEL=trace (most verbose)
+	levelNone  logLevel = iota // suppress all
+	levelWarn                  // LOG_LEVEL=warn
+	levelInfo                  // LOG_LEVEL=info
+	levelDebug                 // LOG_LEVEL=debug
+	levelTrace                 // LOG_LEVEL=trace (most verbose)
 )
 
 var currentLevel = parseLogLevel(os.Getenv("LOG_LEVEL"))
@@ -25,6 +26,8 @@ func parseLogLevel(s string) logLevel {
 		return levelDebug
 	case "info":
 		return levelInfo
+	case "warn":
+		return levelWarn
 	default:
 		return levelNone
 	}
@@ -34,6 +37,11 @@ func logf(level logLevel, prefix, format string, args ...interface{}) {
 	if currentLevel >= level {
 		fmt.Fprintf(os.Stderr, prefix+format, args...)
 	}
+}
+
+// Warnf prints to stderr when LOG_LEVEL=warn or higher.
+func Warnf(format string, args ...interface{}) {
+	logf(levelWarn, "[warn] ", format, args...)
 }
 
 // Infof prints to stderr when LOG_LEVEL=info or higher.


### PR DESCRIPTION
Issue #, if available: [2893](https://github.com/aws-controllers-k8s/community/issues/2893)

Description of changes:
  - Fix generation failure when multiple resources inject custom nested fields into the same underlying SDK shape (e.g. WAFv2's Statement shape shared between WebACL and RuleGroup)
  - Add conflict detection: error with a clear message when overlapping custom fields have different types
  - Log a warning when a compatible duplicate injection is skipped, including the shared shape name
  - Add WAFv2 integration test validating the shared-shape scenario end-to-end

Context:
  PR #691 (Support custom list and map fields, ac02b64) introduced addMemberShapRef with a strict duplicate check that errored unconditionally when a member already existed. This broke controllers like wafv2-controller where both RuleGroup and WebACL configure custom nested fields (e.g. Rules.Statement.AndStatement) that resolve to the same shared SDK Statement shape. The second resource's injection would fail with:

```
Error: resource "WebACL", custom nested field "Rules.Statement.AndStatement": member "AndStatement" already exists in shape of type "structure"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
