### PR TITLE
Add support for applying is_iam_policy and is_document custom comparisons to nested fields

### DIFF
--- a/pkg/generate/code/compare.go
+++ b/pkg/generate/code/compare.go
@@ -881,6 +881,16 @@ func CompareStruct(
 			continue
 		}
 
+		if fieldConfig != nil && fieldConfig.IsIAMPolicy {
+			out += compareIAMPolicy(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, memberFieldPath, indentLevel)
+			continue
+		}
+
+		if fieldConfig != nil && fieldConfig.IsDocument {
+			out += compareDocument(deltaVarName, firstResAdaptedVarName, secondResAdaptedVarName, memberFieldPath, indentLevel)
+			continue
+		}
+
 		fastComparisonOutput, needToCloseBlock, err := fastCompareTypes(
 			compareConfig,
 			memberShape,

--- a/pkg/generate/code/compare_test.go
+++ b/pkg/generate/code/compare_test.go
@@ -1187,3 +1187,52 @@ func TestCompareResource_SNS_Topic_NilEqualsZeroValue(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(expected, got)
 }
+
+func TestCompareResource_DynamoDB_Table_NestedIAMPolicyAndDocument(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewModelForServiceWithOptions(t, "dynamodb", &testutil.TestingModelOptions{
+		GeneratorConfigFile: "generator-nested-policy.yaml",
+	})
+
+	crd := testutil.GetCRDByName(t, g, "Table")
+	require.NotNil(crd)
+
+	got, err := code.CompareResource(
+		crd.Config(), crd, "delta", "a.ko", "b.ko", 1,
+	)
+	require.NoError(err)
+
+	// StreamSpecification.ResourcePolicy is a custom nested field marked with
+	// is_iam_policy: true. Even though it lives inside the StreamSpecification
+	// struct (and is therefore emitted by CompareStruct, not the top-level
+	// field loop), it must use the semantic IAMPolicyDocumentEqual comparison
+	// rather than a plain string comparison.
+	expectedIAMPolicy := `		if ackcompare.HasNilDifference(a.ko.Spec.StreamSpecification.ResourcePolicy, b.ko.Spec.StreamSpecification.ResourcePolicy) {
+			delta.Add("Spec.StreamSpecification.ResourcePolicy", a.ko.Spec.StreamSpecification.ResourcePolicy, b.ko.Spec.StreamSpecification.ResourcePolicy)
+		} else if a.ko.Spec.StreamSpecification.ResourcePolicy != nil && b.ko.Spec.StreamSpecification.ResourcePolicy != nil {
+			if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.StreamSpecification.ResourcePolicy, *b.ko.Spec.StreamSpecification.ResourcePolicy); err != nil || !equal {
+				delta.Add("Spec.StreamSpecification.ResourcePolicy", a.ko.Spec.StreamSpecification.ResourcePolicy, b.ko.Spec.StreamSpecification.ResourcePolicy)
+			}
+		}
+`
+	assert.Contains(got, expectedIAMPolicy)
+
+	// StreamSpecification.PolicyDocument is a custom nested field marked with
+	// is_document: true and must use the semantic DocumentEqual comparison.
+	expectedDocument := `		if ackcompare.HasNilDifference(a.ko.Spec.StreamSpecification.PolicyDocument, b.ko.Spec.StreamSpecification.PolicyDocument) {
+			delta.Add("Spec.StreamSpecification.PolicyDocument", a.ko.Spec.StreamSpecification.PolicyDocument, b.ko.Spec.StreamSpecification.PolicyDocument)
+		} else if a.ko.Spec.StreamSpecification.PolicyDocument != nil && b.ko.Spec.StreamSpecification.PolicyDocument != nil {
+			if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.StreamSpecification.PolicyDocument, *b.ko.Spec.StreamSpecification.PolicyDocument); err != nil || !equal {
+				delta.Add("Spec.StreamSpecification.PolicyDocument", a.ko.Spec.StreamSpecification.PolicyDocument, b.ko.Spec.StreamSpecification.PolicyDocument)
+			}
+		}
+`
+	assert.Contains(got, expectedDocument)
+
+	// Sanity check: the sibling scalar nested field must still use plain
+	// string/value comparison, confirming we only special-case the marked
+	// fields.
+	assert.Contains(got, `			if *a.ko.Spec.StreamSpecification.StreamEnabled != *b.ko.Spec.StreamSpecification.StreamEnabled {`)
+}

--- a/pkg/testdata/models/apis/dynamodb/0000-00-00/generator-nested-policy.yaml
+++ b/pkg/testdata/models/apis/dynamodb/0000-00-00/generator-nested-policy.yaml
@@ -1,0 +1,40 @@
+# Test config that injects custom nested fields carrying semantic-comparison
+# markers (is_iam_policy / is_document) into an existing SDK struct shape
+# (StreamSpecification). Used to verify that CompareStruct honors is_iam_policy
+# and is_document for nested struct members, not just top-level spec fields.
+resources:
+  Table:
+    exceptions:
+      errors:
+        404:
+          code: ResourceNotFoundException
+    fields:
+      # Nested custom field carrying an IAM policy document. This mirrors the
+      # DynamoDB stream resource-policy use case where a policy lives on the
+      # stream configured via StreamSpecification.
+      StreamSpecification.ResourcePolicy:
+        type: "*string"
+        is_iam_policy: true
+      # Nested custom field carrying a generic JSON/YAML document.
+      StreamSpecification.PolicyDocument:
+        type: "*string"
+        is_document: true
+operations:
+  DescribeBackup:
+    output_wrapper_field_path: BackupDescription.BackupDetails
+ignore:
+  field_paths:
+  - DescribeTableOutput.Table.DeletionProtectionEnabled
+  - DescribeTableOutput.Table.TableClassSummary
+  - DescribeTableOutput.Table.WarmThroughput
+  - GlobalSecondaryIndex.OnDemandThroughputOverride
+  - GlobalSecondaryIndex.OnDemandThroughput
+  - DescribeTableOutput.Table.OnDemandThroughput
+  - GlobalSecondaryIndex.WarmThroughput
+  - DescribeTableOutput.Table.MultiRegionConsistency
+  - ReplicaGlobalSecondaryIndexDescription.OnDemandThroughputOverride
+  - ReplicaGlobalSecondaryIndexDescription.WarmThroughput
+  - ReplicaDescription.OnDemandThroughputOverride
+  - ReplicaDescription.ReplicaInaccessibleDateTime
+  - ReplicaDescription.ReplicaTableClassSummary
+  - ReplicaDescription.WarmThroughput


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixes custom comparison configs `is_iam_policy` and `is_document` being silently ignored when applied to a nested field.

- Update CompareStruct to check the field config for both is_iam_policy and is_document
- Add unit test to validate generated comparison code when is_iam_policy and is_document are set for a nested field

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
