### PR TITLE
feat: filter ignore-field-drift differences from generated resource delta

### DIFF
--- a/templates/pkg/resource/delta.go.tpl
+++ b/templates/pkg/resource/delta.go.tpl
@@ -7,6 +7,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws-controllers-k8s/runtime/pkg/featuregate"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 )
 
@@ -36,6 +38,15 @@ func newResourceDelta(
 {{- if $hookCode := Hook .CRD "delta_post_compare" }}
 {{ $hookCode }}
 {{- end }}
+	// Selective reconciliation: when the SelectiveReconciliation feature gate
+	// is enabled and the desired resource carries the
+	// services.k8s.aws/ignore-field-drift annotation, remove any difference
+	// under an ignored field path so that drift on those fields never marks the
+	// resource out-of-sync. This is a no-op for resources that do not use the
+	// feature.
+	if a != nil {
+		ackrt.FilterIgnoredDeltaDifferences(delta, a, featuregate.GetGlobalFeatureGates())
+	}
 	return delta
 }
 


### PR DESCRIPTION
## Description

Wires the runtime's selective field reconciliation feature into the generated per-resource delta. After the existing `delta_post_compare` hook (and before `return delta`), the generated `newResourceDelta` now calls `ackrt.FilterIgnoredDeltaDifferences(delta, a, featuregate.GetGlobalFeatureGates())`.

This ensures that when the `SelectiveReconciliation` feature gate is enabled and a resource carries the `services.k8s.aws/ignore-field-drift` annotation, differences under an ignored field path are removed from the computed delta. As a result, **every** consumer of the generated delta — including the requeue / `IsSynced` path, not just the update path — treats drift on those fields as ignored, consistent with the runtime behavior.

The call is gated and a no-op when the feature is disabled, so existing controllers are unaffected until an operator opts in. The only change is one template (`templates/pkg/resource/delta.go.tpl`); controllers pick it up on their next code-generation + runtime bump. There are no CRD changes.

## Dependency / ordering

> ⚠️ Depends on the companion ACK runtime change that adds `FilterIgnoredDeltaDifferences` and the process-wide feature-gate accessors. Regenerated `delta.go` will not compile until that runtime change is merged and released, and this PR's runtime pin is bumped to that release. **Do not merge until the runtime change is merged and released.**

## Testing

Regenerated the iam-controller with this template against the companion runtime: the generated `pkg/resource/role/delta.go` contains the `FilterIgnoredDeltaDifferences` call and the controller compiles. The feature was then verified end-to-end on a live account (external tag survives reconciliation; resource stays `Synced`).

Refs aws-controllers-k8s/community#2367
