### PR TITLE
Fix zero-value defaultValue trait only in member ref using pointer SDK value

### DIFF
--- a/pkg/api/shape.go
+++ b/pkg/api/shape.go
@@ -1059,13 +1059,68 @@ func (s *Shape) IsEnum() bool {
 	return s.Type == "string" && len(s.Enum) > 0
 }
 
-// HasDefaultValue returns whether this shape has a default value
+// HasDefaultValue returns whether this shape has a default value.
+// A ShapeRef has a default value if either the ref itself carries an explicit
+// default (set from the member's "smithy.api#default" trait) or the underlying
+// Shape carries one (e.g. the injected PrimitiveBoolean shape). The sentinel
+// value "<nil>" means a previously-assigned default was explicitly cleared.
 func (s *ShapeRef) HasDefaultValue() bool {
-	return s.DefaultValue != "<nil>" && s.Shape.HasDefaultValue()
+	if s.DefaultValue == "<nil>" {
+		return false
+	}
+	return s.DefaultValue != "" || s.Shape.HasDefaultValue()
 }
 
 func (s *Shape) HasDefaultValue() bool {
 	return s.DefaultValue != ""
+}
+
+// IsNonPointerInSDK returns true if AWS SDK Go v2 generates this member
+// as a value type (non-pointer) rather than a pointer.
+//
+// The smithy-go codegen (GoPointableIndex -> NullableIndex) treats a member as
+// non-nullable (value type) only when its @default equals the Go zero value
+// for the target type:
+//   - false for boolean
+//   - 0 for numeric types (integer, long, float, double, byte, short)
+//   - "" for string
+//
+// When the default is non-zero (e.g. @default(true) or @default(100)), the
+// SDK keeps the field as a pointer because serialization needs nil to
+// distinguish "not set" from "explicitly set to zero."
+//
+// The @default can come from the member reference itself (ShapeRef.DefaultValue)
+// or from the target shape (Shape.DefaultValue).
+func (s *ShapeRef) IsNonPointerInSDK() bool {
+	if s.DefaultValue == "<nil>" {
+		return false
+	}
+	// Determine the effective default value: prefer the ref, fall back to shape
+	defaultVal := s.DefaultValue
+	if defaultVal == "" {
+		defaultVal = s.Shape.DefaultValue
+	}
+	if defaultVal == "" {
+		return false // no default at all
+	}
+	// Check if the default equals the Go zero value for this type
+	return isDefaultZeroValue(defaultVal, s.Shape.Type)
+}
+
+// isDefaultZeroValue returns true if the given default value string equals the
+// Go zero value for the given Smithy shape type. This mirrors the logic in the
+// smithy-go codegen's NullableIndex.isDefaultZeroValueOfTypeInV1().
+func isDefaultZeroValue(defaultVal string, shapeType string) bool {
+	switch shapeType {
+	case "boolean":
+		return defaultVal == "false"
+	case "integer", "long", "float", "double", "byte", "short":
+		return defaultVal == "0"
+	case "string":
+		return defaultVal == ""
+	default:
+		return false
+	}
 }
 
 // IsRequired returns if member is a required field. Required fields are fields

--- a/pkg/api/shape.go
+++ b/pkg/api/shape.go
@@ -31,6 +31,8 @@ type ShapeRef struct {
 	Shape         *Shape `json:"-"`
 	Documentation string `json:"-"`
 	DefaultValue  string `json:"-"`
+	AddedDefault  bool   `json:"-"`
+	ClientOptional bool  `json:"-"`
 	ShapeName     string `json:"shape"`
 	Location      string
 	LocationName  string
@@ -1093,6 +1095,11 @@ func (s *Shape) HasDefaultValue() bool {
 // or from the target shape (Shape.DefaultValue).
 func (s *ShapeRef) IsNonPointerInSDK() bool {
 	if s.DefaultValue == "<nil>" {
+		return false
+	}
+	// @addedDefault and @clientOptional force the SDK to keep the field as a
+	// pointer regardless of the default value. See NullableIndex in smithy-go.
+	if s.AddedDefault || s.ClientOptional {
 		return false
 	}
 	// Determine the effective default value: prefer the ref, fall back to shape

--- a/pkg/api/shape_test.go
+++ b/pkg/api/shape_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestIsNonPointerInSDK_AddedDefault(t *testing.T) {
+	// A member with @default(false) AND @addedDefault should remain a pointer
+	ref := &ShapeRef{
+		DefaultValue: "false",
+		AddedDefault: true,
+		Shape: &Shape{
+			Type: "boolean",
+		},
+	}
+	if ref.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == false when AddedDefault is set, got true")
+	}
+
+	// Without AddedDefault, @default(false) on a boolean should be non-pointer
+	ref2 := &ShapeRef{
+		DefaultValue: "false",
+		Shape: &Shape{
+			Type: "boolean",
+		},
+	}
+	if !ref2.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == true for @default(false) boolean without AddedDefault, got false")
+	}
+}
+
+func TestIsNonPointerInSDK_ClientOptional(t *testing.T) {
+	// A member with @default(0) AND @clientOptional should remain a pointer
+	ref := &ShapeRef{
+		DefaultValue:   "0",
+		ClientOptional: true,
+		Shape: &Shape{
+			Type: "integer",
+		},
+	}
+	if ref.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == false when ClientOptional is set, got true")
+	}
+
+	// Without ClientOptional, @default(0) on an integer should be non-pointer
+	ref2 := &ShapeRef{
+		DefaultValue: "0",
+		Shape: &Shape{
+			Type: "integer",
+		},
+	}
+	if !ref2.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == true for @default(0) integer without ClientOptional, got false")
+	}
+}
+
+func TestIsNonPointerInSDK_NilDefault(t *testing.T) {
+	// <nil> sentinel value means the default was explicitly cleared
+	ref := &ShapeRef{
+		DefaultValue: "<nil>",
+		Shape: &Shape{
+			Type: "boolean",
+		},
+	}
+	if ref.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == false for <nil> DefaultValue, got true")
+	}
+}
+
+func TestIsNonPointerInSDK_NonZeroDefault(t *testing.T) {
+	// @default(true) on a boolean should still be a pointer (non-zero default)
+	ref := &ShapeRef{
+		DefaultValue: "true",
+		Shape: &Shape{
+			Type: "boolean",
+		},
+	}
+	if ref.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == false for @default(true) boolean, got true")
+	}
+}
+
+func TestIsNonPointerInSDK_ShapeLevelDefault(t *testing.T) {
+	// Default value from shape level (e.g. PrimitiveBoolean)
+	ref := &ShapeRef{
+		Shape: &Shape{
+			Type:         "boolean",
+			DefaultValue: "false",
+		},
+	}
+	if !ref.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == true for shape-level @default(false) boolean, got false")
+	}
+
+	// Shape-level default with AddedDefault on the ref should still be pointer
+	ref2 := &ShapeRef{
+		AddedDefault: true,
+		Shape: &Shape{
+			Type:         "boolean",
+			DefaultValue: "false",
+		},
+	}
+	if ref2.IsNonPointerInSDK() {
+		t.Error("expected IsNonPointerInSDK() == false when AddedDefault is set with shape-level default, got true")
+	}
+}

--- a/pkg/apiv2/converter.go
+++ b/pkg/apiv2/converter.go
@@ -274,6 +274,14 @@ func addMemberRefs(apiShape *awssdkmodel.Shape, shape Shape, serviceAlias string
 		if ok {
 			apiShape.MemberRefs[memberName].DefaultValue = fmt.Sprintf("%v", val)
 		}
+		_, ok = member.Traits["smithy.api#addedDefault"]
+		if ok {
+			apiShape.MemberRefs[memberName].AddedDefault = true
+		}
+		_, ok = member.Traits["smithy.api#clientOptional"]
+		if ok {
+			apiShape.MemberRefs[memberName].ClientOptional = true
+		}
 	}
 	slices.Sort(apiShape.Required)
 }

--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -341,7 +341,7 @@ func SetResource(
 			out += fmt.Sprintf(
 				"%sif %s != \"\" {\n", indent, sourceAdaptedVarName,
 			)
-		} else if !sourceMemberShapeRef.HasDefaultValue() {
+		} else if !sourceMemberShapeRef.IsNonPointerInSDK() {
 			// The fields that have a default value (boolean and integer)
 			// are not pointers, so we won't need to check if they are nil
 			out += fmt.Sprintf(
@@ -417,7 +417,7 @@ func SetResource(
 		if sourceMemberShapeRef.Shape.RealType == "union" {
 			sourceMemberShapeRef.Shape.Type = "structure"
 		}
-		if sourceMemberShapeRef.Shape.IsEnum() || !sourceMemberShapeRef.HasDefaultValue() {
+		if sourceMemberShapeRef.Shape.IsEnum() || !sourceMemberShapeRef.IsNonPointerInSDK() {
 			out += fmt.Sprintf(
 				"%s} else {\n", indent,
 			)
@@ -689,7 +689,7 @@ func setResourceReadMany(
 			out += fmt.Sprintf(
 				"%sif %s != \"\" {\n", innerForIndent, sourceAdaptedVarName,
 			)
-		} else if !sourceMemberShapeRef.HasDefaultValue() {
+		} else if !sourceMemberShapeRef.IsNonPointerInSDK() {
 			out += fmt.Sprintf(
 				"%sif %s != nil {\n", innerForIndent, sourceAdaptedVarName,
 			)
@@ -788,7 +788,7 @@ func setResourceReadMany(
 		if sourceMemberShapeRef.Shape.RealType == "union" {
 			sourceMemberShapeRef.Shape.Type = "structure"
 		}
-		if sourceMemberShapeRef.Shape.IsEnum() || !sourceMemberShapeRef.HasDefaultValue() {
+		if sourceMemberShapeRef.Shape.IsEnum() || !sourceMemberShapeRef.IsNonPointerInSDK() {
 			out += fmt.Sprintf(
 				"%s} else {\n", innerForIndent,
 			)
@@ -1857,7 +1857,7 @@ func SetResourceForStruct(
 			out += fmt.Sprintf(
 				"%sif %s != \"\" {\n", indent, sourceAdaptedVarName,
 			)
-		} else if !sourceMemberShapeRef.HasDefaultValue() {
+		} else if !sourceMemberShapeRef.IsNonPointerInSDK() {
 			// The fields that have a default value (boolean and integer)
 			// are not pointers, so we won't need to check if they are nil
 			out += fmt.Sprintf(
@@ -1928,7 +1928,7 @@ func SetResourceForStruct(
 		if sourceMemberShapeRef.Shape.RealType == "union" {
 			sourceMemberShapeRef.Shape.Type = "structure"
 		}
-		if sourceMemberShape.IsEnum() || !sourceMemberShapeRef.HasDefaultValue() {
+		if sourceMemberShape.IsEnum() || !sourceMemberShapeRef.IsNonPointerInSDK() {
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)
@@ -1970,7 +1970,7 @@ func SetResourceForStruct(
 						out += fmt.Sprintf(
 							"%sif %s != \"\" {\n", indent, sourceAdaptedVarName,
 						)
-					} else if !sourceShapeRef.HasDefaultValue() {
+					} else if !sourceShapeRef.IsNonPointerInSDK() {
 						// The fields that have a default value (boolean and integer)
 						// are not pointers, so we won't need to check if they are nil
 						out += fmt.Sprintf(
@@ -1983,7 +1983,7 @@ func SetResourceForStruct(
 
 					// Use setResourceForScalar and dereference sourceAdaptedVarName
 					// because primitives are being set.
-					if !sourceMemberShapeRef.HasDefaultValue() {
+					if !sourceMemberShapeRef.IsNonPointerInSDK() {
 						sourceAdaptedVarName = "*" + sourceAdaptedVarName
 					}
 					out += setResourceForScalar(
@@ -1994,7 +1994,7 @@ func SetResourceForStruct(
 						false,
 						false,
 					)
-					if sourceShape.IsEnum() || !sourceShapeRef.HasDefaultValue() {
+					if sourceShape.IsEnum() || !sourceShapeRef.IsNonPointerInSDK() {
 						out += fmt.Sprintf(
 							"%s}\n", indent,
 						)
@@ -2296,7 +2296,7 @@ func setResourceForScalar(
 
 	targetVar = strings.TrimPrefix(targetVar, ".")
 	if actualType, ok := intOrFloat[shape.Type]; ok {
-		if !shapeRef.HasDefaultValue() && !isList {
+		if !shapeRef.IsNonPointerInSDK() && !isList {
 			setTo = "*" + setTo
 		}
 		ogMemberName := names.New(shapeRef.OriginalMemberName)
@@ -2307,7 +2307,7 @@ func setResourceForScalar(
 		out += fmt.Sprintf("%s%s = &%sCopy\n", indent, targetVar, ogMemberName.CamelLower)
 	} else if shape.IsEnum() {
 		out += fmt.Sprintf("%s%s = aws.String(string(%s))\n", indent, targetVar, strings.TrimPrefix(setTo, "*"))
-	} else if shapeRef.HasDefaultValue() {
+	} else if shapeRef.IsNonPointerInSDK() {
 		out += fmt.Sprintf("%s%s = &%s\n", indent, targetVar, setTo)
 	} else {
 		out += fmt.Sprintf("%s%s = %s%s\n", indent, targetVar, address, strings.TrimPrefix(setTo, "*"))

--- a/pkg/generate/code/set_sdk.go
+++ b/pkg/generate/code/set_sdk.go
@@ -1500,7 +1500,7 @@ func setSDKForMap(
 	}
 
 	dereference := "*"
-	if !targetShapeRef.HasDefaultValue() && targetShape.ValueRef.Shape.Type != "structure" {
+	if !targetShapeRef.IsNonPointerInSDK() && targetShape.ValueRef.Shape.Type != "structure" {
 		dereference = ""
 	}
 	// Union types are interfaces, not pointers — no dereference needed
@@ -1740,13 +1740,13 @@ func setSDKForScalar(
 		out += fmt.Sprintf("%s}\n", indent)
 		tempVar := ogShapeName.CamelLower + "Copy"
 		out += fmt.Sprintf("%s%s := %s32(%s)\n", indent, tempVar, actualType[2], dereferencedVal)
-		if !shapeRef.HasDefaultValue() && !isListMember {
+		if !shapeRef.IsNonPointerInSDK() && !isListMember {
 			tempVar = "&" + tempVar
 		}
 		out += fmt.Sprintf("%s%s = %s\n", indent, targetVarPath, tempVar)
 	} else if shape.IsEnum() {
 		out += fmt.Sprintf("%s%s = svcsdktypes.%s(%s)\n", indent, targetVarPath, shape.ShapeName, setTo)
-	} else if shapeRef.HasDefaultValue() {
+	} else if shapeRef.IsNonPointerInSDK() {
 		out += fmt.Sprintf("%s%s = %s\n", indent, targetVarPath, setTo)
 
 	} else if targetVarType == "structure" && shape.Type == "boolean" {

--- a/pkg/generate/code/set_sdk_browser_test.go
+++ b/pkg/generate/code/set_sdk_browser_test.go
@@ -1,0 +1,56 @@
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/code-generator/pkg/generate/code"
+	"github.com/aws-controllers-k8s/code-generator/pkg/model"
+	"github.com/aws-controllers-k8s/code-generator/pkg/testutil"
+)
+
+// TestSetSDK_BedrockAgentCoreControl_Browser_DefaultBool verifies that a
+// boolean member with @default on the member reference (targeting
+// smithy.api#Boolean) is treated as a value type (non-pointer) in generated
+// code. Specifically:
+//   - SetSDK (Create): should dereference the CRD field with * to assign to the
+//     non-pointer SDK field (e.g. f0.Enabled = *r.ko.Spec.BrowserSigning.Enabled)
+//   - SetResource (ReadOne): should use & to take the address when assigning to
+//     the CRD pointer field (e.g. f2.Enabled = &resp.BrowserSigning.Enabled)
+//     and should NOT generate a nil check (the SDK field is not a pointer).
+func TestSetSDK_BedrockAgentCoreControl_Browser_DefaultBool(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "bedrock-agentcore-control", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-browser.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Browser")
+	require.NotNil(crd)
+	require.NotNil(crd.Ops.Create)
+
+	// --- SetSDK Create ---
+	// The SDK's BrowserSigningConfigInput.Enabled is a non-pointer bool because
+	// the member targets smithy.api#Boolean with @default(false). The generated
+	// code must dereference the CRD's *bool field with *.
+	sdkOut, err := code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1)
+	require.NoError(err)
+
+	// Should dereference: f<N>.Enabled = *r.ko.Spec.BrowserSigning.Enabled
+	assert.Contains(sdkOut, "= *r.ko.Spec.BrowserSigning.Enabled")
+	// Should NOT assign without dereference (pointer to non-pointer mismatch)
+	assert.NotContains(sdkOut, "= r.ko.Spec.BrowserSigning.Enabled\n")
+
+	// --- SetResource ReadOne ---
+	require.NotNil(crd.Ops.ReadOne)
+	resOut, err := code.SetResource(crd.Config(), crd, model.OpTypeGet, "resp", "ko", 1)
+	require.NoError(err)
+
+	// Should take address: f<N>.Enabled = &resp.BrowserSigning.Enabled
+	assert.Contains(resOut, "= &resp.BrowserSigning.Enabled")
+	// Should NOT generate a nil check for the non-pointer bool field
+	assert.NotContains(resOut, "if resp.BrowserSigning.Enabled != nil")
+}

--- a/pkg/testdata/models/apis/bedrock-agentcore-control/0000-00-00/generator-browser.yaml
+++ b/pkg/testdata/models/apis/bedrock-agentcore-control/0000-00-00/generator-browser.yaml
@@ -1,0 +1,28 @@
+ignore:
+  resource_names:
+    - AgentRuntime
+    - AgentRuntimeEndpoint
+    - ApiKeyCredentialProvider
+    # - Browser  # NOT ignored
+    - BrowserProfile
+    - CodeInterpreter
+    - Evaluator
+    - Gateway
+    - GatewayTarget
+    - Memory
+    - Oauth2CredentialProvider
+    - OnlineEvaluationConfig
+    - WorkloadIdentity
+    - Policy
+    - PolicyEngine
+  field_paths:
+    - CreateGatewayTargetInput.TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.ToolDefinition.InputSchema
+    - CreateGatewayTargetInput.TargetConfiguration.Mcp.Lambda.ToolSchema.InlinePayload.ToolDefinition.OutputSchema
+sdk_names:
+  model_name: bedrock-agentcore-control
+resources:
+  Browser:
+    ignore_idempotency_token: true
+    fields:
+      BrowserId:
+        is_primary_key: true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixes bug when generating code for SDK member fields that had `smith.api#defaultValue` trait set to Go zero-value only in member reference and not the underlying target shape. When generating code for such a field the ACK code-generator both failed to check the `defaultValue` trait set at the member ref level and incorrectly treated the field as a non-pointer type when the default used a non-zero value. 

Additionally, to avoid regressions in controllers that were previously ignoring member level defaultValue traits support for reading the `addedDefault` and `clientOptional` traits to support forcing fields with those traits to use pointer types.

Smithy references:
[GoPointableIndex.isMemberPointable](https://github.com/aws/smithy-go/blob/3f6ece24dd0646e1f43ce05d980bcb4880a6e7fe/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoPointableIndex.java#L166)
[NullableIndex.CLIENT_ZERO_VALUE_V1_NO_INPUT](https://github.com/smithy-lang/smithy/blob/d62a9fca81f30d4e7773e58fb3c67d3ab682dfb6/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java#L101)

- Add IsNonPointerInSDK() to encompass logic for when to use a pointer value for an SDK shape.
- Update set_resource and set_sdk to use IsNonPointerInSDK() instead of directly calling HasDefaultValue().
- Add test case for Bedrock AgentCore Browser resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
