### PR TITLE
Fix config/crd/bases vs helm/crds list-marker mismatch (gofmt ordering)

### DIFF
--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -224,6 +224,16 @@ if ! $ACK_GENERATE_BIN_PATH "${apis_args[@]}"; then
     exit 2
 fi
 
+# gofmt rewrites Markdown-style list markers in doc comments (e.g. "*" -> "-")
+# as part of its doc-comment formatting. Run it here, before the CRD schemas
+# are generated from these doc comments, so that this controller-gen run and
+# the later one in build-controller-release.sh (which reads the same,
+# already-gofmt'd source) produce identical description text. Otherwise the
+# two output targets (config/crd/bases and helm/crds) capture the doc
+# comments on opposite sides of this rewrite and permanently disagree on
+# list-marker style for the same enum text.
+gofmt -w "$SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION"
+
 pushd "$SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION" 1>/dev/null
 
 echo "Generating deepcopy code for $SERVICE"


### PR DESCRIPTION
## Problem

For any generated field whose Go doc comment contains a Markdown bullet list (e.g. an enum's valid-values doc), `config/crd/bases/*.yaml` and `helm/crds/*.yaml` permanently disagree on the list-marker style (`*` vs `-`) for identical description text.

Example live on `aws-controllers-k8s/glue-controller` main today (`Job.spec.jobMode` doc):

```
helm/crds/glue.services.k8s.aws_jobs.yaml:2815:                    - SCRIPT - The job was created using the Glue Studio script editor.
config/crd/bases/glue.services.k8s.aws_jobs.yaml:2815:                     * SCRIPT - The job was created using the Glue Studio script editor.
```

## Root cause

`config/crd/bases` and `helm/crds` are each produced by their own `controller-gen crd` call against the same generated `apis/<version>` source, but on opposite sides of a `gofmt` pass: `scripts/build-controller.sh` runs `controller-gen crd` for `config/crd/bases` *before* its end-of-script `gofmt -w`, while `scripts/build-controller-release.sh` (run right after, same `make build-controller`) runs its own `controller-gen crd` for `helm/crds` against the now-`gofmt`'d source. `gofmt` rewrites `*`-style Markdown list markers in doc comments to `-`, so the two targets capture the same comment before/after that rewrite and disagree forever.

## Fix

Move the doc-comment-normalizing `gofmt -w` to run right after `ack-generate apis`, before either `controller-gen crd` call. No-op on already-formatted source.

## Verification

`make build-controller SERVICE=glue` twice back-to-back: `config/crd/bases` and `helm/crds` now byte-identical for `jobMode` and the rest of the schema; second run idempotent.

cc @michaelhtm
