### PR TITLE
fix(helm): expose IgnoreFieldDrift feature gate

### DIFF
--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -199,3 +199,5 @@ featureGates:
   ResourceAdoption: true
   # Enable IAMRoleSelector, a multirole feature, replacing CARM. See https://github.com/aws-controllers-k8s/community/pull/2628
   IAMRoleSelector: false
+  # Enable IgnoreFieldDrift, services.k8s.aws/ignore-field-drift annotation. See https://aws-controllers-k8s.github.io/docs/guides/ignore-field-drift
+  IgnoreFieldDrift: false


### PR DESCRIPTION
## Summary

Add support for configuring the `IgnoreFieldDrift` feature gate in the ACK controller Helm values.

## Changes

- Added the `IgnoreFieldDrift` feature gate to the Helm values.
- Default value is set to `false` to preserve the current behavior.

## Impact

No functional changes are introduced. The feature remains disabled by default and can be enabled when needed.