### PR TITLE
feat(helm): Add SDK client-side rate limiting to Helm chart templates

### DIFF
--- a/templates/helm/templates/deployment.yaml.tpl
+++ b/templates/helm/templates/deployment.yaml.tpl
@@ -95,6 +95,14 @@ spec:
         - --reconcile-default-max-concurrent-syncs
         - "$(RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS)"
 {{ "{{- end }}" }}
+{{ "{{- if .Values.aws.sdkMaxTPS }}" }}
+        - --sdk-max-tps
+        - "$(ACK_SDK_MAX_TPS)"
+{{ "{{- end }}" }}
+{{ "{{- if .Values.aws.sdkMaxBurst }}" }}
+        - --sdk-max-burst
+        - "$(ACK_SDK_MAX_BURST)"
+{{ "{{- end }}" }}
 {{ "{{- range $key, $value := .Values.reconcile.resourceMaxConcurrentSyncs }}" }}
         - --reconcile-resource-max-concurrent-syncs
         - {{ "\"$(RECONCILE_RESOURCE_MAX_CONCURRENT_SYNCS_{{ $key | upper }})\"" }}
@@ -124,6 +132,14 @@ spec:
           value: {{ "{{ .Values.aws.endpoint_url | quote }}" }}
         - name: AWS_IDENTITY_ENDPOINT_URL
           value: {{ "{{ .Values.aws.identity_endpoint_url | quote }}" }}
+{{ "{{- if .Values.aws.sdkMaxTPS }}" }}
+        - name: ACK_SDK_MAX_TPS
+          value: {{ "{{ .Values.aws.sdkMaxTPS | quote }}" }}
+{{ "{{- end }}" }}
+{{ "{{- if .Values.aws.sdkMaxBurst }}" }}
+        - name: ACK_SDK_MAX_BURST
+          value: {{ "{{ .Values.aws.sdkMaxBurst | quote }}" }}
+{{ "{{- end }}" }}
         - name: ACK_WATCH_NAMESPACE
           value: {{ IncludeTemplate "watch-namespace" }}
         - name: ACK_WATCH_SELECTORS

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -95,6 +95,14 @@ aws:
 {{- if eq .ControllerName "s3" }}
   endpoint_use_path_style: false
 {{- end }}
+  # Client-side rate limiting for AWS SDK API calls.
+  # Limits the maximum request rate to the AWS service API.
+  # Useful for services with low account-level rate limits.
+  # For example, Route53 enforces 5 req/s account-wide — setting sdkMaxTPS: 3
+  # leaves headroom for other consumers (external-dns, Terraform, etc.).
+  # Set to 0 or leave commented to disable (default).
+  # sdkMaxTPS: 3
+  # sdkMaxBurst: 5
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""


### PR DESCRIPTION
Issue #, if available:

Description of changes: Helm support for https://github.com/aws-controllers-k8s/runtime/pull/264

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
