### PR TITLE
Bump pkg to v0.0.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/code-generator
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/pkg v0.0.25
+	github.com/aws-controllers-k8s/pkg v0.0.26
 	github.com/aws-controllers-k8s/runtime v0.62.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.32.7

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/pkg v0.0.25 h1:kTOPpNvj+as6hn1A4ttDcizC/EDwwGXW2wgs+25heFA=
-github.com/aws-controllers-k8s/pkg v0.0.25/go.mod h1:Ms22LY5MTg6WWdQWxDSSxiZawbSf99bSr+omZ5EbGSY=
+github.com/aws-controllers-k8s/pkg v0.0.26 h1:wziB7P5XczSpvFYZyWWV6URYi/cG3SW5OcdT8VqER0I=
+github.com/aws-controllers-k8s/pkg v0.0.26/go.mod h1:Ms22LY5MTg6WWdQWxDSSxiZawbSf99bSr+omZ5EbGSY=
 github.com/aws-controllers-k8s/runtime v0.62.0 h1:6Dw2zbk7565qatREuVwFttEAAFK0O9osavESH5RFX2I=
 github.com/aws-controllers-k8s/runtime v0.62.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Upgrades pkg to v0.0.26 to apply https://github.com/aws-controllers-k8s/pkg/pull/50

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
