### PR TITLE
Remove unused aws.JSONValue import

### DIFF
--- a/templates/apis/types.go.tpl
+++ b/templates/apis/types.go.tpl
@@ -4,14 +4,12 @@ package {{ .APIVersion }}
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
 	_ = ackv1alpha1.AWSAccountID("")
 )
 {{- range $typeDef := .TypeDefs }}


### PR DESCRIPTION
Issue #, if available: [2783](https://github.com/aws-controllers-k8s/community/issues/2783)

Description of changes:
ACK service controllers still include imports for `aws-sdk-go` due to a combination of references in test files, custom hooks, and forced imports of `aws.JSONValue` in the generated types.go. This PR removes this unused imported var.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
