### PR TITLE
chore: update ACK runtime to v0.63.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aws-controllers-k8s/pkg v0.0.26
-	github.com/aws-controllers-k8s/runtime v0.62.0
+	github.com/aws-controllers-k8s/runtime v0.63.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.32.7
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/pkg v0.0.26 h1:wziB7P5XczSpvFYZyWWV6URYi/cG3SW5OcdT8VqER0I=
 github.com/aws-controllers-k8s/pkg v0.0.26/go.mod h1:Ms22LY5MTg6WWdQWxDSSxiZawbSf99bSr+omZ5EbGSY=
-github.com/aws-controllers-k8s/runtime v0.62.0 h1:6Dw2zbk7565qatREuVwFttEAAFK0O9osavESH5RFX2I=
-github.com/aws-controllers-k8s/runtime v0.62.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
+github.com/aws-controllers-k8s/runtime v0.63.0 h1:BR8uOwV08AoP5bNS7tlqoLXkSK6E82r7K8fJOuaoVZw=
+github.com/aws-controllers-k8s/runtime v0.63.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=


### PR DESCRIPTION
Issue #, if available: none filed yet.

Description of changes:

Bumps `github.com/aws-controllers-k8s/runtime` to `v0.63.0`, picking up aws-controllers-k8s/runtime#265: `Update` no longer receives the stored `desired` object, which was also the status merge-patch base, so status a manager set was silently dropped.

This repo sets the version `auto-generate-controllers` puts in the downstream bump PRs, since it reads it from this `go.mod`.

Merging alone does not propagate it — that postsubmit fires on a semver tag, so this needs a code-generator tag bump afterwards to open the controller PRs.

`go build`, `make build-ack-generate`, `go test ./...` pass. go.mod/go.sum only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
