### PR TITLE
fix: resolve Go field names correctly in late_initialize code generation

### DIFF
--- a/pkg/generate/code/late_initialize.go
+++ b/pkg/generate/code/late_initialize.go
@@ -22,6 +22,16 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 )
 
+func fieldGoName(r *model.CRD, configName string) string {
+	if f, ok := r.SpecFields[configName]; ok {
+		return f.Names.Camel
+	}
+	if f, ok := r.Fields[configName]; ok {
+		return f.Names.Camel
+	}
+	return configName
+}
+
 // FindLateInitializedFieldNames outputs the code to create a sorted slice of fieldNames to
 // late initialize. This slice helps with short circuiting the AWSResourceManager.LateInitialize()
 // method if there are no fields to late initialize.
@@ -49,7 +59,7 @@ func FindLateInitializedFieldNames(
 	sort.Strings(lateInitFieldNames)
 	out += fmt.Sprintf("%svar %s = []string{", indent, resVarName)
 	for _, fName := range lateInitFieldNames {
-		out += fmt.Sprintf("%q,", fName)
+		out += fmt.Sprintf("%q,", fieldGoName(r, fName))
 	}
 	out += "}\n"
 	return out
@@ -163,7 +173,8 @@ func LateInitializeFromReadOne(
 				continue
 			}
 			indent := strings.Repeat("\t", fNameIndentLevel)
-			fNamePartAccesor := fmt.Sprintf("Spec%s.%s", fParentPath, fNamePart)
+			goName := fieldGoName(r, fNamePart)
+			fNamePartAccesor := fmt.Sprintf("Spec%s.%s", fParentPath, goName)
 			if mapShapedParent {
 				fNamePartAccesor = fmt.Sprintf("Spec%s[%q]", fParentPath, fNamePart)
 			}
@@ -175,7 +186,7 @@ func LateInitializeFromReadOne(
 					fParentPath = fmt.Sprintf("%s[%q]", fParentPath, fNamePart)
 					mapShapedParent = false
 				} else {
-					fParentPath = fmt.Sprintf("%s.%s", fParentPath, fNamePart)
+					fParentPath = fmt.Sprintf("%s.%s", fParentPath, goName)
 				}
 				fNameIndentLevel = fNameIndentLevel + 1
 			} else {
@@ -303,7 +314,8 @@ func IncompleteLateInitialization(
 				continue
 			}
 			indent := strings.Repeat("\t", fNameIndentLevel)
-			fNamePartAccesor := fmt.Sprintf("Spec%s.%s", fParentPath, fNamePart)
+			goName := fieldGoName(r, fNamePart)
+			fNamePartAccesor := fmt.Sprintf("Spec%s.%s", fParentPath, goName)
 			if mapShapedParent {
 				fNamePartAccesor = fmt.Sprintf("Spec%s[%q]", fParentPath, fNamePart)
 			}
@@ -315,7 +327,7 @@ func IncompleteLateInitialization(
 					fParentPath = fmt.Sprintf("%s[%q]", fParentPath, fNamePart)
 					mapShapedParent = false
 				} else {
-					fParentPath = fmt.Sprintf("%s.%s", fParentPath, fNamePart)
+					fParentPath = fmt.Sprintf("%s.%s", fParentPath, goName)
 				}
 				fNameIndentLevel = fNameIndentLevel + 1
 			} else {

--- a/pkg/generate/code/late_initialize_test.go
+++ b/pkg/generate/code/late_initialize_test.go
@@ -233,3 +233,36 @@ func Test_IncompleteLateInitialization(t *testing.T) {
 	return false`
 	assert.Equal(expected, code.IncompleteLateInitialization(crd.Config(), crd, "latest", 1))
 }
+
+func Test_FindLateInitializedFieldNames_UnpackedAttributeField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "sqs", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-late-initialize.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Queue")
+	require.NotNil(crd)
+	assert.NotNil(crd.Config().GetFieldConfigs(crd.Names.Original)["SqsManagedSseEnabled"].LateInitialize)
+	expected :=
+		`	var lateInitializeFieldNames = []string{"SQSManagedSSEEnabled",}
+`
+	assert.Equal(expected, code.FindLateInitializedFieldNames(crd.Config(), crd, "lateInitializeFieldNames", 1))
+}
+
+func Test_LateInitializeFromReadOne_UnpackedAttributeField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "sqs", &testutil.TestingModelOptions{GeneratorConfigFile: "generator-with-late-initialize.yaml"})
+
+	crd := testutil.GetCRDByName(t, g, "Queue")
+	require.NotNil(crd)
+	expected :=
+		`	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.SQSManagedSSEEnabled != nil && latestKo.Spec.SQSManagedSSEEnabled == nil {
+		latestKo.Spec.SQSManagedSSEEnabled = observedKo.Spec.SQSManagedSSEEnabled
+	}
+	return &resource{latestKo}`
+	assert.Equal(expected, code.LateInitializeFromReadOne(crd.Config(), crd, "observed", "latest", 1))
+}

--- a/pkg/testdata/models/apis/sqs/0000-00-00/generator-with-late-initialize.yaml
+++ b/pkg/testdata/models/apis/sqs/0000-00-00/generator-with-late-initialize.yaml
@@ -1,0 +1,42 @@
+resources:
+  Queue:
+    unpack_attributes_map:
+      get_attributes_input:
+        overrides:
+          AttributeNames:
+            values:
+              - All
+    fields:
+      DelaySeconds:
+        is_attribute: true
+      MaximumMessageSize:
+        is_attribute: true
+      MessageRetentionPeriod:
+        is_attribute: true
+      KmsMasterKeyId:
+        is_attribute: true
+      KmsDataKeyReusePeriodSeconds:
+        is_attribute: true
+      Policy:
+        is_attribute: true
+      ReceiveMessageWaitTimeSeconds:
+        is_attribute: true
+      VisibilityTimeout:
+        is_attribute: true
+      FifoQueue:
+        is_attribute: true
+      ContentBasedDeduplication:
+        is_attribute: true
+      RedrivePolicy:
+        is_attribute: true
+      CreatedTimestamp:
+        is_attribute: true
+      QueueArn:
+        is_attribute: true
+        is_read_only: true
+      QueueUrl:
+        is_read_only: true
+        is_primary_key: true
+      SqsManagedSseEnabled:
+        is_attribute: true
+        late_initialize: {}


### PR DESCRIPTION
Description of changes:
The late_initialize template was using config field keys directly as Go
struct accessors. For fields from unpack_attributes_map (e.g. SQS
"SqsManagedSseEnabled"), the config key differs from the Go field name
("SQSManagedSSEEnabled"). This caused compilation errors in generated
controllers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
