### PR TITLE
Bump aws-controllers-k8s/pkg to v0.0.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/pkg v0.0.23
+	github.com/aws-controllers-k8s/pkg v0.0.25
 	github.com/aws-controllers-k8s/runtime v0.61.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.32.7

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/pkg v0.0.23 h1:iqu8jKQUnyP/c6TiVcXySQYpkATui0iXFC5ax9x01oM=
-github.com/aws-controllers-k8s/pkg v0.0.23/go.mod h1:VvdjLWmR6IJ3KU8KByKiq/lJE8M+ur2piXysXKTGUS0=
+github.com/aws-controllers-k8s/pkg v0.0.25 h1:kTOPpNvj+as6hn1A4ttDcizC/EDwwGXW2wgs+25heFA=
+github.com/aws-controllers-k8s/pkg v0.0.25/go.mod h1:Ms22LY5MTg6WWdQWxDSSxiZawbSf99bSr+omZ5EbGSY=
 github.com/aws-controllers-k8s/runtime v0.61.0 h1:46ksj9nvW5gx86aB44/zfrZOvJj4G7WWnWf7hj2CcCw=
 github.com/aws-controllers-k8s/runtime v0.61.0/go.mod h1:Ovpk9GCCc/3hekVN6CL0cZhsG41JqSvIb8DXwaEwL34=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Picks up the Acme initialism fix (https://github.com/aws-controllers-k8s/pkg/pull/47) so generated CRD kinds for ACME resources are AcmeEndpoint / AcmeExternalAccountBinding / AcmeDomainValidation rather than the mangled ACMe* form.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.