### PR TITLE
Remove outdated aws-sdk-go v1 anti-collision logic for Validate fields

### DIFF
--- a/pkg/api/passes.go
+++ b/pkg/api/passes.go
@@ -429,8 +429,7 @@ func renameCollidingField(name string, v *Shape, field *ShapeRef) {
 func collides(name string) bool {
 	switch name {
 	case "String",
-		"GoString",
-		"Validate":
+		"GoString":
 		return true
 	}
 	return false

--- a/pkg/api/passes_test.go
+++ b/pkg/api/passes_test.go
@@ -183,7 +183,7 @@ func TestCollidingFields(t *testing.T) {
 				"OrigErr",
 				"SetFoo_",
 				"String_",
-				"Validate_",
+				"Validate",
 			},
 		},
 		"ExceptionShape": {

--- a/pkg/generate/code/set_resource_test.go
+++ b/pkg/generate/code/set_resource_test.go
@@ -5607,3 +5607,25 @@ func TestSetResource_BedrockAgentCoreControl_Memory_InputSuffixUnion(t *testing.
 	assert.NotContains(got, "TriggerConditionInput_",
 		"Should use original SDK shape name TriggerConditionInput, not renamed version")
 }
+
+// TestSetResource_LambdaMicrovms_MicrovmImage_Create_ValidateField is the
+// read-path counterpart to the SetSDK regression test. It ensures the
+// generated code reads the real aws-sdk-go-v2 field "Validate" off the
+// response shape rather than the historically-mangled "Validate_" produced by
+// the renameCollidingFields pass. See that test for the full background.
+func TestSetResource_LambdaMicrovms_MicrovmImage_Create_ValidateField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambdamicrovms")
+
+	crd := testutil.GetCRDByName(t, g, "MicrovmImage")
+	require.NotNil(crd)
+
+	got, err := code.SetResource(crd.Config(), crd, model.OpTypeCreate, "resp", "ko", 1)
+	require.NoError(err)
+
+	assert.Contains(got, "if resp.Hooks.MicrovmImageHooks.Validate != \"\" {")
+	assert.Contains(got, "f10f1.Validate = aws.String(string(resp.Hooks.MicrovmImageHooks.Validate))")
+	assert.NotContains(got, "Validate_")
+}

--- a/pkg/generate/code/set_sdk_test.go
+++ b/pkg/generate/code/set_sdk_test.go
@@ -6960,3 +6960,30 @@ func TestSetSDK_EKS_Nodegroup_Create(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(expected, got)
 }
+
+// TestSetSDK_LambdaMicrovms_MicrovmImage_Create_ValidateField is a regression
+// test for the code-generator's renameCollidingFields pass. The "Validate"
+// member name was historically renamed to "Validate_" to avoid colliding with
+// the Validate() method generated on aws-sdk-go (v1) input shapes. aws-sdk-go-v2
+// types carry no such method, so the rename produced references to a
+// non-existent SDK field (e.g. svcsdktypes.MicrovmImageHooks.Validate_) and
+// broke compilation. The MicrovmImageHooks shape has a member literally named
+// "Validate", so this asserts the generated SDK code targets the real field.
+func TestSetSDK_LambdaMicrovms_MicrovmImage_Create_ValidateField(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForService(t, "lambdamicrovms")
+
+	crd := testutil.GetCRDByName(t, g, "MicrovmImage")
+	require.NotNil(crd)
+
+	got, err := code.SetSDK(crd.Config(), crd, model.OpTypeCreate, "r.ko", "res", 1)
+	require.NoError(err)
+
+	// The Validate member must map to the real SDK field "Validate", not the
+	// historically-mangled "Validate_".
+	assert.Contains(got, "if r.ko.Spec.Hooks.MicrovmImageHooks.Validate != nil {")
+	assert.Contains(got, "f10f1.Validate = svcsdktypes.HookState(*r.ko.Spec.Hooks.MicrovmImageHooks.Validate)")
+	assert.NotContains(got, "Validate_")
+}

--- a/pkg/testdata/codegen/sdk-codegen/aws-models/lambdamicrovms.json
+++ b/pkg/testdata/codegen/sdk-codegen/aws-models/lambdamicrovms.json
@@ -1,0 +1,5336 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.amazonaws.lambdamicrovms#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You do not have sufficient access to perform this action.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Architecture": {
+            "type": "enum",
+            "members": {
+                "ARM_64": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ARM_64"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#AuthTokenKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#AuthTokenValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 8000
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#BuildState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "SUCCESSFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCESSFUL"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Capability": {
+            "type": "enum",
+            "members": {
+                "ALL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "The application is granted all available OS capabilities",
+                        "smithy.api#enumValue": "ALL"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "Capability granted to the application when booted"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CapabilityList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#Capability"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of capabilities granted to the application when booted"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Chipset": {
+            "type": "enum",
+            "members": {
+                "GRAVITON": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GRAVITON"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CloudWatchLogging": {
+            "type": "structure",
+            "members": {
+                "logGroup": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch Logs log group to send logs to.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 512
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9_\\-/.#]+$"
+                    }
+                },
+                "logStream": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch Logs log stream within the log group.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 512
+                        },
+                        "smithy.api#pattern": "^[^:*]*$"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for Amazon CloudWatch Logs logging.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CodeArtifact": {
+            "type": "union",
+            "members": {
+                "uri": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URI of the code artifact, such as an Amazon S3 path or Amazon ECR image URI.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the location of the code artifact for a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that caused the conflict.</p>"
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that caused the conflict.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request could not be completed due to a conflict with the current state of the resource.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CpuConfiguration": {
+            "type": "structure",
+            "members": {
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CPU architecture.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for the CPU architecture of a MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CpuConfigurationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#CpuConfiguration"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of CPU architectures"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates an authentication token for accessing a running MicroVM. The token grants access to the specified ports on the MicroVM endpoint.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/auth-token",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to create an authentication token for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "expirationInMinutes": {
+                    "target": "com.amazonaws.lambdamicrovms#PositiveInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration in minutes before the authentication token expires. Maximum: 60 minutes.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "allowedPorts": {
+                    "target": "com.amazonaws.lambdamicrovms#ListOfPortSpecification",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of port specifications that the authentication token grants access to on the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenResponse": {
+            "type": "structure",
+            "members": {
+                "authToken": {
+                    "target": "com.amazonaws.lambdamicrovms#TokenParts",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map containing the authentication token. Use the value at key \"X-aws-proxy-auth\" as the header value when connecting to the MicroVM endpoint.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImageResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a MicroVM image from the specified code artifact and base image. The build is asynchronous — the image transitions from CREATING to CREATED on success, or CREATE_FAILED on failure. Use GetMicrovmImage to poll for completion.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvm-images",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImageRequest": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Lambda-managed base MicroVM image to build upon. Use ListManagedMicrovmImages to discover available base images.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image to use.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role assumed during the image build process. This role must have permissions to access the code artifact and any required resources.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image. Must be unique within the AWS account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request. If you retry a request that completed successfully using the same client token, the operation returns the successful response without performing any further actions.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImageResponse": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the created MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>"
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a shell authentication token for interactive shell access to a running MicroVM. The MicroVM must have been run with the SHELL_INGRESS network connector attached.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/shell-auth-token",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to create a shell authentication token for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "expirationInMinutes": {
+                    "target": "com.amazonaws.lambdamicrovms#PositiveInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration in minutes before the shell authentication token expires.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenResponse": {
+            "type": "structure",
+            "members": {
+                "authToken": {
+                    "target": "com.amazonaws.lambdamicrovms#TokenParts",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The generated shell authentication token key-value pairs for accessing the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a MicroVM image. This operation is idempotent; deleting an image that has already been deleted succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageOutput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the deleted MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image after deletion.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a specific version of a MicroVM image. This operation is idempotent; deleting a version that has already been deleted succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionOutput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version that was deleted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image version after deletion.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableMap": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableValue"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4096
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific MicroVM, including its state, endpoint, image information, and configuration. The state field is eventually consistent — determine readiness by connecting to the endpoint.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a MicroVM image, including its state, versions, and configuration.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuild": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific MicroVM image build, including its state, target architecture, and snapshot information.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}/builds/{buildId}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the build to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildOutput": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The build request ID.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildState": {
+                    "target": "com.amazonaws.lambdamicrovms#BuildState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target CPU architecture for the build. Supported value: ARM_64.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset generation for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the build state, if applicable.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the build was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "snapshotBuild": {
+                    "target": "com.amazonaws.lambdamicrovms#SnapshotBuild",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The snapshot build details, including memory and disk snapshot sizes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageOutput": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific version of a MicroVM image, including its configuration, state, and build information.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionOutput": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmResponse": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endpoint": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTPS endpoint URL for communicating with the MicroVM. Include a valid authentication token in the X-aws-proxy-auth header when sending requests.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM execution role assumed by the MicroVM.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The idle policy configuration of the MicroVM, controlling auto-suspend and auto-resume behavior.</p>"
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist before being terminated by the platform.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM first started.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "terminatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM terminated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for why the MicroVM is in the current state.</p>"
+                    }
+                },
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors configured for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors configured for the MicroVM.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#HookState": {
+            "type": "enum",
+            "members": {
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                },
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "Whether invocation hooks are enabled or disabled on a MicroVm."
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Hooks": {
+            "type": "structure",
+            "members": {
+                "port": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port number on which the hooks listener runs.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 65535
+                        }
+                    }
+                },
+                "microvmHooks": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmHooks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The lifecycle hooks for MicroVM events.</p>"
+                    }
+                },
+                "microvmImageHooks": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageHooks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The hooks for MicroVM image build events.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Lifecycle hook configuration for MicroVMs and MicroVM images.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#IdlePolicy": {
+            "type": "structure",
+            "members": {
+                "maxIdleDurationSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum time in seconds that a MicroVM can remain idle before it is automatically suspended.</p>",
+                        "smithy.api#range": {
+                            "min": 60
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "suspendedDurationSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum time in seconds that a MicroVM can remain suspended before it is automatically terminated.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "autoResumeEnabled": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether the MicroVM automatically resumes when it receives a request while suspended.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration that controls MicroVM auto-suspend and auto-resume behavior. Idle time is measured by inbound traffic through the MicroVM proxy endpoint — if no requests arrive within the configured duration, the MicroVM is suspended.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ImageName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "Name of a MicroVM image.",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "retryAfterSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of seconds to wait before retrying the request.</p>",
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An internal server error occurred. Retry the request later.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500,
+                "smithy.api#retryable": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#InvalidParameterValueException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>One of the parameters in the request is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.lambdamicrovms#LambdaMicrovms": {
+            "type": "service",
+            "version": "2025-09-09",
+            "operations": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersion"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuild"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersion"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImages"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersions"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuilds"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImages"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersions"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListTags"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersion"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#Microvm"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Lambda Microvms",
+                    "arnNamespace": "lambda"
+                },
+                "aws.auth#sigv4": {
+                    "name": "lambda"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#documentation": "<p>Provides APIs to create, manage, and operate AWS Lambda MicroVMs and their associated MicroVM Image environments.</p>",
+                "smithy.api#title": "Lambda MicroVMs",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ],
+                            "type": "tree"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists versions of a managed MicroVM image. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/managed-microvm-images/{imageIdentifier}/versions",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the managed MicroVM image to list versions for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of managed MicroVM image versions.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists AWS managed MicroVM images available for use as base images. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/managed-microvm-images",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of managed MicroVM images.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuilds": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists builds for a MicroVM image version with optional filtering by architecture and chipset. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}/builds",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to list builds for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target CPU architecture.</p>",
+                        "smithy.api#httpQuery": "architecture"
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target chipset.</p>",
+                        "smithy.api#httpQuery": "chipset"
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target chipset generation.</p>",
+                        "smithy.api#httpQuery": "chipsetGeneration"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM image builds.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists versions of a MicroVM image. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to list versions for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM image versions.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImagesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImagesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists MicroVM images in the account with optional name filtering. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImagesRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "nameFilter": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters images whose name contains the specified string.</p>",
+                        "smithy.api#httpQuery": "nameFilter"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImagesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM images.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovms": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists MicroVMs in the account with optional filtering by image and version. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvms",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmsRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional filter to list only MicroVMs running the specified image.</p>",
+                        "smithy.api#httpQuery": "imageIdentifier"
+                    }
+                },
+                "imageVersion": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional filter to list only MicroVMs running the specified image version.</p>",
+                        "smithy.api#httpQuery": "imageVersion"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmItemList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVMs.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListOfPortSpecification": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#PortSpecification"
+            },
+            "traits": {
+                "smithy.api#documentation": "A list of port specifications.",
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTags": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListTagsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListTagsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "ListTags",
+                    "documentation": "Grants permission to list tags on a resource"
+                },
+                "smithy.api#documentation": "<p>Lists the tags associated with a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTagsRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to list tags for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTagsResponse": {
+            "type": "structure",
+            "members": {
+                "Tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value pairs of tags associated with the resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Logging": {
+            "type": "union",
+            "members": {
+                "disabled": {
+                    "target": "com.amazonaws.lambdamicrovms#LoggingDisabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies that logging is disabled.</p>"
+                    }
+                },
+                "cloudWatch": {
+                    "target": "com.amazonaws.lambdamicrovms#CloudWatchLogging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for sending logs to Amazon CloudWatch Logs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for MicroVM logging output. Specify exactly one: cloudWatch to enable CloudWatch logging, or disabled to turn off logging.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#LoggingDisabled": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies that logging is disabled for the MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the managed MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the managed MicroVM image was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a managed MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummary"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersion": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains version information for a managed MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersion"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Microvm": {
+            "type": "resource",
+            "identifiers": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovm"
+            },
+            "read": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovm"
+            },
+            "delete": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovm"
+            },
+            "list": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovms"
+            },
+            "operations": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthToken"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthToken"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResumeMicrovm"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#SuspendMicrovm"
+                }
+            ]
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmHooks": {
+            "type": "structure",
+            "members": {
+                "run": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM starts running.</p>"
+                    }
+                },
+                "runTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the run hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "resume": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM resumes from a suspended state.</p>"
+                    }
+                },
+                "resumeTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the resume hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "suspend": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM is suspended.</p>"
+                    }
+                },
+                "suspendTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the suspend hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "terminate": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM is terminated.</p>"
+                    }
+                },
+                "terminateTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the terminate hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for lifecycle hooks invoked during MicroVM events such as run, resume, suspend, and terminate.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN or ID of the MicroVm",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "MicroVm Image Arn",
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummary"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The build request ID.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildState": {
+                    "target": "com.amazonaws.lambdamicrovms#BuildState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target CPU architecture for the build. Supported value: ARM_64.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset generation for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the build state, if applicable.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the build was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM image build.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageHooks": {
+            "type": "structure",
+            "members": {
+                "ready": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM image build is ready.</p>"
+                    }
+                },
+                "readyTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 30,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the ready hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 3600
+                        }
+                    }
+                },
+                "validate": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked to validate the MicroVM image build.</p>"
+                    }
+                },
+                "validateTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 30,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the validate hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 3600
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for hooks invoked during MicroVM image build events such as ready and validate.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN or ID of the MicroVmImage",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageState": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "CREATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATED"
+                    }
+                },
+                "CREATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_FAILED"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                },
+                "UPDATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATED"
+                    }
+                },
+                "UPDATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATE_FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_FAILED"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageSummary"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of MicroVM image summaries"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "SUCCESSFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCESSFUL"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                },
+                "DELETE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus": {
+            "type": "enum",
+            "members": {
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "Customer image version is active and can be used",
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "INACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "Customer image version is inactive and should not be used",
+                        "smithy.api#enumValue": "INACTIVE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummary": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a version of a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummary"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of MicroVM image version summaries"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmItem": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM started.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM instance.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmItemList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmItem"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "RUNNING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RUNNING"
+                    }
+                },
+                "SUSPENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUSPENDING"
+                    }
+                },
+                "SUSPENDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUSPENDED"
+                    }
+                },
+                "TERMINATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TERMINATING"
+                    }
+                },
+                "TERMINATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TERMINATED"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "The lifecycle state of a MicroVm."
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NetworkConnector": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NetworkConnectorList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#NetworkConnector"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NonBlankString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "A string which is not empty or blank (only whitespace).",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortNumber": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#documentation": "Represents a single port.",
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 65535
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortRange": {
+            "type": "structure",
+            "members": {
+                "startPort": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting port number of the range.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endPort": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending port number of the range.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies a range of ports.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortSpecification": {
+            "type": "union",
+            "members": {
+                "port": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A single port number.</p>"
+                    }
+                },
+                "range": {
+                    "target": "com.amazonaws.lambdamicrovms#PortRange",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A range of ports.</p>"
+                    }
+                },
+                "allPorts": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates that all ports are accessible.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies which ports are accessible on a MicroVM. Only one of the port specification options can be set.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PositiveInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourceConflictException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The resource already exists, or another operation is in progress.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that was not found.</p>"
+                    }
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that was not found.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified resource does not exist.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Resources": {
+            "type": "structure",
+            "members": {
+                "minimumMemoryInMiB": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The minimum amount of memory in MiB to allocate to the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Resource requirements for a MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourcesList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#Resources"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of resources",
+                "smithy.api#length": {
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ResumeMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ResumeMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Resumes a suspended MicroVM, restoring it to RUNNING state with all state intact. The MicroVM must be in SUSPENDED state.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/resume",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to resume.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RoleArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN of an IAM role that the service assumes to perform actions on behalf of the caller.",
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:aws[a-z\\-]*:iam::[0-9]{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Runs a new MicroVM from the specified image. The MicroVM starts in PENDING state and transitions to RUNNING once provisioning completes. To connect, generate an authentication token using CreateMicrovmAuthToken.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors to configure for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors to configure for the MicroVM.</p>"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier (ARN or ID) of the MicroVM image to run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to run.</p>"
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role to be assumed by the MicroVM during execution.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration to control auto-suspend and auto-resume behavior.</p>"
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this MicroVM instance. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream application logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "runHookPayload": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Per-MicroVM initialization data delivered as the request body of the /run lifecycle hook. Use to pass tenant-specific configuration such as session IDs or secret references. Maximum: 16,384 bytes.</p>",
+                        "smithy.api#length": {
+                            "max": 4096
+                        }
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist before being terminated by the platform. Valid range: 1–28,800 (8 hours).</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 28800
+                        }
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovmResponse": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endpoint": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTPS endpoint URL for communicating with the MicroVM. Include a valid authentication token in the X-aws-proxy-auth header when sending requests.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM execution role assumed by the MicroVM.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The idle policy configuration of the MicroVM.</p>"
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM first started.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "terminatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM terminated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for why the MicroVM is in the current state.</p>"
+                    }
+                },
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors configured for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors configured for the MicroVM.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ServiceException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The AWS Lambda MicroVMs service encountered an internal error.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that exceeded the quota.</p>"
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that exceeded the quota.</p>"
+                    }
+                },
+                "serviceCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service code of the exceeded service quota.</p>"
+                    }
+                },
+                "quotaCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota code of the exceeded service quota.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You have exceeded a service quota for Lambda MicroVMs.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SnapshotBuild": {
+            "type": "structure",
+            "members": {
+                "memorySnapshotSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the memory snapshot in bytes.</p>"
+                    }
+                },
+                "codeInstallSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the installed code in bytes.</p>"
+                    }
+                },
+                "diskSnapshotSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the disk snapshot in bytes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains size information about a MicroVM image snapshot build.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#String": {
+            "type": "string"
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#SuspendMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#SuspendMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Suspends a running MicroVM, preserving its full memory and disk state. The MicroVM transitions through SUSPENDING to SUSPENDED. To restore, call ResumeMicrovm or send traffic to the endpoint if autoResumeEnabled is true.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/suspend",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to suspend.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#TagKey",
+                "traits": {
+                    "smithy.api#xmlName": "Key"
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#TagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "TagResource",
+                    "documentation": "Grants permission to add or modify tags on a resource"
+                },
+                "smithy.api#documentation": "<p>Adds tags to a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 204
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to tag.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value pairs of tags to add to the resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TaggableResource": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "ARN of a taggable Lambda resource.",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10000
+                },
+                "smithy.api#pattern": "^arn:(aws[a-zA-Z-]*):lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|(capacity-provider|network-connector|microvm-image):[a-zA-Z0-9-_]+)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Tags": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#TagKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#TagValue"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Terminates a MicroVM. This operation is idempotent; terminating a MicroVM that has already been terminated succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to terminate.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "serviceCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service code of the throttled service quota.</p>"
+                    }
+                },
+                "quotaCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota code of the throttled service quota.</p>"
+                    }
+                },
+                "retryAfterSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of seconds to wait before retrying the request.</p>",
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied due to request throttling. Retry the request later.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429,
+                "smithy.api#retryable": {
+                    "throttling": true
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TokenParts": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#AuthTokenKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#AuthTokenValue"
+            },
+            "traits": {
+                "smithy.api#documentation": "A mapping of auth token keys to values. This is used for supporting multiple token types / schemes with\nthe same API. For example, some token schemes require returning multiple auth headers.\n",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TooManyRequestsException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request throughput limit was exceeded. Retry the request later.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UntagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "UntagResource",
+                    "documentation": "Grants permission to remove tags from a resource"
+                },
+                "smithy.api#documentation": "<p>Removes tags from a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 204
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to remove tags from.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "TagKeys": {
+                    "target": "com.amazonaws.lambdamicrovms#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of tag keys to remove from the resource.</p>",
+                        "smithy.api#httpQuery": "tagKeys",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the configuration of a MicroVM image and triggers a new version build. This operation uses PUT semantics — all required fields (codeArtifact, baseImageArn, buildRoleArn) must be provided with every request.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageRequest": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image to use.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageResponse": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the status of a specific MicroVM image version.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionRequest": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new status to set for the MicroVM image version.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionResponse": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input does not satisfy the constraints specified by the service.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Version": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        }
+    }
+}

--- a/pkg/testdata/models/apis/lambdamicrovms/0000-00-00/generator.yaml
+++ b/pkg/testdata/models/apis/lambdamicrovms/0000-00-00/generator.yaml
@@ -1,0 +1,33 @@
+ignore:
+  resource_names:
+    - MicrovmAuthToken
+    - MicrovmShellAuthToken
+    - MicrovmImageVersion
+    - MicrovmImageBuild
+    - ManagedMicrovmImage
+    - ManagedMicrovmImageVersion
+    - Microvm
+
+empty_shapes:
+  - LoggingDisabled
+
+resources:
+  MicrovmImage:
+    is_arn_primary_key: true
+    renames:
+      operations:
+        GetMicrovmImage:
+          input_fields:
+            ImageIdentifier: Name
+        UpdateMicrovmImage:
+          input_fields:
+            ImageIdentifier: Name
+        DeleteMicrovmImage:
+          input_fields:
+            ImageIdentifier: Name
+    ignore_idempotency_token: true
+    fields:
+      Name:
+        is_primary_key: true
+        is_required: true
+        is_immutable: true

--- a/pkg/testdata/models/apis/lambdamicrovms/0000-00-00/lambda-microvms.json
+++ b/pkg/testdata/models/apis/lambdamicrovms/0000-00-00/lambda-microvms.json
@@ -1,0 +1,5336 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.amazonaws.lambdamicrovms#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You do not have sufficient access to perform this action.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Architecture": {
+            "type": "enum",
+            "members": {
+                "ARM_64": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ARM_64"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#AuthTokenKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#AuthTokenValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 8000
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#BuildState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "SUCCESSFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCESSFUL"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Capability": {
+            "type": "enum",
+            "members": {
+                "ALL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "The application is granted all available OS capabilities",
+                        "smithy.api#enumValue": "ALL"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "Capability granted to the application when booted"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CapabilityList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#Capability"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of capabilities granted to the application when booted"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Chipset": {
+            "type": "enum",
+            "members": {
+                "GRAVITON": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GRAVITON"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CloudWatchLogging": {
+            "type": "structure",
+            "members": {
+                "logGroup": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch Logs log group to send logs to.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 512
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9_\\-/.#]+$"
+                    }
+                },
+                "logStream": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the CloudWatch Logs log stream within the log group.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 512
+                        },
+                        "smithy.api#pattern": "^[^:*]*$"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for Amazon CloudWatch Logs logging.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CodeArtifact": {
+            "type": "union",
+            "members": {
+                "uri": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URI of the code artifact, such as an Amazon S3 path or Amazon ECR image URI.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the location of the code artifact for a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that caused the conflict.</p>"
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that caused the conflict.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request could not be completed due to a conflict with the current state of the resource.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CpuConfiguration": {
+            "type": "structure",
+            "members": {
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CPU architecture.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for the CPU architecture of a MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CpuConfigurationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#CpuConfiguration"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of CPU architectures"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates an authentication token for accessing a running MicroVM. The token grants access to the specified ports on the MicroVM endpoint.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/auth-token",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to create an authentication token for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "expirationInMinutes": {
+                    "target": "com.amazonaws.lambdamicrovms#PositiveInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration in minutes before the authentication token expires. Maximum: 60 minutes.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "allowedPorts": {
+                    "target": "com.amazonaws.lambdamicrovms#ListOfPortSpecification",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of port specifications that the authentication token grants access to on the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmAuthTokenResponse": {
+            "type": "structure",
+            "members": {
+                "authToken": {
+                    "target": "com.amazonaws.lambdamicrovms#TokenParts",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map containing the authentication token. Use the value at key \"X-aws-proxy-auth\" as the header value when connecting to the MicroVM endpoint.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImageResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a MicroVM image from the specified code artifact and base image. The build is asynchronous — the image transitions from CREATING to CREATED on success, or CREATE_FAILED on failure. Use GetMicrovmImage to poll for completion.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvm-images",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImageRequest": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Lambda-managed base MicroVM image to build upon. Use ListManagedMicrovmImages to discover available base images.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image to use.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role assumed during the image build process. This role must have permissions to access the code artifact and any required resources.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image. Must be unique within the AWS account.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request. If you retry a request that completed successfully using the same client token, the operation returns the successful response without performing any further actions.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmImageResponse": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the created MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>"
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a shell authentication token for interactive shell access to a running MicroVM. The MicroVM must have been run with the SHELL_INGRESS network connector attached.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/shell-auth-token",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to create a shell authentication token for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "expirationInMinutes": {
+                    "target": "com.amazonaws.lambdamicrovms#PositiveInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration in minutes before the shell authentication token expires.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthTokenResponse": {
+            "type": "structure",
+            "members": {
+                "authToken": {
+                    "target": "com.amazonaws.lambdamicrovms#TokenParts",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The generated shell authentication token key-value pairs for accessing the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a MicroVM image. This operation is idempotent; deleting an image that has already been deleted succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageOutput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the deleted MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image after deletion.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a specific version of a MicroVM image. This operation is idempotent; deleting a version that has already been deleted succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersionOutput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version that was deleted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image version after deletion.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableMap": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableValue"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 50
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#EnvironmentVariableValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4096
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific MicroVM, including its state, endpoint, image information, and configuration. The state field is eventually consistent — determine readiness by connecting to the endpoint.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a MicroVM image, including its state, versions, and configuration.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuild": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific MicroVM image build, including its state, target architecture, and snapshot information.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}/builds/{buildId}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the build to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageBuildOutput": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The build request ID.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildState": {
+                    "target": "com.amazonaws.lambdamicrovms#BuildState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target CPU architecture for the build. Supported value: ARM_64.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset generation for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the build state, if applicable.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the build was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "snapshotBuild": {
+                    "target": "com.amazonaws.lambdamicrovms#SnapshotBuild",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The snapshot build details, including memory and disk snapshot sizes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageOutput": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A set of key-value pairs that you can attach to the resource. Use tags to categorize resources for cost allocation, access control (ABAC), and organization.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the details of a specific version of a MicroVM image, including its configuration, state, and build information.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionInput": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmImageVersionOutput": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to retrieve.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#GetMicrovmResponse": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endpoint": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTPS endpoint URL for communicating with the MicroVM. Include a valid authentication token in the X-aws-proxy-auth header when sending requests.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM execution role assumed by the MicroVM.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The idle policy configuration of the MicroVM, controlling auto-suspend and auto-resume behavior.</p>"
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist before being terminated by the platform.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM first started.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "terminatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM terminated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for why the MicroVM is in the current state.</p>"
+                    }
+                },
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors configured for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors configured for the MicroVM.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#HookState": {
+            "type": "enum",
+            "members": {
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                },
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "Whether invocation hooks are enabled or disabled on a MicroVm."
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Hooks": {
+            "type": "structure",
+            "members": {
+                "port": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The port number on which the hooks listener runs.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 65535
+                        }
+                    }
+                },
+                "microvmHooks": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmHooks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The lifecycle hooks for MicroVM events.</p>"
+                    }
+                },
+                "microvmImageHooks": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageHooks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The hooks for MicroVM image build events.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Lifecycle hook configuration for MicroVMs and MicroVM images.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#IdlePolicy": {
+            "type": "structure",
+            "members": {
+                "maxIdleDurationSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum time in seconds that a MicroVM can remain idle before it is automatically suspended.</p>",
+                        "smithy.api#range": {
+                            "min": 60
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "suspendedDurationSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum time in seconds that a MicroVM can remain suspended before it is automatically terminated.</p>",
+                        "smithy.api#range": {
+                            "min": 0
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "autoResumeEnabled": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether the MicroVM automatically resumes when it receives a request while suspended.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration that controls MicroVM auto-suspend and auto-resume behavior. Idle time is measured by inbound traffic through the MicroVM proxy endpoint — if no requests arrive within the configured duration, the MicroVM is suspended.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ImageName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "Name of a MicroVM image.",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "retryAfterSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of seconds to wait before retrying the request.</p>",
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An internal server error occurred. Retry the request later.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500,
+                "smithy.api#retryable": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#InvalidParameterValueException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>One of the parameters in the request is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.lambdamicrovms#LambdaMicrovms": {
+            "type": "service",
+            "version": "2025-09-09",
+            "operations": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#DeleteMicrovmImageVersion"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageBuild"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#GetMicrovmImageVersion"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImages"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersions"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuilds"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImages"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersions"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ListTags"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImage"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersion"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#Microvm"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Lambda Microvms",
+                    "arnNamespace": "lambda"
+                },
+                "aws.auth#sigv4": {
+                    "name": "lambda"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#documentation": "<p>Provides APIs to create, manage, and operate AWS Lambda MicroVMs and their associated MicroVM Image environments.</p>",
+                "smithy.api#title": "Lambda MicroVMs",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 13,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ],
+                            "type": "tree"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists versions of a managed MicroVM image. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/managed-microvm-images/{imageIdentifier}/versions",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the managed MicroVM image to list versions for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImageVersionsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of managed MicroVM image versions.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists AWS managed MicroVM images available for use as base images. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/managed-microvm-images",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListManagedMicrovmImagesOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of managed MicroVM images.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuilds": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists builds for a MicroVM image version with optional filtering by architecture and chipset. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}/builds",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to list builds for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target CPU architecture.</p>",
+                        "smithy.api#httpQuery": "architecture"
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target chipset.</p>",
+                        "smithy.api#httpQuery": "chipset"
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters builds by target chipset generation.</p>",
+                        "smithy.api#httpQuery": "chipsetGeneration"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageBuildsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM image builds.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists versions of a MicroVM image. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to list versions for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImageVersionsOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM image versions.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImagesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmImagesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists MicroVM images in the account with optional name filtering. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvm-images",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImagesRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "nameFilter": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filters images whose name contains the specified string.</p>",
+                        "smithy.api#httpQuery": "nameFilter"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmImagesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVM images.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovms": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovmsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists MicroVMs in the account with optional filtering by image and version. We recommend using pagination to ensure that the operation returns quickly and successfully.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2025-09-09/microvms",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmsRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to return in a single call.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token from a previous call. Use this token to retrieve the next page of results.</p>",
+                        "smithy.api#httpQuery": "nextToken"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional filter to list only MicroVMs running the specified image.</p>",
+                        "smithy.api#httpQuery": "imageIdentifier"
+                    }
+                },
+                "imageVersion": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional filter to list only MicroVMs running the specified image version.</p>",
+                        "smithy.api#httpQuery": "imageVersion"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListMicrovmsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "com.amazonaws.lambdamicrovms#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in a subsequent request to retrieve the next page of results. This value is null when there are no more results to return.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmItemList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of MicroVMs.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListOfPortSpecification": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#PortSpecification"
+            },
+            "traits": {
+                "smithy.api#documentation": "A list of port specifications.",
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTags": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ListTagsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ListTagsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "ListTags",
+                    "documentation": "Grants permission to list tags on a resource"
+                },
+                "smithy.api#documentation": "<p>Lists the tags associated with a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTagsRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to list tags for.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ListTagsResponse": {
+            "type": "structure",
+            "members": {
+                "Tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value pairs of tags associated with the resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Logging": {
+            "type": "union",
+            "members": {
+                "disabled": {
+                    "target": "com.amazonaws.lambdamicrovms#LoggingDisabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies that logging is disabled.</p>"
+                    }
+                },
+                "cloudWatch": {
+                    "target": "com.amazonaws.lambdamicrovms#CloudWatchLogging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for sending logs to Amazon CloudWatch Logs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for MicroVM logging output. Specify exactly one: cloudWatch to enable CloudWatch logging, or disabled to turn off logging.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#LoggingDisabled": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies that logging is disabled for the MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the managed MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the managed MicroVM image was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a managed MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageSummary"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersion": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the managed MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains version information for a managed MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#ManagedMicrovmImageVersion"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Microvm": {
+            "type": "resource",
+            "identifiers": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovm"
+            },
+            "read": {
+                "target": "com.amazonaws.lambdamicrovms#GetMicrovm"
+            },
+            "delete": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovm"
+            },
+            "list": {
+                "target": "com.amazonaws.lambdamicrovms#ListMicrovms"
+            },
+            "operations": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmAuthToken"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#CreateMicrovmShellAuthToken"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResumeMicrovm"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#SuspendMicrovm"
+                }
+            ]
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmHooks": {
+            "type": "structure",
+            "members": {
+                "run": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM starts running.</p>"
+                    }
+                },
+                "runTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the run hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "resume": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM resumes from a suspended state.</p>"
+                    }
+                },
+                "resumeTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the resume hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "suspend": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM is suspended.</p>"
+                    }
+                },
+                "suspendTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the suspend hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                },
+                "terminate": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM is terminated.</p>"
+                    }
+                },
+                "terminateTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 1,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the terminate hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 60
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for lifecycle hooks invoked during MicroVM events such as run, resume, suspend, and terminate.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN or ID of the MicroVm",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "MicroVm Image Arn",
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummary"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageBuildSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildId": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The build request ID.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "buildState": {
+                    "target": "com.amazonaws.lambdamicrovms#BuildState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "architecture": {
+                    "target": "com.amazonaws.lambdamicrovms#Architecture",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target CPU architecture for the build. Supported value: ARM_64.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipset": {
+                    "target": "com.amazonaws.lambdamicrovms#Chipset",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "chipsetGeneration": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target chipset generation for the build.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the build state, if applicable.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the build was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM image build.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageHooks": {
+            "type": "structure",
+            "members": {
+                "ready": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked when the MicroVM image build is ready.</p>"
+                    }
+                },
+                "readyTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 30,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the ready hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 3600
+                        }
+                    }
+                },
+                "validate": {
+                    "target": "com.amazonaws.lambdamicrovms#HookState",
+                    "traits": {
+                        "smithy.api#default": "DISABLED",
+                        "smithy.api#documentation": "<p>The path of the hook invoked to validate the MicroVM image build.</p>"
+                    }
+                },
+                "validateTimeoutInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#default": 30,
+                        "smithy.api#documentation": "<p>The maximum time in seconds for the validate hook to complete.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 3600
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration for hooks invoked during MicroVM image build events such as ready and validate.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN or ID of the MicroVmImage",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageState": {
+            "type": "enum",
+            "members": {
+                "CREATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATING"
+                    }
+                },
+                "CREATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATED"
+                    }
+                },
+                "CREATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_FAILED"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                },
+                "UPDATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATED"
+                    }
+                },
+                "UPDATE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATE_FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_FAILED"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageSummary"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of MicroVM image summaries"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageSummary": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "SUCCESSFUL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCESSFUL"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "DELETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETED"
+                    }
+                },
+                "DELETE_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus": {
+            "type": "enum",
+            "members": {
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "Customer image version is active and can be used",
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "INACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "Customer image version is inactive and should not be used",
+                        "smithy.api#enumValue": "INACTIVE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummary": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a version of a MicroVM image.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionSummary"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of MicroVM image version summaries"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmItem": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM started.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains summary information about a MicroVM instance.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmItemList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#MicrovmItem"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#MicrovmState": {
+            "type": "enum",
+            "members": {
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "RUNNING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RUNNING"
+                    }
+                },
+                "SUSPENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUSPENDING"
+                    }
+                },
+                "SUSPENDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUSPENDED"
+                    }
+                },
+                "TERMINATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TERMINATING"
+                    }
+                },
+                "TERMINATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TERMINATED"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "The lifecycle state of a MicroVm."
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NetworkConnector": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NetworkConnectorList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#NetworkConnector"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#NonBlankString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "A string which is not empty or blank (only whitespace).",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortNumber": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#documentation": "Represents a single port.",
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 65535
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortRange": {
+            "type": "structure",
+            "members": {
+                "startPort": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting port number of the range.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endPort": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending port number of the range.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies a range of ports.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PortSpecification": {
+            "type": "union",
+            "members": {
+                "port": {
+                    "target": "com.amazonaws.lambdamicrovms#PortNumber",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A single port number.</p>"
+                    }
+                },
+                "range": {
+                    "target": "com.amazonaws.lambdamicrovms#PortRange",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A range of ports.</p>"
+                    }
+                },
+                "allPorts": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates that all ports are accessible.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies which ports are accessible on a MicroVM. Only one of the port specification options can be set.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#PositiveInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourceConflictException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The resource already exists, or another operation is in progress.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that was not found.</p>"
+                    }
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that was not found.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified resource does not exist.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Resources": {
+            "type": "structure",
+            "members": {
+                "minimumMemoryInMiB": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The minimum amount of memory in MiB to allocate to the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Resource requirements for a MicroVM.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResourcesList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#Resources"
+            },
+            "traits": {
+                "smithy.api#documentation": "List of resources",
+                "smithy.api#length": {
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#ResumeMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#ResumeMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Resumes a suspended MicroVM, restoring it to RUNNING state with all state intact. The MicroVM must be in SUSPENDED state.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/resume",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to resume.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ResumeMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RoleArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "The ARN of an IAM role that the service assumes to perform actions on behalf of the caller.",
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:aws[a-z\\-]*:iam::[0-9]{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#RunMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Runs a new MicroVM from the specified image. The MicroVM starts in PENDING state and transitions to RUNNING once provisioning completes. To connect, generate an authentication token using CreateMicrovmAuthToken.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors to configure for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors to configure for the MicroVM.</p>"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier (ARN or ID) of the MicroVM image to run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to run.</p>"
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role to be assumed by the MicroVM during execution.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration to control auto-suspend and auto-resume behavior.</p>"
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this MicroVM instance. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream application logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "runHookPayload": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Per-MicroVM initialization data delivered as the request body of the /run lifecycle hook. Use to pass tenant-specific configuration such as session IDs or secret references. Maximum: 16,384 bytes.</p>",
+                        "smithy.api#length": {
+                            "max": 4096
+                        }
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist before being terminated by the platform. Valid range: 1–28,800 (8 hours).</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 28800
+                        }
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#RunMicrovmResponse": {
+            "type": "structure",
+            "members": {
+                "microvmId": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current lifecycle state of the MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endpoint": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTPS endpoint URL for communicating with the MicroVM. Include a valid authentication token in the X-aws-proxy-auth header when sending requests.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image used to run this MicroVM.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "executionRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM execution role assumed by the MicroVM.</p>"
+                    }
+                },
+                "idlePolicy": {
+                    "target": "com.amazonaws.lambdamicrovms#IdlePolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The idle policy configuration of the MicroVM.</p>"
+                    }
+                },
+                "maximumDurationInSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum duration in seconds that the MicroVM can exist.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "startedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM first started.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "terminatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM terminated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for why the MicroVM is in the current state.</p>"
+                    }
+                },
+                "ingressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of ingress network connectors configured for the MicroVM.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors configured for the MicroVM.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ServiceException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The AWS Lambda MicroVMs service encountered an internal error.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "resourceId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the resource that exceeded the quota.</p>"
+                    }
+                },
+                "resourceType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the resource that exceeded the quota.</p>"
+                    }
+                },
+                "serviceCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service code of the exceeded service quota.</p>"
+                    }
+                },
+                "quotaCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota code of the exceeded service quota.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You have exceeded a service quota for Lambda MicroVMs.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SnapshotBuild": {
+            "type": "structure",
+            "members": {
+                "memorySnapshotSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the memory snapshot in bytes.</p>"
+                    }
+                },
+                "codeInstallSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the installed code in bytes.</p>"
+                    }
+                },
+                "diskSnapshotSizeInBytes": {
+                    "target": "smithy.api#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the disk snapshot in bytes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains size information about a MicroVM image snapshot build.</p>"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#String": {
+            "type": "string"
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#SuspendMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#SuspendMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Suspends a running MicroVM, preserving its full memory and disk state. The MicroVM transitions through SUSPENDING to SUSPENDED. To restore, call ResumeMicrovm or send traffic to the endpoint if autoResumeEnabled is true.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}/suspend",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to suspend.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#SuspendMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.lambdamicrovms#TagKey",
+                "traits": {
+                    "smithy.api#xmlName": "Key"
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#TagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "TagResource",
+                    "documentation": "Grants permission to add or modify tags on a resource"
+                },
+                "smithy.api#documentation": "<p>Adds tags to a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 204
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to tag.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value pairs of tags to add to the resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                },
+                "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TaggableResource": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "ARN of a taggable Lambda resource.",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10000
+                },
+                "smithy.api#pattern": "^arn:(aws[a-zA-Z-]*):lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|(capacity-provider|network-connector|microvm-image):[a-zA-Z0-9-_]+)$"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Tags": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#TagKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#TagValue"
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovm": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovmRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#TerminateMicrovmResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Terminates a MicroVM. This operation is idempotent; terminating a MicroVM that has already been terminated succeeds without error.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2025-09-09/microvms/{microvmIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovmRequest": {
+            "type": "structure",
+            "members": {
+                "microvmIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the MicroVM to terminate.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TerminateMicrovmResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "serviceCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service code of the throttled service quota.</p>"
+                    }
+                },
+                "quotaCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota code of the throttled service quota.</p>"
+                    }
+                },
+                "retryAfterSeconds": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of seconds to wait before retrying the request.</p>",
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied due to request throttling. Retry the request later.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429,
+                "smithy.api#retryable": {
+                    "throttling": true
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TokenParts": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.lambdamicrovms#AuthTokenKey"
+            },
+            "value": {
+                "target": "com.amazonaws.lambdamicrovms#AuthTokenValue"
+            },
+            "traits": {
+                "smithy.api#documentation": "A mapping of auth token keys to values. This is used for supporting multiple token types / schemes with\nthe same API. For example, some token schemes require returning multiple auth headers.\n",
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#TooManyRequestsException": {
+            "type": "structure",
+            "members": {
+                "Type": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The exception type.</p>"
+                    }
+                },
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request throughput limit was exceeded. Retry the request later.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UntagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InvalidParameterValueException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#TooManyRequestsException"
+                }
+            ],
+            "traits": {
+                "aws.iam#iamAction": {
+                    "name": "UntagResource",
+                    "documentation": "Grants permission to remove tags from a resource"
+                },
+                "smithy.api#documentation": "<p>Removes tags from a Lambda MicroVM resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/2017-03-31/tags/{Resource}",
+                    "code": 204
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "Resource": {
+                    "target": "com.amazonaws.lambdamicrovms#TaggableResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the resource to remove tags from.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "TagKeys": {
+                    "target": "com.amazonaws.lambdamicrovms#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of tag keys to remove from the resource.</p>",
+                        "smithy.api#httpQuery": "tagKeys",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the configuration of a MicroVM image and triggers a new version build. This operation uses PUT semantics — all required fields (codeArtifact, baseImageArn, buildRoleArn) must be provided with every request.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageRequest": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image to use.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageResponse": {
+            "type": "structure",
+            "members": {
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.lambdamicrovms#ImageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "latestActiveImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest active version of the MicroVM image.</p>"
+                    }
+                },
+                "latestFailedImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The latest failed version of the MicroVM image, if any.</p>"
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the MicroVM image.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact containing the application code and metadata for the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for build-time and runtime logs. Specify {\"cloudWatch\": {\"logGroup\": \"...\"}} to stream logs to a custom CloudWatch log group, or {\"disabled\": {}} to turn off logging.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the MicroVM image was last updated.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.lambdamicrovms#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.lambdamicrovms#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates the status of a specific MicroVM image version.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/2025-09-09/microvm-images/{imageIdentifier}/versions/{imageVersion}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionRequest": {
+            "type": "structure",
+            "members": {
+                "imageIdentifier": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageIdentifier",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The unique identifier (ARN or ID) of the MicroVM image.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new status to set for the MicroVM image version.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#UpdateMicrovmImageVersionResponse": {
+            "type": "structure",
+            "members": {
+                "baseImageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the base MicroVM image used.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "baseImageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#Version",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The specific version of the base MicroVM image.</p>"
+                    }
+                },
+                "buildRoleArn": {
+                    "target": "com.amazonaws.lambdamicrovms#RoleArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM build role.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the version.</p>"
+                    }
+                },
+                "codeArtifact": {
+                    "target": "com.amazonaws.lambdamicrovms#CodeArtifact",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code artifact for this version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "logging": {
+                    "target": "com.amazonaws.lambdamicrovms#Logging",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The logging configuration for this version.</p>"
+                    }
+                },
+                "egressNetworkConnectors": {
+                    "target": "com.amazonaws.lambdamicrovms#NetworkConnectorList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of egress network connectors available to the MicroVM at runtime.</p>",
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "cpuConfigurations": {
+                    "target": "com.amazonaws.lambdamicrovms#CpuConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of supported CPU configurations for the MicroVM.</p>"
+                    }
+                },
+                "resources": {
+                    "target": "com.amazonaws.lambdamicrovms#ResourcesList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource requirements for the MicroVM.</p>"
+                    }
+                },
+                "additionalOsCapabilities": {
+                    "target": "com.amazonaws.lambdamicrovms#CapabilityList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional OS capabilities granted to the MicroVM runtime environment.</p>"
+                    }
+                },
+                "hooks": {
+                    "target": "com.amazonaws.lambdamicrovms#Hooks"
+                },
+                "environmentVariables": {
+                    "target": "com.amazonaws.lambdamicrovms#EnvironmentVariableMap",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Environment variables set in the MicroVM runtime environment.</p>"
+                    }
+                },
+                "imageArn": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "imageVersion": {
+                    "target": "com.amazonaws.lambdamicrovms#NonBlankString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the MicroVM image.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "state": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the version.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.lambdamicrovms#MicrovmImageVersionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The availability status of the version: ACTIVE (can be used by RunMicrovm) or INACTIVE (blocked from launching new MicroVMs).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "updatedAt": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the version was last updated.</p>"
+                    }
+                },
+                "stateReason": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the current state. For example, one or more builds failed.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.lambdamicrovms#Tags",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key-value pairs associated with the version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambdamicrovms#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input does not satisfy the constraints specified by the service.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.lambdamicrovms#Version": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^[^\\s]+$"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The code-generator's renameCollidingFields pass (pkg/api/passes.go) unconditionally renamed any shape member named Validate to Validate_. This was a holdover from aws-sdk-go v1, where every generated input/request struct implemented a Validate() error method (via aws/request), so a member literally named Validate would collide with it. aws-sdk-go-v2 restructured generated types and no longer emits that method, so the rename now produces references to a non-existent SDK field — e.g. svcsdktypes.MicrovmImageHooks.Validate_ — which fails to compile for any API with a Validate member (such as Lambda MicroVMs' MicrovmImageHooks). This PR removes the obsolete Validate case from collides() so the member maps to the real Validate field, updates the TestCollidingFields expectation, and adds SetSDK/SetResource regression tests against the Lambda MicroVMs model.

- Remove "Validate" from collides() in passes.go
- Update passes_test.go to reflect new behavior
- Add set_resource.go and set_sdk.go tests to validate that Validate field does not erroneously have "_" appended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
