### PR TITLE
Render updateable.when guard for custom update methods

### DIFF
--- a/templates/pkg/resource/sdk_update_custom.go.tpl
+++ b/templates/pkg/resource/sdk_update_custom.go.tpl
@@ -5,6 +5,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
+{{- GoCodeResourceIsUpdateable .CRD "latest" 1 }}
 	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, delta)
 }
 {{- end -}}


### PR DESCRIPTION
`updateable.when` is silently ignored by any resource that sets
`update_operation.custom_method_name`.

`ResourceIsUpdateable` is called from `sdk_update.go.tpl` and
`sdk_update_set_attributes.go.tpl`, but not from `sdk_update_custom.go.tpl`,
which delegated straight to the custom method. So the config renders no code and
no warning — it looks applied and does nothing. Now emitted before the
delegation; resources without an `updateable.when` block are unaffected, since
the helper renders nothing.

Found while prototyping a guard on sns-controller's Subscription, which uses
`custom_method_name: customUpdate`. That controller ended up not needing the
guard, so nothing depends on this PR -- it is a standalone fix for config that
silently does nothing.

`sdk_delete_custom.go.tpl` has the same gap for `deletable.when`. Left out to
keep this to one line — happy to fold it in.

### Testing

`go build ./...` and `go test ./pkg/generate/code/` pass unchanged. Verified
end-to-end by regenerating sns-controller with `updateable.when` on a Subscription
status field: the guard appears in the generated `sdkUpdate`, compiles, and was
confirmed on a live cluster to requeue the update instead of calling the service
API. `goimports` picks up `"time"` and the aliased `ackutil` as it already does
for the other update templates.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
