### PR TITLE
Mark errors raised after a successful create

### DIFF
--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -101,6 +101,19 @@ func (rm *resourceManager) sdkCreate(
 {{- end }}
 {{ GoCodeSetCreateOutput .CRD "resp" "ko" 1 }}
 	rm.setStatusDefaults(ko)
+	// The resource now exists in AWS and ko carries its identifiers. Mark any
+	// error from here on as a post-create failure so the reconciler retains the
+	// ACK finalizer, and return ko so those identifiers reach the CR status and
+	// the next reconciliation finds the resource instead of creating a second
+	// one. See https://github.com/aws-controllers-k8s/community/issues/2849.
+	defer func() {
+		if err != nil {
+			err = ackerr.WrapPostCreateError(err)
+			if created == nil {
+				created = &resource{ko}
+			}
+		}
+	}()
 {{- if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Create }}
 	// custom set output from response
 	ko, err = rm.{{ $setOutputCustomMethodName }}(ctx, desired, resp, ko)


### PR DESCRIPTION
Issue [#2849](https://github.com/aws-controllers-k8s/community/issues/2849)

Depends on aws-controllers-k8s/runtime#268. **Do not merge before that is
released** — generated code calls `ackerr.WrapPostCreateError`, so regenerating
a controller against a runtime without it fails to compile:

```
pkg/resource/security_group/sdk.go:257:17: undefined: ackerr.WrapPostCreateError
```

Description of changes:

`sdkCreate` issues the create API call and then, for many resources, further
calls that apply tags, attributes or associated sub-resources. When one of those
fails the resource exists in AWS but `sdkCreate` still returns an error, and the
reconciler removes the ACK finalizer because it cannot tell that apart from a
create that never happened. The next reconciliation finds an existing resource
with no finalizer and terminally conditions it as not managed by ACK, orphaning
it. runtime#268 has the full analysis.

This defers a wrap once the create call has returned, so every error raised
below it is marked as a post-create failure:

```go
rm.setStatusDefaults(ko)
defer func() {
	if err != nil {
		err = ackerr.WrapPostCreateError(err)
		if created == nil {
			created = &resource{ko}
		}
	}
}()
```

Three things about this shape are deliberate.

**A defer rather than edits at each return.** Scanning every generated
`sdkCreate` in the fleet, 41 of 277 resources can fail after a successful
create, and 28 of those return `nil, err` from inlined hook code. Because the
defer mutates the named return, it covers those returns without any hook
template being edited.

**Placed after `setStatusDefaults` so `ko` is in scope.** That matters for the
`created` backfill below. The region above it is output field mapping; every one
of the 41 real post-create failures sits at or after this point, including the
`set_output_custom_method_name` block and the `sdk_create_post_set_output` hook.

**Backfilling `created`.** When a hook returned `nil`, generated
`manager.Create` substitutes `desired`, so the identifiers from the create
response are never persisted. For a server-generated identifier the next
reconciliation reads `NotFound` and creates a *second* resource, leaking the
first. Returning `ko` prevents that.

`WrapPostCreateError` only wraps AWS API errors, so the `ackerr.NotFound`
guards and `ackrequeue` signals that hooks return here pass through unchanged.
Of the resources that return a requeue after a successful create, none carries
an AWS error inside it.

Not covered: `custom_implementation` on the create operation short-circuits at
the top of `sdkCreate`, before this defer is registered. Two resources use it —
`elasticache/Snapshot` (`CustomCreateSnapshot`) and `apigatewayv2/API`
(`customCreateApi`) — and need the wrap applied by hand in their controller
repos.

### Testing

`go build ./...` and the full `go test ./...` suite pass.

Regenerating ec2-controller produces the defer in all 20 resources that have a
create operation, with no other change beyond the expected `version.go` and
`ack-generate-metadata.yaml` timestamps. In `security_group/sdk.go` it lands
ahead of both the `requiredFieldsMissingForSGRule` guard and
`deleteDefaultSecurityGroupRule`, which is the call that triggers #2849. The
regenerated controller compiles against runtime#268.

The regenerated controller was then deployed to an EKS cluster and the
post-create failure injected two ways (an IAM deny of
`ec2:RevokeSecurityGroupEgress`, and an ingress rule referencing a non-existent
security group). The finalizer was retained, the condition was
`ACK.Recoverable` rather than terminal, exactly one security group was created
per CR, the resource self-healed once the permission was restored, and deleting
the CRs removed the security groups from AWS. Full before/after in runtime#268.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
