### PR TITLE
feat: log controller version at startup

### DIFF
--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws-controllers-k8s/code-generator/pkg/model"
 	ackmodel "github.com/aws-controllers-k8s/code-generator/pkg/model"
 	"github.com/aws-controllers-k8s/code-generator/pkg/util"
+	"github.com/aws-controllers-k8s/code-generator/pkg/version"
 )
 
 var (
@@ -311,8 +312,17 @@ func Controller(
 		return nil, err
 	}
 
-	// Next add the template for pkg/version/version.go file
-	if err = ts.Add("pkg/version/version.go", "pkg/version/version.go.tpl", nil); err != nil {
+	// Next add the template for pkg/version/version.go file. The context
+	// carries the ack-generate build info so the generated controller records
+	// which code-generator version produced it.
+	versionVars := struct {
+		Version   string
+		BuildDate string
+	}{
+		Version:   version.Version,
+		BuildDate: version.BuildDate,
+	}
+	if err = ts.Add("pkg/version/version.go", "pkg/version/version.go.tpl", versionVars); err != nil {
 		return nil, err
 	}
 

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -5,6 +5,8 @@ package main
 import (
 	"os"
 	"context"
+	goruntime "runtime"
+	"runtime/debug"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -50,6 +52,21 @@ var (
 	scheme			        = runtime.NewScheme()
 	setupLog		        = ctrlrt.Log.WithName("setup")
 )
+
+// depVersion returns the module version of the given dependency import path,
+// as recorded in the binary's build info, or "unknown" if it cannot be found.
+func depVersion(path string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == path {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -149,6 +166,16 @@ func main() {
 	setupLog.Info(
 		"initializing service controller",
 		"aws.service", awsServiceAlias,
+		"version", version.GitVersion,
+	)
+	setupLog.V(1).Info(
+		"build details",
+		"aws.service", awsServiceAlias,
+		"gitCommit", version.GitCommit,
+		"buildDate", version.BuildDate,
+		"goVersion", goruntime.Version(),
+		"ackRuntimeVersion", depVersion("github.com/aws-controllers-k8s/runtime"),
+		"awsSDKGoV2Version", depVersion("github.com/aws/aws-sdk-go-v2"),
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup,

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -174,6 +174,7 @@ func main() {
 		"gitCommit", version.GitCommit,
 		"buildDate", version.BuildDate,
 		"goVersion", goruntime.Version(),
+		"ackGenerateVersion", version.ACKGenerateVersion,
 		"ackRuntimeVersion", depVersion("github.com/aws-controllers-k8s/runtime"),
 		"awsSDKGoV2Version", depVersion("github.com/aws/aws-sdk-go-v2"),
 	)

--- a/templates/pkg/version/version.go.tpl
+++ b/templates/pkg/version/version.go.tpl
@@ -2,8 +2,18 @@
 
 package version
 
+// GitVersion, GitCommit, and BuildDate describe the service controller build
+// and are injected at controller build time via -ldflags.
 var (
 	GitVersion string
 	GitCommit  string
 	BuildDate  string
+)
+
+// ACKGenerateVersion and ACKGenerateBuildDate identify the ack-generate build
+// that generated this controller's code. They are baked in at code-generation
+// time and are immutable for the life of the generated code.
+const (
+	ACKGenerateVersion   = "{{ .Version }}"
+	ACKGenerateBuildDate = "{{ .BuildDate }}"
 )


### PR DESCRIPTION
Generated controllers build their version info at startup but never log it, so a running controller's version can't be determined from its logs alone. This adds it.

  Commit 1 — controller version:
  - Adds the controller release version to the initializing service controller info line.
  - Adds a debug-level build details line (`--log-level=debug`) with git commit, build date, Go compiler version, and the compiled-in ACK runtime + aws-sdk-go-v2 module versions (read from `debug.BuildInfo`).
  
  Commit 2 — ack-generate version:
  - Bakes `ACKGenerateVersion` / `ACKGenerateBuildDate` into the generated pkg/version/version.go and logs `ackGenerateVersion` on the debug line.

Note, code-gen and runtime versions are already recoverable by mapping the controller release semver back through immutable images; this is just quick-validation shorthand. If we don't want this, we can leave it off (why this is 2 commits).

Example output (s3-controller built from these templates, run against a live cluster):

`--log-level=info`:
```
  {"level":"info","ts":"2026-08-10T11:48:23.611-0700","logger":"setup","msg":"initializing service controller","aws.service":"s3","version":"v1.0.19"}
```

`--log-level=debug`
```
  {"level":"info","ts":"2026-08-10T11:49:30.389-0700","logger":"setup","msg":"initializing service controller","aws.service":"s3","version":"v1.0.19"}
  {"level":"debug","ts":"2026-08-10T11:49:30.389-0700","logger":"setup","msg":"build details","aws.service":"s3","gitCommit":"abc1234","buildDate":"2026-08-10T14:00:00Z","goVersion":"go1.26.4","ackGenerateVersion":"v0.62.0","ackRuntimeVersion":"v0.58.0","awsSDKGoV2Version":"v1.36.6"}
```
  Testing:
  - `make build-controller SERVICE=s3` runs clean end-to-end (code gen + CRDs + RBAC + Helm); `main.go` and `version.go` render as expected.
  - Generated output compiles and runs; output above captured from the built binary against a live cluster. 

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.